### PR TITLE
Support DTOs with properties typed 'any'

### DIFF
--- a/platform-api/che-core-api-dto/pom.xml
+++ b/platform-api/che-core-api-dto/pom.xml
@@ -52,6 +52,18 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+            <version>${com.google.code.guice.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-gwt</artifactId>
+            <version>${che.core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>${org.testng.version}</version>
@@ -111,7 +123,7 @@
                 <artifactId>exec-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>generate-test-dto</id>
+                        <id>generate-test-server-dto</id>
                         <phase>process-test-sources</phase>
                         <goals>
                             <goal>java</goal>
@@ -122,6 +134,23 @@
                                 <argument>--dto_packages=org.eclipse.che.dto</argument>
                                 <argument>--gen_file_name=${generated.test.sources.directory}/org/eclipse/che/dto/DtoServerImpls.java</argument>
                                 <argument>--impl=server</argument>
+                                <argument>--package_base=${generated.test.sources.directory}/</argument>
+                            </arguments>
+                            <classpathScope>test</classpathScope>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-test-client-dto</id>
+                        <phase>process-test-sources</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>org.eclipse.che.dto.generator.DtoGenerator</mainClass>
+                            <arguments>
+                                <argument>--dto_packages=org.eclipse.che.dto</argument>
+                                <argument>--gen_file_name=${generated.test.sources.directory}/org/eclipse/che/dto/DtoClientImpls.java</argument>
+                                <argument>--impl=client</argument>
                                 <argument>--package_base=${generated.test.sources.directory}/</argument>
                             </arguments>
                             <classpathScope>test</classpathScope>

--- a/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImpl.java
+++ b/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImpl.java
@@ -17,6 +17,7 @@ import org.eclipse.che.dto.shared.SerializationIndex;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.gson.stream.JsonWriter;
 
@@ -33,6 +34,8 @@ import java.util.Map;
 
 /** Abstract base class for the source generating template for a single DTO. */
 abstract class DtoImpl {
+    protected static final String COPY_JSONS_PARAM = "copyJsons";
+    
     private final Class<?>     dtoInterface;
     private final DtoTemplate  enclosingTemplate;
     private final boolean      compactJson;
@@ -252,6 +255,10 @@ abstract class DtoImpl {
     /** Tests whether or not a given return type is a java.util.Map. */
     public static boolean isMap(Class<?> returnType) {
         return returnType.equals(Map.class);
+    }
+
+    public static boolean isAny(Class<?> returnType) {
+        return returnType.equals(Object.class);
     }
 
     /**

--- a/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImplServerTemplate.java
+++ b/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImplServerTemplate.java
@@ -280,6 +280,10 @@ public class DtoImplServerTemplate extends DtoImpl {
 
     private void emitSerializer(List<Method> getters, StringBuilder builder) {
         builder.append("    public JsonElement toJsonElement() {\n");
+        // The default toJsonElement() returns JSONs for unsafe use thus 'any' properties should be copied
+        builder.append("      return toJsonElementInt(true);\n");
+        builder.append("    }\n");
+        builder.append("    public JsonElement toJsonElementInt(boolean ").append(COPY_JSONS_PARAM).append(") {\n");
         if (isCompactJson()) {
             builder.append("      JsonArray result = new JsonArray();\n");
             for (Method method : getters) {
@@ -296,7 +300,8 @@ public class DtoImplServerTemplate extends DtoImpl {
         builder.append("\n");
         builder.append("    @Override\n");
         builder.append("    public String toJson() {\n");
-        builder.append("      return gson.toJson(toJsonElement());\n");
+        // The default toJson() creates its own JSON for internal printing, thus keeping JSONs values is safe
+        builder.append("      return gson.toJson(toJsonElementInt(false));\n");
         builder.append("    }\n");
         builder.append("\n");
         builder.append("    @Override\n");
@@ -391,7 +396,7 @@ public class DtoImplServerTemplate extends DtoImpl {
         } else if (getEnclosingTemplate().isDtoInterface(rawClass)) {
             builder.append(i).append("JsonElement ").append(outVar).append(" = ").append(depth == 0 ? "this." + inVar : inVar).append(
                     " == null ? JsonNull.INSTANCE : ((").append(getImplNameForDto((Class<?>)expandedTypes.get(depth))).append(")")
-                   .append(depth == 0 ? "this." + inVar : inVar).append(").toJsonElement();\n");
+                   .append(depth == 0 ? "this." + inVar : inVar).append(").toJsonElementInt(").append(COPY_JSONS_PARAM).append(");\n");
         } else if (rawClass.equals(String.class)) {
             builder.append(i).append("JsonElement ").append(outVar).append(" = (").append(depth == 0 ? "this." + inVar : inVar).append(
                     " == null) ? JsonNull.INSTANCE : new JsonPrimitive(").append(depth == 0 ? "this." + inVar : inVar).append(");\n");
@@ -413,12 +418,18 @@ public class DtoImplServerTemplate extends DtoImpl {
                    || rawClass == Byte.class) {
             builder.append(i).append("JsonElement ").append(outVar).append(depth == 0 ? " = this." + inVar : inVar).append(
                     " == null ? JsonNull.INSTANCE : new JsonPrimitive(").append(depth == 0 ? "this." + inVar : inVar).append(");\n");
+        } else if (isAny(rawClass)) {
+            // TODO JsonElement.deepCopy() is package-protected, JSONs are serialized to strings then parsed for copying them
+            // outVar = inVar == null ? JsonNull.INSTNACE : (copyJsons ? new JsonParser().parse(inVar) : inVar);
+            builder.append(i).append("JsonElement ").append(outVar).append(depth == 0 ? " = this." + inVar : inVar)
+                    .append(" == null || !(").append(inVar).append(" instanceof JsonElement) ? JsonNull.INSTANCE : (");
+            appendCopyJsonExpression(inVar, builder).append(");\n");
         } else {
             final Class<?> dtoImplementation = getEnclosingTemplate().getDtoImplementation(rawClass);
             if (dtoImplementation != null) {
                 builder.append(i).append("JsonElement ").append(outVar).append(" = ").append(depth == 0 ? "this." + inVar : inVar).append(
                         " == null ? JsonNull.INSTANCE : ((").append(dtoImplementation.getCanonicalName()).append(")")
-                       .append(depth == 0 ? "this." + inVar : inVar).append(").toJsonElement();\n");
+                       .append(depth == 0 ? "this." + inVar : inVar).append(").toJsonElementInt(").append(COPY_JSONS_PARAM).append(");\n");
             } else {
                 throw new IllegalArgumentException("Unable to generate server implementation for DTO interface " +
                                                    getDtoInterface().getCanonicalName() + ". Type " + rawClass +
@@ -441,7 +452,11 @@ public class DtoImplServerTemplate extends DtoImpl {
 
     /** Generates a static factory method that creates a new instance based on a JsonElement. */
     private void emitDeserializer(List<Method> getters, StringBuilder builder) {
+        // The default fromJsonElement(json) works in unsafe mode and clones the JSON's for 'any' properties
         builder.append("    public static ").append(getImplClassName()).append(" fromJsonElement(JsonElement jsonElem) {\n");
+        builder.append("      return fromJsonElement(jsonElem, true);\n");
+        builder.append("    }\n");
+        builder.append("    public static ").append(getImplClassName()).append(" fromJsonElement(JsonElement jsonElem, boolean ").append(COPY_JSONS_PARAM).append(") {\n");
         builder.append("      if (jsonElem == null || jsonElem.isJsonNull()) {\n");
         builder.append("        return null;\n");
         builder.append("      }\n\n");
@@ -468,7 +483,8 @@ public class DtoImplServerTemplate extends DtoImpl {
         builder.append("      if (jsonString == null) {\n");
         builder.append("        return null;\n");
         builder.append("      }\n\n");
-        builder.append("      return fromJsonElement(new JsonParser().parse(jsonString));\n");
+        // The default fromJsonElement(json) creates its own JSON thus keeping parts of its as value is OK
+        builder.append("      return fromJsonElement(new JsonParser().parse(jsonString), false);\n");
         builder.append("    }\n\n");
     }
 
@@ -562,18 +578,23 @@ public class DtoImplServerTemplate extends DtoImpl {
         } else if (getEnclosingTemplate().isDtoInterface(rawClass)) {
             String className = getImplName(rawClass, false);
             builder.append(i).append(className).append(" ").append(outVar).append(" = ").append(getImplNameForDto(rawClass))
-                   .append(".fromJsonElement(").append(inVar).append(");\n");
+                   .append(".fromJsonElement(").append(inVar).append(", ").append(COPY_JSONS_PARAM).append(");\n");
         } else if (rawClass.isPrimitive()) {
             String primitiveName = rawClass.getSimpleName();
             String primitiveNameCap = primitiveName.substring(0, 1).toUpperCase() + primitiveName.substring(1);
             builder.append(i).append(primitiveName).append(" ").append(outVar).append(" = ").append(inVar).append(
                     ".getAs").append(primitiveNameCap).append("();\n");
+        } else if (isAny(rawClass)) {
+            // TODO JsonElement.deepCopy() is package-protected, JSONs are serialized to strings then parsed for copying them
+            // outVar = copyJsons ? new JsonParser().parse(inVar) : inVar;
+            builder.append(i).append("JsonElement ").append(outVar).append(" = ");
+            appendCopyJsonExpression(inVar, builder).append(";\n");
         } else {
             final Class<?> dtoImplementation = getEnclosingTemplate().getDtoImplementation(rawClass);
             if (dtoImplementation != null) {
                 String className = getImplName(rawClass, false);
                 builder.append(i).append(className).append(" ").append(outVar).append(" = ")
-                       .append(dtoImplementation.getCanonicalName()).append(".fromJsonElement(").append(inVar).append(");\n");
+                       .append(dtoImplementation.getCanonicalName()).append(".fromJsonElement(").append(inVar).append(", ").append(COPY_JSONS_PARAM).append(");\n");
             } else {
                 // Use gson to handle all other types.
                 String rawClassName = rawClass.getName().replace('$', '.');
@@ -581,6 +602,20 @@ public class DtoImplServerTemplate extends DtoImpl {
                         inVar).append(", ").append(rawClassName).append(".class);\n");
             }
         }
+    }
+    
+    /**
+     * Append the expression that clones the given JsonElement variable into a new value. If the copyJons run-time
+     * parameter is set to false, then the expression won't perform a clone but instead will reuse the variable by
+     * reference.
+     */
+    private static StringBuilder appendCopyJsonExpression(String inVar, StringBuilder builder) {
+        builder.append(COPY_JSONS_PARAM).append(" ? ");
+        appendNaiveCopyJsonExpression(inVar, builder).append(" : (JsonElement)(").append(inVar).append(")");
+        return builder;
+    }
+    private static StringBuilder appendNaiveCopyJsonExpression(String inValue, StringBuilder builder) {
+        return builder.append("new JsonParser().parse((").append(inValue).append(").toString())");
     }
 
     private void emitPreamble(Class<?> dtoInterface, StringBuilder builder) {
@@ -754,6 +789,9 @@ public class DtoImplServerTemplate extends DtoImpl {
             emitDeepCopyCollections(expandedTypes, depth, builder, fieldNameIn, fieldNameOut, i);
             builder.append(i).append("  ").append("this.").append(fieldName).append(" = ").append(fieldNameOut).append(";\n");
             builder.append(i).append("}\n");
+        } else if (isAny(rawClass)) {
+            builder.append(i).append("this.").append(fieldName).append(" = ");
+            appendNaiveCopyJsonExpression(origin + "." + getterName + "()", builder).append(";\n");
         } else if (getEnclosingTemplate().isDtoInterface(rawClass)) {
             builder.append(i).append(rawTypeName).append(" ").append(fieldNameIn).append(" = ").append(origin).append(".")
                    .append(getterName).append("();\n");

--- a/platform-api/che-core-api-dto/src/test/java/org/eclipse/che/dto/ServerDtoTest.java
+++ b/platform-api/che-core-api-dto/src/test/java/org/eclipse/che/dto/ServerDtoTest.java
@@ -11,11 +11,14 @@
 package org.eclipse.che.dto;
 
 import org.eclipse.che.dto.definitions.ComplicatedDto;
+import org.eclipse.che.dto.definitions.DtoWithAny;
 import org.eclipse.che.dto.definitions.DtoWithDelegate;
 import org.eclipse.che.dto.definitions.DtoWithFieldNames;
 import org.eclipse.che.dto.definitions.SimpleDto;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
@@ -108,6 +111,32 @@ public class ServerDtoTest {
 
         Assert.assertEquals(dto.getTheName(), fooString);
         Assert.assertEquals(dto.getTheDefault(), _default);
+    }
+
+    @Test
+    public void testSerializerWithAny() throws Exception {
+        DtoWithAny dto = dtoFactory.createDto(DtoWithAny.class).withStuff(createTestValueForAny());
+        final String json = dtoFactory.toJson(dto);
+
+        JsonObject jsonObject = new JsonParser().parse(json).getAsJsonObject();
+        Assert.assertEquals(jsonObject.get("stuff"), createTestValueForAny());
+    }
+
+    @Test
+    public void testDeerializerWithAny() throws Exception {
+        final JsonElement stuff = createTestValueForAny();
+
+        JsonObject json = new JsonObject();
+        json.add("stuff", stuff);
+
+        DtoWithAny dto = dtoFactory.createDtoFromJson(json.toString(), DtoWithAny.class);
+
+        Assert.assertEquals(dto.getStuff(), createTestValueForAny());
+    }
+
+    /** Intentionally call several times to ensure non-reference equality */
+    private static JsonElement createTestValueForAny() {
+        return new JsonParser().parse("{a:100,b:{c:'blah',d:null}}");
     }
 
     @Test

--- a/platform-api/che-core-api-dto/src/test/java/org/eclipse/che/dto/definitions/DtoWithAny.java
+++ b/platform-api/che-core-api-dto/src/test/java/org/eclipse/che/dto/definitions/DtoWithAny.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.dto.definitions;
+
+import org.eclipse.che.dto.shared.DTO;
+
+/**
+ * Makes use of the 'any' (JsonElement) property type feature.
+ * 
+ * @author Tareq Sharafy (tareq.sharafy@sap.com)
+ */
+@DTO
+public interface DtoWithAny {
+    int getId();
+
+    Object getStuff();
+
+    void setStuff(Object stuff);
+
+    DtoWithAny withStuff(Object stuff);
+}


### PR DESCRIPTION
1- Serialzie and de-serialize JsonElement properties as raw JSONs
2- Deep-copy them in the generated copy constructors
3- Avoid redundant copying in fromJsonString() and toJson() cases

Signed-off-by: Tareq Sharafy <tareq.sharafy@sap.com>