### PR TITLE
Copy move with overwrite

### DIFF
--- a/che-core-vfs-impl/src/main/java/org/eclipse/che/vfs/impl/fs/VirtualFileImpl.java
+++ b/che-core-vfs-impl/src/main/java/org/eclipse/che/vfs/impl/fs/VirtualFileImpl.java
@@ -201,15 +201,22 @@ public class VirtualFileImpl implements VirtualFile {
     }
 
     //
-
     @Override
-    public VirtualFile copyTo(VirtualFile parent) throws ForbiddenException, ConflictException, ServerException {
-        return mountPoint.copy(this, (VirtualFileImpl)parent);
+    public VirtualFileImpl copyTo(VirtualFile parent) throws ForbiddenException, ConflictException, ServerException {
+        return copyTo(parent, null, false); // default behaviour
+    }
+
+    public VirtualFileImpl copyTo(VirtualFile parent, String name, boolean overWrite) throws ForbiddenException, ConflictException, ServerException {
+        return mountPoint.copy(this, (VirtualFileImpl) parent, name, overWrite);
     }
 
     @Override
-    public VirtualFile moveTo(VirtualFile parent, String lockToken) throws ForbiddenException, ConflictException, ServerException {
-        return mountPoint.move(this, (VirtualFileImpl)parent, lockToken);
+    public VirtualFileImpl moveTo(VirtualFile parent, String lockToken) throws ForbiddenException, ConflictException, ServerException {
+        return moveTo(parent, null, false, lockToken);
+    }
+
+    public VirtualFileImpl moveTo(VirtualFile parent, String name, boolean overWrite, String lockToken) throws ForbiddenException, ConflictException, ServerException {
+        return mountPoint.move(this, (VirtualFileImpl) parent, name, overWrite, lockToken);
     }
 
     @Override

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/FileEntry.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/FileEntry.java
@@ -35,20 +35,32 @@ public class FileEntry extends VirtualFileEntry {
         super(workspace, virtualFile);
     }
 
+    @Override
     public FileEntry copyTo(String newParent) throws NotFoundException, ForbiddenException, ConflictException, ServerException {
+        return copyTo(newParent, getName(), false);
+    }
+
+    @Override
+    public FileEntry copyTo(String newParent, String newName, boolean override) throws NotFoundException, ForbiddenException, ConflictException, ServerException {
         if (Path.fromString(newParent).isRoot()) {
             throw new ServerException(String.format("Invalid path %s. Can't create file outside of project.", newParent));
         }
         final VirtualFile vf = getVirtualFile();
         final MountPoint mp = vf.getMountPoint();
-        return new FileEntry(getWorkspace(), vf.copyTo(mp.getVirtualFile(newParent)));
+        return new FileEntry(getWorkspace(), vf.copyTo(mp.getVirtualFile(newParent), newName, override));
     }
 
+    @Override
     public void moveTo(String newParent) throws ConflictException, NotFoundException, ForbiddenException, ServerException {
+        moveTo(newParent,null,false);
+    }
+
+    @Override
+    public void moveTo(String newParent, String name, boolean overWrite) throws NotFoundException, ForbiddenException, ConflictException, ServerException {
         if (Path.fromString(newParent).isRoot()) {
             throw new ServerException(String.format("Invalid path %s. Can't move this item outside of project.", newParent));
         }
-        super.moveTo(newParent);
+        super.moveTo(newParent, name, overWrite); //To change body of generated methods, choose Tools | Templates.
     }
 
     /**

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/FolderEntry.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/FolderEntry.java
@@ -55,10 +55,16 @@ public class FolderEntry extends VirtualFileEntry {
         super(workspace, virtualFile);
     }
 
+    @Override
     public FolderEntry copyTo(String newParent) throws NotFoundException, ForbiddenException, ConflictException, ServerException {
+        return copyTo(newParent, getName(), false);
+    }
+
+    @Override
+    public FolderEntry copyTo(String newParent, String name, boolean overWrite) throws NotFoundException, ForbiddenException, ConflictException, ServerException {
         final VirtualFile vf = getVirtualFile();
         final MountPoint mp = vf.getMountPoint();
-        return new FolderEntry(getWorkspace(), vf.copyTo(mp.getVirtualFile(newParent)));
+        return new FolderEntry(getWorkspace(), vf.copyTo(mp.getVirtualFile(newParent),name,overWrite));
     }
 
     /**

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
@@ -103,6 +103,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import org.eclipse.che.api.project.shared.dto.CopyOptions;
+import org.eclipse.che.api.project.shared.dto.MoveOptions;
 
 /**
  * @author andrew00x
@@ -714,15 +716,25 @@ public class ProjectService extends Service {
             @ApiResponse(code = 500, message = "Internal Server Error")})
     @POST
     @Path("/copy/{path:.*}")
+    @Consumes(MediaType.APPLICATION_JSON)
     public Response copy(@ApiParam(value = "Workspace ID", required = true)
                          @PathParam("ws-id") String workspace,
                          @ApiParam(value = "Path to a resource", required = true)
                          @PathParam("path") String path,
                          @ApiParam(value = "Path to a new location", required = true)
-                         @QueryParam("to") String newParent)
+            @QueryParam("to") String newParent,
+            @DefaultValue("{}") @Description("options for copy operation") CopyOptions copyOptions)
             throws NotFoundException, ForbiddenException, ConflictException, ServerException {
         final VirtualFileEntry entry = getVirtualFileEntry(workspace, path);
-        final VirtualFileEntry copy = entry.copyTo(newParent);
+        // used to indicate over write of destination
+        boolean isOverWrite = false;
+        // used to hold new name set in request body
+        String newName = entry.getName();
+        if (copyOptions != null) {
+            isOverWrite = copyOptions.getOverWrite();
+            newName = copyOptions.getName();
+        }
+        final VirtualFileEntry copy = entry.copyTo(newParent, newName, isOverWrite);
         final URI location = getServiceContext().getServiceUriBuilder()
                                                 .path(getClass(), copy.isFile() ? "getFile" : "getChildren")
                                                 .build(workspace, copy.getPath().substring(1));
@@ -753,10 +765,21 @@ public class ProjectService extends Service {
                          @ApiParam(value = "Path to a resource to be moved", required = true)
                          @PathParam("path") String path,
                          @ApiParam(value = "Path to a new location", required = true)
-                         @QueryParam("to") String newParent)
+            @QueryParam("to") String newParent,
+            @DefaultValue("{}") @Description("options for move operation") MoveOptions moveOptions)
             throws NotFoundException, ForbiddenException, ConflictException, ServerException {
         final VirtualFileEntry entry = getVirtualFileEntry(workspace, path);
-        entry.moveTo(newParent);
+        
+// used to indicate over write of destination
+        boolean isOverWrite = false;
+        // used to hold new name set in request body
+        String newName = entry.getName();
+        if (moveOptions != null) {
+            isOverWrite = moveOptions.getOverWrite();
+            newName = moveOptions.getName();
+        }
+        
+        entry.moveTo(newParent, newName, isOverWrite);
         final URI location = getServiceContext().getServiceUriBuilder()
                                                 .path(getClass(), entry.isFile() ? "getFile" : "getChildren")
                                                 .build(workspace, entry.getPath().substring(1));

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/VirtualFileEntry.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/VirtualFileEntry.java
@@ -136,6 +136,21 @@ public abstract class VirtualFileEntry {
             throws NotFoundException, ForbiddenException, ConflictException, ServerException;
 
     /**
+     * Creates copy of this item in new parent.
+     *
+     * @param newParent path of new parent
+     * @param name new name for destination
+     * @param override true to overwrite destination
+     * @throws NotFoundException if {@code newParent} doesn't exist
+     * @throws ForbiddenException if copy operation is forbidden
+     * @throws ConflictException if copy operation causes conflict, e.g. name
+     * conflict
+     * @throws ServerException if other error occurs
+     */
+    public abstract VirtualFileEntry copyTo(String newParent, String name, boolean override)
+            throws NotFoundException, ForbiddenException, ConflictException, ServerException;
+
+    /**
      * Moves this item to the new parent.
      *
      * @param newParent
@@ -150,8 +165,24 @@ public abstract class VirtualFileEntry {
      *         if other error occurs
      */
     public void moveTo(String newParent) throws NotFoundException, ForbiddenException, ConflictException, ServerException {
+        moveTo(newParent, null, false);
+    }
+
+    /**
+     * Moves this item to the new parent.
+     *
+     * @param newParent path of new parent
+     * @param name new name for destination
+     * @param overWrite true to overwrite destination
+     * @throws NotFoundException if {@code newParent} doesn't exist
+     * @throws ForbiddenException if move operation is forbidden
+     * @throws ConflictException if move operation causes conflict, e.g. name
+     * conflict
+     * @throws ServerException if other error occurs
+     */
+    public void moveTo(String newParent, String name, boolean overWrite) throws NotFoundException, ForbiddenException, ConflictException, ServerException {
         final MountPoint mp = virtualFile.getMountPoint();
-        virtualFile = virtualFile.moveTo(mp.getVirtualFile(newParent), null);
+        virtualFile = virtualFile.moveTo(mp.getVirtualFile(newParent), name, overWrite, null);
     }
 
     /**

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/shared/dto/CopyOptions.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/shared/dto/CopyOptions.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.project.shared.dto;
+
+import org.eclipse.che.dto.shared.DTO;
+
+/**
+ *
+ * @author Ori Libhaber
+ */
+@DTO
+public interface CopyOptions {
+    /**
+     * Get value of overWrite attribute
+     * @return overWrite attribute
+     */
+    public abstract boolean getOverWrite();
+    /**
+     * Set value of overWrite attribute
+     * @param overWrite is the value to set to overWrite attribute
+     */
+    public abstract void setOverWrite(boolean overWrite);
+    /**
+     * Get value of name attribute
+     * @return name attribute
+     */
+    public abstract String getName();
+    /**
+     * Set value of name attribute
+     * @param name is the value to set to name attribute
+     */
+    public abstract void setName(String name);
+    
+}

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/shared/dto/MoveOptions.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/shared/dto/MoveOptions.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.project.shared.dto;
+
+import org.eclipse.che.dto.shared.DTO;
+
+/**
+ *
+ * @author Ori Libhaber
+ */
+@DTO
+public interface MoveOptions {
+    /**
+     * Get value of overWrite attribute
+     * @return overWrite attribute
+     */
+    public abstract boolean getOverWrite();
+    /**
+     * Set value of overWrite attribute
+     * @param overWrite is the value to set to overWrite attribute
+     */
+    public abstract void setOverWrite(boolean overWrite);
+    /**
+     * Get value of name attribute
+     * @return name attribute
+     */
+    public abstract String getName();
+    /**
+     * Set value of name attribute
+     * @param name is the value to set to name attribute
+     */
+    public abstract void setName(String name);
+    
+}

--- a/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
+++ b/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
@@ -94,9 +94,12 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Scanner;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import org.eclipse.che.api.project.shared.dto.CopyOptions;
+import org.eclipse.che.api.project.shared.dto.MoveOptions;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -1075,6 +1078,82 @@ public class ProjectServiceTest {
     }
 
     @Test
+    public void testCopyFileWithRename() throws Exception {
+        Project myProject = pm.getProject(workspace, "my_project");
+        myProject.getBaseFolder().createFolder("a/b/c");
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), "text/plain");
+
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Content-Type", Arrays.asList("application/json"));
+
+        CopyOptions descriptor = DtoFactory.getInstance().createDto(CopyOptions.class);
+        descriptor.setName("copyOfTest.txt");
+        descriptor.setOverWrite(false);
+
+        ContainerResponse response = launcher.service("POST",
+                String.format(
+                        "http://localhost:8080/api/project/%s/copy/my_project/a/b/test.txt?to=/my_project/a/b/c",
+                        workspace),
+                "http://localhost:8080/api", headers, DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+        assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
+        assertEquals(response.getHttpHeaders().getFirst("Location"),
+                URI.create(String.format("http://localhost:8080/api/project/%s/file/my_project/a/b/c/copyOfTest.txt", workspace)));
+        assertNotNull(myProject.getBaseFolder().getChild("a/b/c/copyOfTest.txt")); // new
+        assertNotNull(myProject.getBaseFolder().getChild("a/b/test.txt")); // old
+    }
+
+    @Test
+    public void testCopyFileWithRenameAndOverwrite() throws Exception {
+        Project myProject = pm.getProject(workspace, "my_project");
+        myProject.getBaseFolder().createFolder("a/b/c");
+
+        // File names
+        String originFileName = "test.txt";
+        String destinationFileName = "overwriteMe.txt";
+
+        // File contents
+        String originContent = "to be or not no be";
+        String overwritenContent = "that is the question";
+
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes(), "text/plain");
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwritenContent.getBytes(), "text/plain");
+
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Content-Type", Arrays.asList("application/json"));
+
+        CopyOptions descriptor = DtoFactory.getInstance().createDto(CopyOptions.class);
+        descriptor.setName(destinationFileName);
+        descriptor.setOverWrite(true);
+
+        ContainerResponse response = launcher.service("POST",
+                String.format(
+                        "http://localhost:8080/api/project/%s/copy/my_project/a/b/" + originFileName + "?to=/my_project/a/b/c",
+                        workspace),
+                "http://localhost:8080/api", headers, DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+        assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
+        assertEquals(response.getHttpHeaders().getFirst("Location"),
+                URI.create(String.format("http://localhost:8080/api/project/%s/file/my_project/a/b/c/" + destinationFileName, workspace)));
+        assertNotNull(myProject.getBaseFolder().getChild("a/b/c/" + destinationFileName)); // new
+        assertNotNull(myProject.getBaseFolder().getChild("a/b/" + originFileName)); // old
+
+        Scanner inputStreamScanner = null;
+        String theFirstLineFromDestinationFile = null;
+
+        try {
+            inputStreamScanner = new Scanner(myProject.getBaseFolder().getChild("a/b/c/" + destinationFileName).getVirtualFile().getContent().getStream());
+            theFirstLineFromDestinationFile = inputStreamScanner.nextLine();
+            // destination should contain original file's content
+            assertEquals(theFirstLineFromDestinationFile, originContent);
+        } catch (ForbiddenException | ServerException e) {
+            Assert.fail(e.getMessage());
+        } finally {
+            if (inputStreamScanner != null) {
+                inputStreamScanner.close();
+            }
+        }
+    }
+
+    @Test
     public void testCopyFolder() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
