### PR TITLE
Allow defining custom JSON field names for DTO interfaces

### DIFF
--- a/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImpl.java
+++ b/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImpl.java
@@ -12,10 +12,16 @@ package org.eclipse.che.dto.generator;
 
 import org.eclipse.che.dto.shared.CompactJsonDto;
 import org.eclipse.che.dto.shared.DelegateTo;
+import org.eclipse.che.dto.shared.JsonFieldName;
 import org.eclipse.che.dto.shared.SerializationIndex;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonWriter;
 
+import java.io.IOException;
+import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -111,7 +117,10 @@ abstract class DtoImpl {
         return "ensure" + getCamelCaseName(fieldName);
     }
 
-    protected String getJsonFieldName(String getterName) {
+    /**
+     * Get the canonical name of the field by deriving it from a getter method's name.
+     */
+    protected String getFieldNameFromGetterName(String getterName) {
         String fieldName;
         if (getterName.startsWith("get")) {
             fieldName = getterName.substring(3);
@@ -120,6 +129,22 @@ abstract class DtoImpl {
             fieldName = getterName.substring(2);
         }
         return Character.toLowerCase(fieldName.charAt(0)) + fieldName.substring(1);
+    }
+
+    /**
+     * Get the name of the JSON field that corresponds to the given getter method in a DTO-annotated type.
+     */
+    protected String getJsonFieldName(Method getterMethod) {
+        // First, check if a custom field name is defined for the getter
+        JsonFieldName fieldNameAnn = getterMethod.getAnnotation(JsonFieldName.class);
+        if (fieldNameAnn != null) {
+            String customFieldName = fieldNameAnn.value();
+            if (customFieldName != null && !customFieldName.isEmpty()) {
+                return customFieldName;
+            }
+        }
+        // If no custom name is given for the field, deduce it from the camel notation
+        return getFieldNameFromGetterName(getterMethod.getName());
     }
 
     /**
@@ -323,6 +348,21 @@ abstract class DtoImpl {
     protected boolean isLastMethod(Method method) {
         Preconditions.checkNotNull(method);
         return method == dtoMethods.get(dtoMethods.size() - 1);
+    }
+    
+    /**
+     * Create a textual representation of a string literal that evaluates to the given value.
+     */
+    protected String quoteStringLiteral(String value) {
+        StringWriter sw = new StringWriter();
+        try (JsonWriter writer = new JsonWriter(sw)) {
+            writer.setLenient(true);
+            writer.value(value);
+            writer.flush();
+        } catch (IOException ex) {
+            throw new RuntimeException("Unexpected I/O failure: " + ex.getLocalizedMessage(), ex);
+        }
+        return sw.toString();
     }
 
     /**

--- a/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImplClientTemplate.java
+++ b/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImplClientTemplate.java
@@ -286,15 +286,17 @@ public class DtoImplClientTemplate extends DtoImpl {
     }
 
     private void emitSerializeFieldForMethod(Method getter, final StringBuilder builder) {
-        final String jsonFieldName = getJsonFieldName(getter.getName());
-        final String fieldNameOut = jsonFieldName + "Out";
+        final String fieldName = getFieldNameFromGetterName(getter.getName());
+        final String fieldNameOut = fieldName + "Out";
         final String baseIndentation = "      ";
+        final String jsonFieldName = getJsonFieldName(getter);
+        final String jsonFieldNameLiteral = quoteStringLiteral(jsonFieldName);
         builder.append("\n");
         List<Type> expandedTypes = expandType(getter.getGenericReturnType());
         emitSerializerImpl(expandedTypes, 0, builder, getJavaFieldName(getter.getName()), fieldNameOut, baseIndentation);
-        builder.append("      result.put(\"");
-        builder.append(jsonFieldName);
-        builder.append("\", ");
+        builder.append("      result.put(");
+        builder.append(jsonFieldNameLiteral);
+        builder.append(", ");
         builder.append(fieldNameOut);
         builder.append(");\n");
     }
@@ -304,7 +306,7 @@ public class DtoImplClientTemplate extends DtoImpl {
             builder.append("      result.set(0, JSONNull.getInstance());\n");
             return;
         }
-        final String jsonFieldName = getJsonFieldName(getter.getName());
+        final String jsonFieldName = getFieldNameFromGetterName(getter.getName());
         final String fieldNameOut = jsonFieldName + "Out";
         final String baseIndentation = "      ";
         builder.append("\n");
@@ -448,22 +450,24 @@ public class DtoImplClientTemplate extends DtoImpl {
     }
 
     private void emitDeserializeFieldForMethod(Method getter, StringBuilder builder) {
-        final String fieldName = getJsonFieldName(getter.getName());
+        final String fieldName = getFieldNameFromGetterName(getter.getName());
         final String fieldNameIn = fieldName + "In";
         final String fieldNameOut = fieldName + "Out";
         final String baseIndentation = "        ";
+        final String jsonFieldName = getJsonFieldName(getter);
+        final String jsonFieldNameLiteral = quoteStringLiteral(jsonFieldName);
         builder.append("\n");
-        builder.append("      if (json.containsKey(\"").append(fieldName).append("\")) {\n");
+        builder.append("      if (json.containsKey(").append(jsonFieldNameLiteral).append(")) {\n");
         List<Type> expandedTypes = expandType(getter.getGenericReturnType());
-        builder.append("        JSONValue ").append(fieldNameIn).append(" = json.get(\"").append(fieldName).append(
-                "\");\n");
+        builder.append("        JSONValue ").append(fieldNameIn).append(" = json.get(").append(jsonFieldNameLiteral).append(
+                ");\n");
         emitDeserializerImpl(expandedTypes, 0, builder, fieldNameIn, fieldNameOut, baseIndentation);
         builder.append("        dto.").append(getSetterName(fieldName)).append("(").append(fieldNameOut).append(");\n");
         builder.append("      }\n");
     }
 
     private void emitDeserializeFieldForMethodCompact(Method method, final StringBuilder builder) {
-        final String fieldName = getJsonFieldName(method.getName());
+        final String fieldName = getFieldNameFromGetterName(method.getName());
         final String fieldNameIn = fieldName + "In";
         final String fieldNameOut = fieldName + "Out";
         final String baseIndentation = "        ";

--- a/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImplServerTemplate.java
+++ b/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImplServerTemplate.java
@@ -306,15 +306,16 @@ public class DtoImplServerTemplate extends DtoImpl {
     }
 
     private void emitSerializeFieldForMethod(Method getter, final StringBuilder builder) {
-        final String jsonFieldName = getJsonFieldName(getter.getName());
-        final String fieldNameOut = jsonFieldName + "Out";
+        final String fieldName = getFieldNameFromGetterName(getter.getName());
+        final String jsonFieldName = getJsonFieldName(getter);
+        final String fieldNameOut = fieldName + "Out";
         final String baseIndentation = "      ";
         builder.append("\n");
         List<Type> expandedTypes = expandType(getter.getGenericReturnType());
         emitSerializerImpl(expandedTypes, 0, builder, getJavaFieldName(getter.getName()), fieldNameOut, baseIndentation);
-        builder.append("      result.add(\"");
-        builder.append(jsonFieldName);
-        builder.append("\", ");
+        builder.append("      result.add(");
+        builder.append(quoteStringLiteral(jsonFieldName));
+        builder.append(", ");
         builder.append(fieldNameOut);
         builder.append(");\n");
     }
@@ -324,7 +325,7 @@ public class DtoImplServerTemplate extends DtoImpl {
             builder.append("      result.add(JsonNull.INSTANCE);\n");
             return;
         }
-        final String jsonFieldName = getJsonFieldName(getter.getName());
+        final String jsonFieldName = getJsonFieldName(getter);
         final String fieldNameOut = jsonFieldName + "Out";
         final String baseIndentation = "      ";
         builder.append("\n");
@@ -472,22 +473,24 @@ public class DtoImplServerTemplate extends DtoImpl {
     }
 
     private void emitDeserializeFieldForMethod(Method method, StringBuilder builder) {
-        final String fieldName = getJsonFieldName(method.getName());
+        final String fieldName = getFieldNameFromGetterName(method.getName());
         final String fieldNameIn = fieldName + "In";
         final String fieldNameOut = fieldName + "Out";
         final String baseIndentation = "        ";
+        
+        final String jsonFieldName = getJsonFieldName(method);
 
         builder.append("\n");
-        builder.append("      if (json.has(\"").append(fieldName).append("\")) {\n");
+        builder.append("      if (json.has(").append(quoteStringLiteral(jsonFieldName)).append(")) {\n");
         List<Type> expandedTypes = expandType(method.getGenericReturnType());
-        builder.append("        JsonElement ").append(fieldNameIn).append(" = json.get(\"").append(fieldName).append("\");\n");
+        builder.append("        JsonElement ").append(fieldNameIn).append(" = json.get(").append(quoteStringLiteral(jsonFieldName)).append(");\n");
         emitDeserializerImpl(expandedTypes, 0, builder, fieldNameIn, fieldNameOut, baseIndentation);
         builder.append("        dto.").append(getSetterName(fieldName)).append("(").append(fieldNameOut).append(");\n");
         builder.append("      }\n");
     }
 
     private void emitDeserializeFieldForMethodCompact(Method method, final StringBuilder builder) {
-        final String fieldName = getJsonFieldName(method.getName());
+        final String fieldName = getJsonFieldName(method);
         final String fieldNameIn = fieldName + "In";
         final String fieldNameOut = fieldName + "Out";
         final String baseIndentation = "        ";

--- a/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/shared/JsonFieldName.java
+++ b/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/shared/JsonFieldName.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.dto.shared;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * Use a custom name for the JSON element that corresponds to a class field
+ * 
+ * @author Tareq Sharafy (tareq.sharafy@sap.com)
+ */
+@Beta
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonFieldName {
+    String value();
+}

--- a/platform-api/che-core-api-dto/src/test/java/org/eclipse/che/dto/ServerDtoTest.java
+++ b/platform-api/che-core-api-dto/src/test/java/org/eclipse/che/dto/ServerDtoTest.java
@@ -12,6 +12,7 @@ package org.eclipse.che.dto;
 
 import org.eclipse.che.dto.definitions.ComplicatedDto;
 import org.eclipse.che.dto.definitions.DtoWithDelegate;
+import org.eclipse.che.dto.definitions.DtoWithFieldNames;
 import org.eclipse.che.dto.definitions.SimpleDto;
 import org.eclipse.che.dto.server.DtoFactory;
 import com.google.gson.JsonArray;
@@ -79,6 +80,34 @@ public class ServerDtoTest {
 
         // Check to make sure things are in a sane state.
         checkSimpleDto(dto, fooString, fooId, _default);
+    }
+
+    @Test
+    public void testSerializerWithFieldNames() throws Exception {
+        final String fooString = "Something";
+        final String _default = "test_default_keyword";
+
+        DtoWithFieldNames dto = dtoFactory.createDto(DtoWithFieldNames.class).withTheName(fooString).withTheDefault(_default);
+        final String json = dtoFactory.toJson(dto);
+
+        JsonObject jsonObject = new JsonParser().parse(json).getAsJsonObject();
+        Assert.assertEquals(jsonObject.get(DtoWithFieldNames.THENAME_FIELD).getAsString(), fooString);
+        Assert.assertEquals(jsonObject.get(DtoWithFieldNames.THEDEFAULT_FIELD).getAsString(), _default);
+    }
+
+    @Test
+    public void testDeerializerWithFieldNames() throws Exception {
+        final String fooString = "Something";
+        final String _default = "test_default_keyword";
+
+        JsonObject json = new JsonObject();
+        json.add(DtoWithFieldNames.THENAME_FIELD, new JsonPrimitive(fooString));
+        json.add(DtoWithFieldNames.THEDEFAULT_FIELD, new JsonPrimitive(_default));
+
+        DtoWithFieldNames dto = dtoFactory.createDtoFromJson(json.toString(), DtoWithFieldNames.class);
+
+        Assert.assertEquals(dto.getTheName(), fooString);
+        Assert.assertEquals(dto.getTheDefault(), _default);
     }
 
     @Test

--- a/platform-api/che-core-api-dto/src/test/java/org/eclipse/che/dto/definitions/DtoWithFieldNames.java
+++ b/platform-api/che-core-api-dto/src/test/java/org/eclipse/che/dto/definitions/DtoWithFieldNames.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.dto.definitions;
+
+import org.eclipse.che.dto.shared.DTO;
+import org.eclipse.che.dto.shared.JsonFieldName;
+
+/**
+ * Makes use of the JsonFieldName annotation
+ * 
+ * @author Tareq Sharafy (tareq.sharafy@sap.com)
+ */
+@DTO
+public interface DtoWithFieldNames {
+
+    public String THENAME_FIELD = "the name";
+    public String THEDEFAULT_FIELD = "default";
+
+    @JsonFieldName(THENAME_FIELD)
+    String getTheName();
+
+    void setTheName(String v);
+
+    DtoWithFieldNames withTheName(String v);
+
+    @JsonFieldName(THEDEFAULT_FIELD)
+    String getTheDefault();
+
+    void setTheDefault(String v);
+
+    DtoWithFieldNames withTheDefault(String v);
+}


### PR DESCRIPTION
A new annotation, \@JsonFieldName, allow defining it

Signed-off-by: Tareq Sharafy <tareq.sharafy@sap.com>