### PR TITLE
add support for include files in getTree() of project-api

### DIFF
--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/FolderEntry.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/FolderEntry.java
@@ -44,6 +44,13 @@ public class FolderEntry extends VirtualFileEntry {
         }
     };
 
+    private static final VirtualFileFilter FILE_FOLDER_FILTER = new VirtualFileFilter() {
+        @Override
+        public boolean accept(VirtualFile file) {
+            return (file.isFile() || file.isFolder());
+        }
+    };
+
     public FolderEntry(String workspace, VirtualFile virtualFile) {
         super(workspace, virtualFile);
     }
@@ -114,6 +121,16 @@ public class FolderEntry extends VirtualFileEntry {
             children.add(new FolderEntry(getWorkspace(), vfChildren.next()));
         }
         return children;
+    }
+
+    /**
+     * Gets child folders and files of this folder. If current user doesn't have read access to some child they aren't added in result list.
+     *
+     * @throws ServerException
+     *         if an error occurs
+     */
+    public List<VirtualFileEntry> getChildFoldersFiles() throws ServerException {
+        return getChildren(FILE_FOLDER_FILTER);
     }
 
     List<VirtualFileEntry> getChildren(VirtualFileFilter filter) throws ServerException {

--- a/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
+++ b/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
@@ -1994,6 +1994,80 @@ public class ProjectServiceTest {
         Assert.assertTrue(names.contains("x/y"));
     }
 
+
+    @Test
+    public void testGetTreeWithDepthAndIncludeFiles() throws Exception {
+        Project myProject = pm.getProject(workspace, "my_project");
+        FolderEntry a = myProject.getBaseFolder().createFolder("a");
+        a.createFolder("b/c");
+        a.createFolder("x").createFile("test.txt", "test".getBytes(), "text/plain");
+        ContainerResponse response = launcher.service("GET",
+                                                      String.format("http://localhost:8080/api/project/%s/tree/my_project/a?depth=100&includeFiles=true",
+                                                                    workspace),
+                                                      "http://localhost:8080/api", null, null, null);
+        assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
+        TreeElement tree = (TreeElement)response.getEntity();
+        ItemReference a_node = tree.getNode();
+        assertEquals(a_node.getName(), "a");
+        List<TreeElement> children = tree.getChildren();
+        assertNotNull(children);
+        Set<String> names = new LinkedHashSet<>(4);
+        for (TreeElement subTree : children) {
+            ItemReference _node = subTree.getNode();
+            validateFolderLinks(_node);
+            String name = _node.getName();
+            names.add(name);
+            for (TreeElement subSubTree : subTree.getChildren()) {
+                ItemReference __node = subSubTree.getNode();
+                if (__node.getType().equals("folder")) {
+                	validateFolderLinks(__node);
+                } else if (__node.getType().equals("file")){
+                	validateFileLinks(__node);
+                }
+                names.add(name + "/" + __node.getName());
+            }
+        }
+        Assert.assertTrue(names.contains("b"));
+        Assert.assertTrue(names.contains("x"));
+        Assert.assertTrue(names.contains("b/c"));
+        Assert.assertTrue(names.contains("x/test.txt"));
+    }
+    
+    @Test
+    public void testGetTreeWithDepthAndIncludeFilesNoFiles() throws Exception {
+        Project myProject = pm.getProject(workspace, "my_project");
+        FolderEntry a = myProject.getBaseFolder().createFolder("a");
+        a.createFolder("b/c");
+        a.createFolder("x");
+        ContainerResponse response = launcher.service("GET",
+                                                      String.format("http://localhost:8080/api/project/%s/tree/my_project/a?depth=100&includeFiles=true",
+                                                                    workspace),
+                                                      "http://localhost:8080/api", null, null, null);
+        assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
+        TreeElement tree = (TreeElement)response.getEntity();
+        ItemReference a_node = tree.getNode();
+        assertEquals(a_node.getName(), "a");
+        List<TreeElement> children = tree.getChildren();
+        assertNotNull(children);
+        Set<String> names = new LinkedHashSet<>(4);
+        for (TreeElement subTree : children) {
+            ItemReference _node = subTree.getNode();
+            validateFolderLinks(_node);
+            String name = _node.getName();
+            names.add(name);
+            for (TreeElement subSubTree : subTree.getChildren()) {
+                ItemReference __node = subSubTree.getNode();
+                validateFolderLinks(__node);
+                names.add(name + "/" + __node.getName());
+            }
+        }
+        Assert.assertTrue(names.contains("b"));
+        Assert.assertTrue(names.contains("x"));
+        Assert.assertTrue(names.contains("b/c"));
+        Assert.assertFalse(names.contains("x/test.txt"));
+    }
+
+
     @Test
     public void testSwitchProjectVisibilityToPrivate() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");


### PR DESCRIPTION
Hello,

Currently, the getTree() api does not include file children in it's response (only folders); to get the files we will need to traverse the tree by calling getChildren() api repeatedly.

So, in order for us to have the functionality we need, I would like to suggest a small addition to the getTree() api (GET /project/{ws-id}/tree/{parent:.*})

I would like to add another query param: ?includeFiles (which will be set to false by default); this param will indicate whether or not to include file children in the result tree.

I've made the relevant changes in: 
platform-api\che-core-api-project\src\main\java\org\eclipse\che\api\project\server\ProjectService.java
and in:
platform-api\che-core-api-project\src\main\java\org\eclipse\che\api\project\server\FolderEntry.java

I've tested it locally; it seems to work fine. I have also added relevant tests to: 
platform-api\che-core-api-project\src\test\java\org\eclipse\che\api\project\server\ProjectServiceTest.java  

Thanks in advance,
Anat