@@ -1089,6 +1168,73 @@ public class ProjectServiceTest {
                      URI.create(String.format("http://localhost:8080/api/project/%s/children/my_project/a/b/c/b", workspace)));
         assertNotNull(myProject.getBaseFolder().getChild("a/b/test.txt"));
         assertNotNull(myProject.getBaseFolder().getChild("a/b/c/b/test.txt"));
+    }
+
+    @Test
+    public void testCopyFolderWithRename() throws Exception {
+        Project myProject = pm.getProject(workspace, "my_project");
+        myProject.getBaseFolder().createFolder("a/b/c");
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), "text/plain");
+
+        // new name for folder
+        final String renamedFolder = "renamedFolder";
+
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Content-Type", Arrays.asList("application/json"));
+
+        CopyOptions descriptor = DtoFactory.getInstance().createDto(CopyOptions.class);
+        descriptor.setName(renamedFolder);
+        descriptor.setOverWrite(false);
+
+        ContainerResponse response = launcher.service("POST",
+                String.format(
+                        "http://localhost:8080/api/project/%s/copy/my_project/a/b?to=/my_project/a/b/c",
+                        workspace),
+                "http://localhost:8080/api", headers, DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+        assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
+        assertEquals(response.getHttpHeaders().getFirst("Location"),
+                URI.create(String.format("http://localhost:8080/api/project/%s/children/my_project/a/b/c/%s", workspace, renamedFolder)));
+        assertNotNull(myProject.getBaseFolder().getChild("a/b/test.txt"));
+        assertNotNull(myProject.getBaseFolder().getChild(String.format("a/b/c/%s/test.txt", renamedFolder)));
+    }
+    
+    @Test
+    public void testCopyFolderWithRenameAndOverwrite() throws Exception {
+        Project myProject = pm.getProject(workspace, "my_project");
+        myProject.getBaseFolder().createFolder("a/b/c");
+
+        // File names
+        String originFileName = "test.txt";
+        String destinationFileName = "overwriteMe.txt";
+
+        // File contents
+        String originContent = "to be or not no be";
+        String overwritenContent = "that is the question";
+        
+        // new name for folder
+        final String renamedFolder = "renamedFolder";
+
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes(), "text/plain");
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwritenContent.getBytes(), "text/plain");
+
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Content-Type", Arrays.asList("application/json"));
+
+        CopyOptions descriptor = DtoFactory.getInstance().createDto(CopyOptions.class);
+        descriptor.setName(renamedFolder);
+        descriptor.setOverWrite(true);
+
+        ContainerResponse response = launcher.service("POST",
+                String.format(
+                        "http://localhost:8080/api/project/%s/copy/my_project/a/b?to=/my_project/a/b/c",
+                        workspace),
+                "http://localhost:8080/api", headers, DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+        assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
+        assertEquals(response.getHttpHeaders().getFirst("Location"),
+                URI.create(String.format("http://localhost:8080/api/project/%s/children/my_project/a/b/c/%s", workspace, renamedFolder)));
+        assertNotNull(myProject.getBaseFolder().getChild("a/b/test.txt"));
+        assertNotNull(myProject.getBaseFolder().getChild(String.format("a/b/c/%s/test.txt", renamedFolder)));
+        assertEquals(myProject.getBaseFolder().getChild("a/b/test.txt").getName(), myProject.getBaseFolder().getChild(String.format("a/b/c/%s/%s", renamedFolder, originFileName)).getName());
     }
 
     @Test
