### PR TITLE
Allow getting a filtered list of tasks right from BuildQueue

### DIFF
--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuildQueue.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuildQueue.java
@@ -533,7 +533,37 @@ public class BuildQueue {
      * Return tasks of this queue.
      */
     public List<BuildQueueTask> getTasks() {
-        return new ArrayList<>(tasks.values());
+        return getTasks(null, null, null);
+    }
+
+    /**
+     * Get a list of the build tasks that match the given criteria.
+     * 
+     * @param workspaceId
+     *            The ID of the workspace that the build was invoked inside of.
+     * @param projectPath
+     *            The path of the project that the tasks was invoked on. Ignored if the workspace ID is null.
+     * @param user
+     *            The User that invoked the build task.
+     * @return A list of build tasks.
+     */
+    public List<BuildQueueTask> getTasks(String workspaceId, String projectPath, User user) {
+        // Normalize the build path
+        if (projectPath != null && !projectPath.startsWith("/")) {
+            projectPath = '/' + projectPath;
+        }
+        final List<BuildQueueTask> builds = new LinkedList<>();
+        for (BuildQueueTask task : tasks.values()) {
+            final BaseBuilderRequest request = task.getRequest();
+            // If a workspace is specified, match it. If a project is specified, match it only if a workspace is
+            // specified too. Match the user name independently from the workspace and space.
+            if ((workspaceId == null || (request.getWorkspace().equals(workspaceId) && (projectPath == null || request
+                    .getProject().equals(projectPath))))
+                    && (user == null || request.getUserId().equals(user.getName()))) {
+                builds.add(task);
+            }
+        }
+        return builds;
     }
 
     public BuildQueueTask getTask(Long id) throws NotFoundException {

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuilderService.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuilderService.java
@@ -132,29 +132,20 @@ public class BuilderService extends Service {
                                             @ApiParam(value = "Project name", required = false)
                                             @Required @Description("project name")
                                             @QueryParam("project") String project) {
-        // handle project name
-        if (project != null && !project.startsWith("/")) {
-            project = '/' + project;
-        }
         final List<BuildTaskDescriptor> builds = new LinkedList<>();
         final User user = EnvironmentContext.getCurrent().getUser();
         if (user != null) {
-            final String userName = user.getName();
-            for (BuildQueueTask task : buildQueue.getTasks()) {
-                final BaseBuilderRequest request = task.getRequest();
-                if (request.getWorkspace().equals(workspace)
-                    && request.getProject().equals(project)
-                    && request.getUserId().equals(userName)) {
-                    try {
-                        builds.add(task.getDescriptor());
-                    } catch (NotFoundException e) {
-                        // NotFoundException is possible and should not be treated as error in this case. Typically it occurs if slave
-                        // builder already cleaned up the task by its internal cleaner but BuildQueue doesn't re-check yet slave builder and
-                        // doesn't have actual info about state of slave builder.
-                    } catch (BuilderException e) {
-                        // Decide ignore such error to be able show maximum available info.
-                        LOG.error(e.getMessage(), e);
-                    }
+            List<BuildQueueTask> tasks = buildQueue.getTasks(workspace, project, user);
+            for (BuildQueueTask task : tasks) {
+                try {
+                    builds.add(task.getDescriptor());
+                } catch (NotFoundException e) {
+                    // NotFoundException is possible and should not be treated as error in this case. Typically it occurs if slave
+                    // builder already cleaned up the task by its internal cleaner but BuildQueue doesn't re-check yet slave builder and
+                    // doesn't have actual info about state of slave builder.
+                } catch (BuilderException e) {
+                    // Decide ignore such error to be able show maximum available info.
+                    LOG.error(e.getMessage(), e);
                 }
             }
         }


### PR DESCRIPTION
I propose pushing the main functionality of BuilderService.builds() (/apit/builder/{ws}/builds) down to BuildQueue so that other areas in the server can benefit from this right from java code without having to interact with services and REST calls.