### PR TITLE
Fixes that allow to search 1. for special characters 2. contains query

### DIFF
--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/LuceneSearcher.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/LuceneSearcher.java
@@ -144,9 +144,6 @@ public abstract class LuceneSearcher implements Searcher {
         }
         if (text != null) {
             QueryParser qParser = new QueryParser("text", makeAnalyzer());
-			if (text.startsWith("*") || text.startsWith("?")) {
-				qParser.setAllowLeadingWildcard(true);
-			}
             try {
                 luceneQuery.add(qParser.parse(text), BooleanClause.Occur.MUST);
             } catch (ParseException e) {

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/LuceneSearcher.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/LuceneSearcher.java
@@ -19,7 +19,10 @@ import org.eclipse.che.api.vfs.server.VirtualFileFilter;
 import org.eclipse.che.api.vfs.server.util.MediaTypeFilter;
 
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.core.SimpleAnalyzer;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.core.LowerCaseFilter;
+import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
@@ -74,7 +77,14 @@ public abstract class LuceneSearcher implements Searcher {
     }
 
     protected Analyzer makeAnalyzer() {
-        return new SimpleAnalyzer();
+        return new Analyzer() {
+			@Override
+			protected TokenStreamComponents createComponents(String fieldName) {
+				Tokenizer tokenizer = new WhitespaceTokenizer();
+				TokenStream filter = new LowerCaseFilter(tokenizer);
+				return new TokenStreamComponents(tokenizer, filter);
+			}
+		};
     }
 
     protected abstract Directory makeDirectory() throws ServerException;


### PR DESCRIPTION
Hello,

I would like to enhance Lucene searcher capabilities therefore I did following changes:
1. queryParser.setAllowLeadingWildcard(true) enables performing contains query ( like *uer* )
2. SimpleAnalyzer uses LetterTokenizer with LowerCaseFilter, that means that it creates tokens by broking a text by non-letter characters, therefore in current implementation it is not possible to search for the text containing special characters. Using WhitespaceTokenizer solves this issue as it creates tokens by broking a text by whitespace.

Thanks & Regards,
Rima