@@ -1109,6 +1255,84 @@ public class ProjectServiceTest {
     }
 
     @Test
+    public void testMoveFileWithRename() throws Exception {
+        Project myProject = pm.getProject(workspace, "my_project");
+        myProject.getBaseFolder().createFolder("a/b/c");
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), "text/plain");
+        
+        // name for file after move
+        final String destinationName = "copyOfTestForMove.txt";
+
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Content-Type", Arrays.asList("application/json"));
+
+        MoveOptions descriptor = DtoFactory.getInstance().createDto(MoveOptions.class);
+        descriptor.setName(destinationName);
+        descriptor.setOverWrite(false);
+
+        ContainerResponse response = launcher.service("POST",
+                String.format(
+                        "http://localhost:8080/api/project/%s/move/my_project/a/b/test.txt?to=/my_project/a/b/c",
+                        workspace),
+                "http://localhost:8080/api", headers, DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+        assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
+        assertEquals(response.getHttpHeaders().getFirst("Location"),
+                URI.create(String.format("http://localhost:8080/api/project/%s/file/my_project/a/b/c/%s", workspace,destinationName)));
+        VirtualFileEntry theTargetFile = myProject.getBaseFolder().getChild(String.format("a/b/c/%s", destinationName));
+        assertNotNull(theTargetFile); // new
+    }
+    
+    @Test
+    public void testMoveFileWithRenameAndOverwrite() throws Exception {
+        Project myProject = pm.getProject(workspace, "my_project");
+        myProject.getBaseFolder().createFolder("a/b/c");
+
+        // File names
+        String originFileName = "test.txt";
+        String destinationFileName = "overwriteMe.txt";
+
+        // File contents
+        String originContent = "to be or not no be";
+        String overwritenContent = "that is the question";
+
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes(), "text/plain");
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwritenContent.getBytes(), "text/plain");
+
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Content-Type", Arrays.asList("application/json"));
+
+        MoveOptions descriptor = DtoFactory.getInstance().createDto(MoveOptions.class);
+        descriptor.setName(destinationFileName);
+        descriptor.setOverWrite(true);
+
+        ContainerResponse response = launcher.service("POST",
+                String.format(
+                        "http://localhost:8080/api/project/%s/move/my_project/a/b/" + originFileName + "?to=/my_project/a/b/c",
+                        workspace),
+                "http://localhost:8080/api", headers, DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+        assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
+        assertEquals(response.getHttpHeaders().getFirst("Location"),
+                URI.create(String.format("http://localhost:8080/api/project/%s/file/my_project/a/b/c/" + destinationFileName, workspace)));
+        assertNotNull(myProject.getBaseFolder().getChild("a/b/c/" + destinationFileName)); // new
+
+        Scanner inputStreamScanner = null;
+        String theFirstLineFromDestinationFile = null;
+
+        try {
+            inputStreamScanner = new Scanner(myProject.getBaseFolder().getChild("a/b/c/" + destinationFileName).getVirtualFile().getContent().getStream());
+            theFirstLineFromDestinationFile = inputStreamScanner.nextLine();
+            // destination should contain original file's content
+            assertEquals(theFirstLineFromDestinationFile, originContent);
+        } catch (ForbiddenException | ServerException e) {
+            Assert.fail(e.getMessage());
+        } finally {
+            if (inputStreamScanner != null) {
+                inputStreamScanner.close();
+            }
+        }
+    }
+
+    @Test
     public void testMoveFolder() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
