### PR TITLE
Adding environment variables support to Builder.class

### DIFF
--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/Builder.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/Builder.java
@@ -422,8 +422,13 @@ public abstract class Builder {
         }
     }
     
-    public Map<String, String> updateEnvironmentVariables(Map<String, String> env){
-    	return env;
+    private void updateEnvironment(final BuilderConfiguration configuration , ProcessBuilder processBuilder){
+    	Map<String, String> env = configuration.getEnv();
+    	// Check if the build process Environment should be updated from BuilderConfiguration or use current process environment
+    	if(!configuration.getEnv().isEmpty()){
+    		processBuilder.environment().clear();
+    		processBuilder.environment().putAll(env);
+    	}
     }
 
     protected Callable<Boolean> createTaskFor(final CommandLine commandLine,
@@ -446,8 +451,7 @@ public abstract class Builder {
                 try {
                     ProcessBuilder processBuilder = new ProcessBuilder().command(commandLine.toShellCommand()).directory(
                             configuration.getWorkDir()).redirectErrorStream(true);
-                    Map<String, String> env = processBuilder.environment();
-                    updateEnvironmentVariables(env);
+                    updateEnvironment(configuration,processBuilder);
                     
                     Process process = processBuilder.start();
 

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/Builder.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/Builder.java
@@ -422,8 +422,8 @@ public abstract class Builder {
         }
     }
     
-    public HashMap<String, String> getEnvironmentVariables(){
-    	return new HashMap<String, String>();
+    public Map<String, String> updateEnvironmentVariables(Map<String, String> env){
+    	return env;
     }
 
     protected Callable<Boolean> createTaskFor(final CommandLine commandLine,
@@ -447,7 +447,7 @@ public abstract class Builder {
                     ProcessBuilder processBuilder = new ProcessBuilder().command(commandLine.toShellCommand()).directory(
                             configuration.getWorkDir()).redirectErrorStream(true);
                     Map<String, String> env = processBuilder.environment();
-                    env.putAll(getEnvironmentVariables());
+                    updateEnvironmentVariables(env);
                     
                     Process process = processBuilder.start();
 

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/Builder.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/Builder.java
@@ -29,6 +29,7 @@ import org.eclipse.che.api.core.util.StreamPump;
 import org.eclipse.che.api.core.util.Watchdog;
 import org.eclipse.che.commons.lang.IoUtil;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import org.slf4j.Logger;
@@ -36,8 +37,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -418,6 +421,10 @@ public abstract class Builder {
             throw new BuilderException(e);
         }
     }
+    
+    public HashMap<String, String> getEnvironmentVariables(){
+    	return new HashMap<String, String>();
+    }
 
     protected Callable<Boolean> createTaskFor(final CommandLine commandLine,
                                               final BuildLogger logger,
@@ -439,6 +446,9 @@ public abstract class Builder {
                 try {
                     ProcessBuilder processBuilder = new ProcessBuilder().command(commandLine.toShellCommand()).directory(
                             configuration.getWorkDir()).redirectErrorStream(true);
+                    Map<String, String> env = processBuilder.environment();
+                    env.putAll(getEnvironmentVariables());
+                    
                     Process process = processBuilder.start();
 
                     if (timeout > 0) {

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/BuilderConfiguration.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/BuilderConfiguration.java
@@ -14,6 +14,7 @@ import org.eclipse.che.api.builder.dto.BaseBuilderRequest;
 import org.eclipse.che.dto.server.DtoFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,12 +29,14 @@ public class BuilderConfiguration {
     private final java.io.File       workDir;
     private final BuilderTaskType    taskType;
     private final BaseBuilderRequest request;
+    private Map<String,String> env; 
 
     public BuilderConfiguration(java.io.File buildDir, java.io.File workDir, BuilderTaskType taskType, BaseBuilderRequest request) {
         this.buildDir = buildDir;
         this.workDir = workDir;
         this.taskType = taskType;
         this.request = request;
+        this.env = new HashMap<String, String>();
     }
 
     public java.io.File getWorkDir() {
@@ -68,4 +71,12 @@ public class BuilderConfiguration {
                ", request=" + request +
                '}';
     }
+
+	public Map<String, String> getEnv() {
+		return env;
+	}
+
+	public void setEnv(Map<String, String> env) {
+		this.env = env;
+	}
 }


### PR DESCRIPTION
Hi,
I am developing Che Builder that should be able to execute build requests while the execution relies on environment variables.
i.e. the commands that are going to be executed by the builder read some information from the  environment variables.
Hence the environment variables should be updated before the build execution dynamically for every build. 

Following current implementation the information could be passed to the builder using the BuildRequest, but as I see it, update of the environment variables before the build execution is missing.
So I'm proposing  to add  the following method to the Builder.class 

public Map<String, String> getEnvironmentVariables (){
                return new HashMap<String, String>();
}

Any implementing builder class can override this method , by default it will be empty . 
so that in Line 440 in Builder.class ,the code could be changed to the following :

ProcessBuilder processBuilder = new ProcessBuilder().command(commandLine.toShellCommand()).directory(
                            configuration.getWorkDir()).redirectErrorStream(true); 

HashMap<String, String> env = processBuilder.environment();
env. putAll(getEnvironmentVariables());

Process process = processBuilder.start();



This way the command executed by the builder will be able to use the environment variables passed in to the builder using the BuildRequest.

Thanks
Dany.