@@ -1124,6 +1348,70 @@ public class ProjectServiceTest {
         assertNotNull(myProject.getBaseFolder().getChild("a/c/test.txt"));
         Assert.assertNull(myProject.getBaseFolder().getChild("a/b/c/test.txt"));
         Assert.assertNull(myProject.getBaseFolder().getChild("a/b/c"));
+    }
+
+    @Test
+    public void testMoveFolderWithRename() throws Exception {
+        Project myProject = pm.getProject(workspace, "my_project");
+        myProject.getBaseFolder().createFolder("a/b/c");
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), "text/plain");
+
+        // new name for folder
+        final String renamedFolder = "renamedFolder";
+
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Content-Type", Arrays.asList("application/json"));
+
+        MoveOptions descriptor = DtoFactory.getInstance().createDto(MoveOptions.class);
+        descriptor.setName(renamedFolder);
+        descriptor.setOverWrite(false);
+
+        ContainerResponse response = launcher.service("POST",
+                String.format(
+                        "http://localhost:8080/api/project/%s/copy/my_project/a/b?to=/my_project/a/b/c",
+                        workspace),
+                "http://localhost:8080/api", headers, DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+        assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
+        assertEquals(response.getHttpHeaders().getFirst("Location"),
+                URI.create(String.format("http://localhost:8080/api/project/%s/children/my_project/a/b/c/%s", workspace, renamedFolder)));
+        assertNotNull(myProject.getBaseFolder().getChild(String.format("a/b/c/%s/test.txt", renamedFolder)));
+    }
+    
+    @Test
+    public void testMoveFolderWithRenameAndOverwrite() throws Exception {
+        Project myProject = pm.getProject(workspace, "my_project");
+        myProject.getBaseFolder().createFolder("a/b/c");
+
+        // File names
+        String originFileName = "test.txt";
+        String destinationFileName = "overwriteMe.txt";
+
+        // File contents
+        String originContent = "to be or not no be";
+        String overwritenContent = "that is the question";
+        
+        // new name for folder
+        final String renamedFolder = "renamedFolder";
+
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes(), "text/plain");
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwritenContent.getBytes(), "text/plain");
+
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Content-Type", Arrays.asList("application/json"));
+
+        MoveOptions descriptor = DtoFactory.getInstance().createDto(MoveOptions.class);
+        descriptor.setName(renamedFolder);
+        descriptor.setOverWrite(true);
+
+        ContainerResponse response = launcher.service("POST",
+                String.format(
+                        "http://localhost:8080/api/project/%s/copy/my_project/a/b?to=/my_project/a/b/c",
+                        workspace),
+                "http://localhost:8080/api", headers, DtoFactory.getInstance().toJson(descriptor).getBytes(), null);
+        assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
+        assertEquals(response.getHttpHeaders().getFirst("Location"),
+                URI.create(String.format("http://localhost:8080/api/project/%s/children/my_project/a/b/c/%s", workspace, renamedFolder)));
+        assertNotNull(myProject.getBaseFolder().getChild(String.format("a/b/c/%s/test.txt", renamedFolder)));
     }
 
     @Test

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/VirtualFile.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/VirtualFile.java
@@ -259,6 +259,23 @@ public interface VirtualFile extends Comparable<VirtualFile> {
     VirtualFile copyTo(VirtualFile parent) throws ForbiddenException, ConflictException, ServerException;
 
     /**
+     * Copies this file to the new parent.
+     *
+     * @param parent the new parent
+     * @param name a new name for the moved source, can be left {@code null} or empty {@code String} for current source name
+     * @param overWrite should the destination be overwritten, set to true to overwrite, false otherwise
+     * @return reference to copy
+     * @throws ForbiddenException if specified {@code parent} doesn't denote a
+     * folder or user doesn't have write permission to the specified
+     * {@code parent}
+     * @throws ConflictException if {@code parent} already contains item with
+     * the same name as this virtual file has
+     * @throws ServerException if other error occurs
+     * @see #isFolder()
+     */
+    VirtualFile copyTo(VirtualFile parent, String name, boolean overWrite) throws ForbiddenException, ConflictException, ServerException;
+
+    /**
      * Moves this file to the new parent.
      *
      * @param parent
@@ -280,6 +297,29 @@ public interface VirtualFile extends Comparable<VirtualFile> {
      */
     VirtualFile moveTo(VirtualFile parent, String lockToken) throws ForbiddenException, ConflictException, ServerException;
 
+    /**
+     * Moves this VirtualFile under new parent.
+     *
+     * @param parent parent to move
+     * @param name a new name for the moved source, can be left {@code null} or empty {@code String} for current source name
+     * @param overWrite should the destination be overwritten, set to true to overwrite, false otherwise
+     * @param lockToken lock token. This parameter is required if the file is
+     * locked
+     * @throws ForbiddenException if any of following conditions are met:
+     * <ul>
+     * <li>specified {@code parent} doesn't denote a folder</li>
+     * <li>user doesn't have write permission to the specified {@code parent} or
+     * this item</li>
+     * <li>this item is locked file and {@code lockToken} is {@code null} or
+     * doesn't match</li>
+     * </ul>
+     * @throws ConflictException if {@code parent} already contains item with
+     * the same name as this virtual file has
+     * @throws ServerException if other error occurs
+     * @see #isFolder()
+     */
+    VirtualFile moveTo(VirtualFile parent, String name, boolean overWrite, String lockToken) throws ForbiddenException, ConflictException, ServerException;
+    
     /**
      * Renames and (or) update media type of this VirtualFile.
      *

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/impl/memory/MemoryVirtualFile.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/impl/memory/MemoryVirtualFile.java
@@ -626,8 +626,17 @@ public class MemoryVirtualFile implements VirtualFile {
 
     @Override
     public VirtualFile copyTo(VirtualFile parent) throws ForbiddenException, ConflictException, ServerException {
+        return copyTo(parent, null, false);
+    }
+
+    @Override
+    public VirtualFile copyTo(VirtualFile parent, String name, boolean overWrite) throws ForbiddenException, ConflictException, ServerException {
         checkExist();
-        ((MemoryVirtualFile)parent).checkExist();
+        MemoryVirtualFile theParent = ((MemoryVirtualFile) parent);
+        theParent.checkExist();
+        // setting copy name accordingly
+        String nameToCopy = ("".equals(String.valueOf(name).trim()) || null == name) ? this.getName() : name;
+
         if (isRoot()) {
             throw new ServerException("Unable copy root folder. ");
         }
@@ -635,12 +644,13 @@ public class MemoryVirtualFile implements VirtualFile {
             throw new ForbiddenException(String.format("Unable create copy of '%s'. Item '%s' specified as parent is not a folder.",
                                                        getPath(), parent.getPath()));
         }
-        if (!((MemoryVirtualFile)parent).hasPermission(BasicPermissions.WRITE.value(), true)) {
+        if (!theParent.hasPermission(BasicPermissions.WRITE.value(), true)) {
             throw new ForbiddenException(String.format("Unable copy item '%s' to '%s'. Operation not permitted. ",
                                                        getPath(), parent.getPath()));
         }
-        VirtualFile copy = doCopy(parent);
-        mountPoint.putItem((MemoryVirtualFile)copy);
+
+        VirtualFile copy = doCopy(parent, nameToCopy, overWrite);
+        mountPoint.putItem((MemoryVirtualFile) copy);
         SearcherProvider searcherProvider = mountPoint.getSearcherProvider();
         if (searcherProvider != null) {
             try {
@@ -654,11 +664,22 @@ public class MemoryVirtualFile implements VirtualFile {
     }
 
     private VirtualFile doCopy(VirtualFile parent) throws ConflictException {
+        return doCopy(parent, null, false);
+    }
+
+    private VirtualFile doCopy(VirtualFile parent, String targetName, boolean overWrite) throws ConflictException {
+
+        String nameToCopy = ("".equals(String.valueOf(targetName).trim()) || null == targetName) ? this.getName() : targetName;
+
+        if (overWrite) {
+            doOverWrite(parent, targetName);
+        }
+
         VirtualFile virtualFile;
         if (isFile()) {
-            virtualFile = newFile((MemoryVirtualFile)parent, name, Arrays.copyOf(content, content.length), getMediaType());
+            virtualFile = newFile((MemoryVirtualFile) parent, nameToCopy, Arrays.copyOf(content, content.length), getMediaType());
         } else {
-            virtualFile = newFolder((MemoryVirtualFile)parent, name);
+            virtualFile = newFolder((MemoryVirtualFile) parent, nameToCopy);
             LazyIterator<VirtualFile> children = getChildren(VirtualFileFilter.ALL);
             while (children.hasNext()) {
                 ((MemoryVirtualFile)children.next()).doCopy(virtualFile);
@@ -678,11 +699,40 @@ public class MemoryVirtualFile implements VirtualFile {
         return virtualFile;
     }
 
+    private void doOverWrite(VirtualFile theParent, String targetName) {
+        try {
+            VirtualFile overWritenVirtualFile = theParent.getChild(targetName);
+            boolean targetExists = (null != overWritenVirtualFile);
+            /**
+             * if a VirtualFile with same target name already exists under new
+             * parent we need to determent if we should overwrite it or not.
+             */
+            if (targetExists) { // name collision
+                String deleteToken = null;
+                if (isFile()) {
+                    deleteToken = overWritenVirtualFile.lock(0);
+                }
+                overWritenVirtualFile.delete(deleteToken);
+            }
+        } catch (ForbiddenException | ServerException | ConflictException ex) {
+            LOG.error(ex.getMessage());
+        }
+    }
+
     @Override
     public VirtualFile moveTo(VirtualFile parent, final String lockToken) throws ConflictException, ForbiddenException, ServerException {
+        return moveTo(parent, null, false, lockToken);
+    }
+
+    @Override
+    public VirtualFile moveTo(VirtualFile parent, String newName, boolean overWrite, String lockToken) throws ForbiddenException, ConflictException, ServerException {
         checkExist();
         ((MemoryVirtualFile)parent).checkExist();
         boolean isFile = isFile();
+
+        // the name set to destination after moving
+        String destinationName = ("".equals(String.valueOf(newName).trim()) || null == newName) ? this.getName() : newName;
+
         if (isRoot()) {
             throw new ForbiddenException("Unable move root folder. ");
         }
@@ -741,11 +791,34 @@ public class MemoryVirtualFile implements VirtualFile {
                 throw new ForbiddenException(String.format("Unable move item %s. Item is locked. ", myPath));
             }
         }
-        if (!((MemoryVirtualFile)parent).addChild(this)) {
+
+        //====-overwriting-====
+        if (overWrite) {
+            doOverWrite(parent, destinationName);
+        }
+        //=====================
+
+        /**
+         * if newName was sent NOT null NOR empty String, then request was
+         * intended to change the VirtualFile name after moving
+         */
+        if (!("".equals(String.valueOf(newName).trim()) || null == newName)) {
+            if (((MemoryVirtualFile) parent).children.containsKey(destinationName)) {
+                throw new ConflictException(String.format("Item '%s' already exists. ", (parent.getPath() + '/' + destinationName)));
+            }
+            this.parent.children.remove(getName());
+            this.parent = (MemoryVirtualFile) parent;
+            this.parent.children.put(destinationName, this);
+            this.name = destinationName;
+        } else { // default behavior is to move with current name
+            if (!((MemoryVirtualFile) parent).addChild(this)) {
             throw new ConflictException(String.format("Item '%s' already exists. ", (parent.getPath() + '/' + name)));
         }
         this.parent.children.remove(getName());
-        this.parent = (MemoryVirtualFile)parent;
+            this.parent = (MemoryVirtualFile) parent;
+        }
+        // =======================
+
         SearcherProvider searcherProvider = mountPoint.getSearcherProvider();
         if (searcherProvider != null) {
             try {


### PR DESCRIPTION
Hello,

I created this pull request to address the issue described in my previous message to the mailing list
regarding the need to enable copy/move with rename operations to be conducted by a single REST call.

Summary of changes:

* Changes were made to both Copy and Move service methods in che-core-api-project: an additional argument was added, CopyOptions/MoveOptions respectively.
* The body of both services is now in the form of (application/json) { “name” : [the new name to set] , “overwrite” : [true/false] }
* The inclusion of this body is not mandatory so the API is not broken, it’s absence results in previous system behavior for copy/move services.
* Changes were made to org.eclipse.che.vfs.imple.fs project: To be able to pass along the new name and overwrite options, key methods and interfaces were both added and altered, keeping previous behavior intact.
* Tests were added accordingly

Please review and comment.

B.R
Ori Libhaber

