### PR TITLE
Use HTTP constants instead of hard-coded strings

### DIFF
--- a/che-core-vfs-impl/src/main/java/org/eclipse/che/vfs/impl/fs/FSMountPoint.java
+++ b/che-core-vfs-impl/src/main/java/org/eclipse/che/vfs/impl/fs/FSMountPoint.java
@@ -49,6 +49,7 @@ import org.eclipse.che.commons.lang.Strings;
 import org.eclipse.che.commons.lang.cache.Cache;
 import org.eclipse.che.commons.lang.cache.LoadingValueSLRUCache;
 import org.eclipse.che.commons.lang.cache.SynchronizedCache;
+import org.eclipse.che.commons.lang.ws.rs.ExtMediaType;
 import org.eclipse.che.dto.server.DtoFactory;
 
 import com.google.common.annotations.Beta;
@@ -1137,7 +1138,7 @@ public class FSMountPoint implements MountPoint {
             }
             closeQuietly(zipOut);
             final String name = virtualFile.getName() + ".zip";
-            return new ContentStream(name, new DeleteOnCloseFileInputStream(zipFile), "application/zip", zipFile.length(), new Date());
+            return new ContentStream(name, new DeleteOnCloseFileInputStream(zipFile), ExtMediaType.APPLICATION_ZIP, zipFile.length(), new Date());
         } catch (IOException | RuntimeException ioe) {
             if (zipFile != null) {
                 zipFile.delete();

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/ACLTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/ACLTest.java
@@ -14,8 +14,8 @@ import org.eclipse.che.api.vfs.shared.dto.AccessControlEntry;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.user.UserImpl;
-
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -31,6 +31,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 
 import static org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
 
@@ -72,7 +76,7 @@ public class ACLTest extends LocalFileSystemTest {
     public void testGetACL() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "acl/" + fileId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         @SuppressWarnings("unchecked")
@@ -89,7 +93,7 @@ public class ACLTest extends LocalFileSystemTest {
         // Request must fail since we have not permissions any more to read ACL.
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "acl/" + fileId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
     }
@@ -100,8 +104,8 @@ public class ACLTest extends LocalFileSystemTest {
         // Give write permission for john. No changes for other users.
         String acl = "[{\"principal\":{\"name\":\"john\",\"type\":\"USER\"},\"permissions\":[\"read\", \"write\"]}]";
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, h, acl.getBytes(), null);
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, h, acl.getBytes(), null);
         assertEquals(204, response.getStatus());
 
         Principal principal = DtoFactory.getInstance().createDto(Principal.class).withName("john").withType(Principal.Type.USER);
@@ -112,7 +116,7 @@ public class ACLTest extends LocalFileSystemTest {
 
         // check API
         assertEquals(permissions,
-                     toMap((List<AccessControlEntry>)launcher.service("GET", requestPath, BASE_URI, null, null, null).getEntity()));
+                     toMap((List<AccessControlEntry>)launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, null).getEntity()));
     }
 
     @SuppressWarnings("unchecked")
@@ -121,8 +125,8 @@ public class ACLTest extends LocalFileSystemTest {
         // Give 'all' rights to admin and take away all rights for other users.
         String acl = "[{\"principal\":{\"name\":\"admin\",\"type\":\"USER\"},\"permissions\":[\"all\"]}]";
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, h, acl.getBytes(), null);
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, h, acl.getBytes(), null);
         assertEquals(204, response.getStatus());
 
         Principal user1 = DtoFactory.getInstance().createDto(Principal.class).withName("andrew").withType(Principal.Type.USER);
@@ -136,7 +140,7 @@ public class ACLTest extends LocalFileSystemTest {
 
         // check API
         assertEquals(permissions,
-                     toMap((List<AccessControlEntry>)launcher.service("GET", requestPath, BASE_URI, null, null, null).getEntity()));
+                     toMap((List<AccessControlEntry>)launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, null).getEntity()));
     }
 
     @SuppressWarnings("unchecked")
@@ -145,8 +149,8 @@ public class ACLTest extends LocalFileSystemTest {
         String requestPath = SERVICE_URI + "acl/" + fileId + '?' + "override=" + true;
         String acl = "[]";
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, h, acl.getBytes(), null);
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, h, acl.getBytes(), null);
         assertEquals(204, response.getStatus());
 
         // check backend
@@ -154,7 +158,7 @@ public class ACLTest extends LocalFileSystemTest {
 
         // check API
         List<AccessControlEntry> updatedAcl =
-                (List<AccessControlEntry>)launcher.service("GET", requestPath, BASE_URI, null, null, null).getEntity();
+                (List<AccessControlEntry>)launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, null).getEntity();
         // TODO: test files because we always provide "default ACL" at the moment.
         // It is temporary solution before we get client side tool to manage ACL.
         // assertTrue(updatedAcl.isEmpty());
@@ -171,11 +175,11 @@ public class ACLTest extends LocalFileSystemTest {
         // Give write permission for john. No changes for other users.
         String acl = "[{\"principal\":{\"name\":\"admin\",\"type\":\"USER\"},\"permissions\":[\"read\", \"write\"]}]";
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
         // File is protected and default principal 'andrew' has not update_acl permission.
         // Replace default principal by principal who has write permission.
         EnvironmentContext.getCurrent().setUser(new UserImpl("andrew", "andrew", null, Arrays.asList("workspace/developer"), false));
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, h, acl.getBytes(), null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, h, acl.getBytes(), null);
         assertEquals(204, response.getStatus());
 
         principal = DtoFactory.getInstance().createDto(Principal.class).withName("admin").withType(Principal.Type.USER);
@@ -186,7 +190,7 @@ public class ACLTest extends LocalFileSystemTest {
 
         // check API
         assertEquals(permissions,
-                     toMap((List<AccessControlEntry>)launcher.service("GET", requestPath, BASE_URI, null, null, null).getEntity()));
+                     toMap((List<AccessControlEntry>)launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, null).getEntity()));
     }
 
     @SuppressWarnings("unchecked")
@@ -198,12 +202,12 @@ public class ACLTest extends LocalFileSystemTest {
 
         String acl = "[{\"principal\":{\"name\":\"admin\",\"type\":\"USER\"},\"permissions\":[\"all\"]}]";
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         // Request must fail since we have not permissions any more to update ACL.
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "acl/" + fileId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, h, acl.getBytes(), writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, h, acl.getBytes(), writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
 
@@ -214,7 +218,7 @@ public class ACLTest extends LocalFileSystemTest {
 
         // check API
         assertEquals(permissions,
-                     toMap((List<AccessControlEntry>)launcher.service("GET", requestPath, BASE_URI, null, null, null).getEntity()));
+                     toMap((List<AccessControlEntry>)launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, null).getEntity()));
     }
 
     @SuppressWarnings("unchecked")
@@ -223,10 +227,10 @@ public class ACLTest extends LocalFileSystemTest {
                      "{\"principal\":{\"name\":\"any\",\"type\":\"USER\"},\"permissions\":null}," +
                      "{\"principal\":{\"name\":\"admin\",\"type\":\"USER\"},\"permissions\":[\"read\"]}]";
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         String requestPath = SERVICE_URI + "acl/" + lockedFileId + '?' + "lockToken=" + lockToken + "&override=" + true;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, h, acl.getBytes(), null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, h, acl.getBytes(), null);
 
         assertEquals(204, response.getStatus());
 
@@ -242,7 +246,7 @@ public class ACLTest extends LocalFileSystemTest {
 
         // check API
         assertEquals(thisTestAccessList,
-                     toMap((List<AccessControlEntry>)launcher.service("GET", requestPath, BASE_URI, null, null, null).getEntity()));
+                     toMap((List<AccessControlEntry>)launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, null).getEntity()));
     }
 
     @SuppressWarnings("unchecked")
@@ -251,16 +255,16 @@ public class ACLTest extends LocalFileSystemTest {
                      "{\"principal\":{\"name\":\"any\",\"type\":\"USER\"},\"permissions\":null}," +
                      "{\"principal\":{\"name\":\"admin\",\"type\":\"USER\"},\"permissions\":[\"read\"]}]";
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         String requestPath = SERVICE_URI + "acl/" + lockedFileId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, h, acl.getBytes(), null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, h, acl.getBytes(), null);
 
         assertEquals(403, response.getStatus());
 
         // ACL must not be updated.
         List<AccessControlEntry> updatedAcl =
-                (List<AccessControlEntry>)launcher.service("GET", requestPath, BASE_URI, null, null, null).getEntity();
+                (List<AccessControlEntry>)launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, null).getEntity();
         assertTrue(updatedAcl.isEmpty()); // TODO
     }
 

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/ChildrenTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/ChildrenTest.java
@@ -17,6 +17,7 @@ import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.user.UserImpl;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -30,6 +31,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import javax.ws.rs.HttpMethod;
 
 import static org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
 
@@ -81,7 +84,7 @@ public class ChildrenTest extends LocalFileSystemTest {
     public void testGetChildren() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "children/" + folderId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         log.info(new String(writer.getBody()));
         @SuppressWarnings("unchecked")
@@ -102,7 +105,7 @@ public class ChildrenTest extends LocalFileSystemTest {
     public void testGetChildren_File() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "children/" + fileId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -113,7 +116,7 @@ public class ChildrenTest extends LocalFileSystemTest {
         // Replace default principal by principal who has read permission.
         EnvironmentContext.getCurrent().setUser(new UserImpl("andrew", "andrew", null, Arrays.asList("workspace/developer"), false));
         // ---
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         log.info(new String(writer.getBody()));
         @SuppressWarnings("unchecked")
@@ -125,7 +128,7 @@ public class ChildrenTest extends LocalFileSystemTest {
     public void testGetChildrenNoPermissions() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "children/" + protectedFolderId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -142,7 +145,7 @@ public class ChildrenTest extends LocalFileSystemTest {
 
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "children/" + folderId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         log.info(new String(writer.getBody()));
         @SuppressWarnings("unchecked")
@@ -163,7 +166,7 @@ public class ChildrenTest extends LocalFileSystemTest {
     public void testGetChildrenPagingSkipCount() throws Exception {
         // Get all children.
         String requestPath = SERVICE_URI + "children/" + folderId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         @SuppressWarnings("unchecked")
         ItemList children = (ItemList)response.getEntity();
@@ -179,13 +182,13 @@ public class ChildrenTest extends LocalFileSystemTest {
 
         // Skip first item in result.
         requestPath = SERVICE_URI + "children/" + folderId + '?' + "skipCount=" + 1;
-        checkPage(requestPath, "GET", Item.class.getMethod("getName"), all);
+        checkPage(requestPath, HttpMethod.GET, Item.class.getMethod("getName"), all);
     }
 
     public void testGetChildrenPagingMaxItems() throws Exception {
         // Get all children.
         String requestPath = SERVICE_URI + "children/" + folderId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         @SuppressWarnings("unchecked")
         ItemList children = (ItemList)response.getEntity();
@@ -198,14 +201,14 @@ public class ChildrenTest extends LocalFileSystemTest {
 
         // Exclude last item from result.
         requestPath = SERVICE_URI + "children/" + folderId + '?' + "maxItems=" + 3;
-        checkPage(requestPath, "GET", Item.class.getMethod("getName"), all);
+        checkPage(requestPath, HttpMethod.GET, Item.class.getMethod("getName"), all);
     }
 
     public void testGetChildrenNoPropertyFilter() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         // Get children without filter.
         String requestPath = SERVICE_URI + "children/" + folderId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         @SuppressWarnings("unchecked")
@@ -225,7 +228,7 @@ public class ChildrenTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         // Get children and apply filter for properties.
         String requestPath = SERVICE_URI + "children/" + folderId + '?' + "propertyFilter=" + e1.getKey();
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         @SuppressWarnings("unchecked")
@@ -240,7 +243,7 @@ public class ChildrenTest extends LocalFileSystemTest {
     public void testGetChildrenTypeFilter() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "children/" + folderId + '?' + "itemType=" + "folder";
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         @SuppressWarnings("unchecked")

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/ContentTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/ContentTest.java
@@ -12,12 +12,16 @@ package org.eclipse.che.vfs.impl.fs;
 
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
 import org.everrest.core.tools.ByteArrayContainerResponseWriter;
 
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -67,29 +71,29 @@ public class ContentTest extends LocalFileSystemTest {
     public void testGetContent() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "content/" + fileId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         assertTrue(Arrays.equals(content, writer.getBody()));
-        assertEquals("text/plain", writer.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+        assertEquals(MediaType.TEXT_PLAIN, writer.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
     }
 
     public void testDownloadFile() throws Exception {
-        // Expect the same as 'get content' plus header "Content-Disposition".
+        // Expect the same as 'get content' plus header HttpHeaders.CONTENT_DISPOSITION.
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "downloadfile/" + fileId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         assertTrue(Arrays.equals(content, writer.getBody()));
-        assertEquals("text/plain", writer.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+        assertEquals(MediaType.TEXT_PLAIN, writer.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
         assertEquals(String.format("attachment; filename=\"%s\"", "ContentTest_File.txt"),
-                     writer.getHeaders().getFirst("Content-Disposition"));
+                     writer.getHeaders().getFirst(HttpHeaders.CONTENT_DISPOSITION));
     }
 
     public void testGetContentFolder() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "content/" + folderId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
     }
@@ -97,7 +101,7 @@ public class ContentTest extends LocalFileSystemTest {
     public void testGetContentNoPermissions() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "content/" + protectedFileId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
     }
@@ -105,17 +109,17 @@ public class ContentTest extends LocalFileSystemTest {
     public void testGetContentByPath() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "contentbypath" + filePath;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         log.info(new String(writer.getBody()));
         assertTrue(Arrays.equals(content, writer.getBody()));
-        assertEquals("text/plain", writer.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+        assertEquals(MediaType.TEXT_PLAIN, writer.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
     }
 
     public void testGetContentByPathNoPermissions() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "contentbypath" + protectedFilePath;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
     }
@@ -124,19 +128,19 @@ public class ContentTest extends LocalFileSystemTest {
     public void testUpdateContent() throws Exception {
         String requestPath = SERVICE_URI + "content/" + fileId;
         Map<String, List<String>> headers = new HashMap<>(1);
-        headers.put("Content-Type", Arrays.asList("text/plain"));
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, headers, updateContent, null);
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.TEXT_PLAIN));
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, headers, updateContent, null);
         assertEquals(204, response.getStatus());
         assertTrue(Arrays.equals(updateContent, readFile(filePath)));
         Map<String, String[]> expectedProperties = new HashMap<>(1);
-        expectedProperties.put("vfs:mimeType", new String[]{"text/plain"});
+        expectedProperties.put("vfs:mimeType", new String[]{MediaType.TEXT_PLAIN});
         validateProperties(filePath, expectedProperties);
     }
 
     public void testUpdateContentFolder() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "content/" + folderId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, updateContent, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, updateContent, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -151,8 +155,8 @@ public class ContentTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "content/" + protectedFileId;
         Map<String, List<String>> headers = new HashMap<>(1);
-        headers.put("Content-Type", Arrays.asList("text/plain"));
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, headers, updateContent, writer, null);
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.TEXT_PLAIN));
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, headers, updateContent, writer, null);
         // Request must fail since 'admin' has not 'write' permission (only 'read').
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
@@ -162,24 +166,24 @@ public class ContentTest extends LocalFileSystemTest {
 
     public void testUpdateContentLocked() throws Exception {
         Map<String, List<String>> headers = new HashMap<>(1);
-        headers.put("Content-Type", Arrays.asList("text/plain"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.TEXT_PLAIN));
         String requestPath = SERVICE_URI + "content/" + lockedFileId + '?' + "lockToken=" + lockToken;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, headers, updateContent, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, headers, updateContent, null);
         // File is locked.
         assertEquals(204, response.getStatus());
         assertTrue(Arrays.equals(updateContent, readFile(lockedFilePath))); // content updated
         // media type is set
         Map<String, String[]> expectedProperties = new HashMap<>(1);
-        expectedProperties.put("vfs:mimeType", new String[]{"text/plain"});
+        expectedProperties.put("vfs:mimeType", new String[]{MediaType.TEXT_PLAIN});
         validateProperties(lockedFilePath, expectedProperties);
     }
 
     public void testUpdateContentLockedNoLockToken() throws Exception {
         Map<String, List<String>> headers = new HashMap<>(1);
-        headers.put("Content-Type", Arrays.asList("text/plain"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.TEXT_PLAIN));
         String requestPath = SERVICE_URI + "content/" + lockedFileId;
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, headers, updateContent, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, headers, updateContent, writer, null);
         // File is locked.
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/CopyTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/CopyTest.java
@@ -14,6 +14,7 @@ import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.user.UserImpl;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -25,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+
+import javax.ws.rs.HttpMethod;
 
 import static org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
 import static org.eclipse.che.commons.lang.IoUtil.deleteRecursive;
@@ -72,7 +75,7 @@ public class CopyTest extends LocalFileSystemTest {
     public void testCopyFile() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "copy/" + fileId + '?' + "parentId=" + destinationId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         String expectedPath = destinationPath + '/' + fileName;
@@ -85,7 +88,7 @@ public class CopyTest extends LocalFileSystemTest {
         byte[] existedFileContent = "existed file".getBytes();
         String existedFile = createFile(destinationPath, fileName, existedFileContent);
         String requestPath = SERVICE_URI + "copy/" + fileId + '?' + "parentId=" + destinationId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals(409, response.getStatus());
         // untouched ??
         assertTrue(exists(existedFile));
@@ -97,7 +100,7 @@ public class CopyTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "copy/" + fileId + '?' + "parentId=" + protectedDestinationId;
         EnvironmentContext.getCurrent().setUser(new UserImpl("andrew", "andrew", null, Arrays.asList("workspace/developer"), false));
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         String expectedPath = protectedDestinationPath + '/' + fileName;
@@ -109,7 +112,7 @@ public class CopyTest extends LocalFileSystemTest {
     public void testCopyFileNoPermissionsDestination() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "copy/" + fileId + '?' + "parentId=" + protectedDestinationId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
         String expectedPath = protectedDestinationPath + '/' + fileName;
@@ -121,7 +124,7 @@ public class CopyTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "copy/" + folderId + '?' + "parentId=" + destinationId;
         final long start = System.currentTimeMillis();
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         final long end = System.currentTimeMillis();
         log.info(">>>>> Copy tree time: {}ms", (end - start));
         log.info(new String(writer.getBody()));
@@ -157,7 +160,7 @@ public class CopyTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "copy/" + folderId + '?' + "parentId=" + destinationId;
         final long start = System.currentTimeMillis();
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         final long end = System.currentTimeMillis();
         log.info(">>>>> Copy tree time: {}ms", (end - start));
         log.info(new String(writer.getBody()));
@@ -201,7 +204,7 @@ public class CopyTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "copy/" + folderId + '?' + "parentId=" + destinationId;
         final long start = System.currentTimeMillis();
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         final long end = System.currentTimeMillis();
         log.info(">>>>> Copy tree time: {}ms", (end - start));
         log.info(new String(writer.getBody()));
@@ -221,7 +224,7 @@ public class CopyTest extends LocalFileSystemTest {
     public void testCopyFolderAlreadyExist() throws Exception {
         createDirectory(destinationPath, folderName);
         String requestPath = SERVICE_URI + "copy/" + folderId + '?' + "parentId=" + destinationId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals(409, response.getStatus());
         assertTrue("Source folder not found. ", exists(folderPath));
     }

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/CreateTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/CreateTest.java
@@ -15,6 +15,7 @@ import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.user.UserImpl;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -26,6 +27,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 
 import static org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
 
@@ -63,16 +68,16 @@ public class CreateTest extends LocalFileSystemTest {
         String requestPath = SERVICE_URI + "file/" + folderId + '?' + "name=" + name;
         Map<String, List<String>> headers = new HashMap<>();
         List<String> contentType = new ArrayList<>();
-        contentType.add("text/plain");
-        headers.put("Content-Type", contentType);
+        contentType.add(MediaType.TEXT_PLAIN);
+        headers.put(HttpHeaders.CONTENT_TYPE, contentType);
 
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, headers, content.getBytes(), null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, headers, content.getBytes(), null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         String expectedPath = folderPath + '/' + name;
         assertTrue("File was not created in expected location. ", exists(expectedPath));
         assertEquals(content, new String(readFile(expectedPath)));
         Map<String, String[]> expectedProperties = new HashMap<>(1);
-        expectedProperties.put("vfs:mimeType", new String[]{"text/plain"});
+        expectedProperties.put("vfs:mimeType", new String[]{MediaType.TEXT_PLAIN});
         validateProperties(expectedPath, expectedProperties);
     }
 
@@ -82,7 +87,7 @@ public class CreateTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "file/" + folderId + '?' + "name=" + name;
         ContainerResponse response =
-                launcher.service("POST", requestPath, BASE_URI, null, DEFAULT_CONTENT_BYTES, writer, null);
+                launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, DEFAULT_CONTENT_BYTES, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(409, response.getStatus());
     }
@@ -93,26 +98,26 @@ public class CreateTest extends LocalFileSystemTest {
         String requestPath = SERVICE_URI + "file/" + ROOT_ID + '?' + "name=" + name;
         Map<String, List<String>> headers = new HashMap<>();
         List<String> contentType = new ArrayList<>();
-        contentType.add("text/plain");
-        headers.put("Content-Type", contentType);
+        contentType.add(MediaType.TEXT_PLAIN);
+        headers.put(HttpHeaders.CONTENT_TYPE, contentType);
 
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         ContainerResponse response =
-                launcher.service("POST", requestPath, BASE_URI, headers, content.getBytes(), writer, null);
+                launcher.service(HttpMethod.POST, requestPath, BASE_URI, headers, content.getBytes(), writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         String expectedPath = '/' + name;
         assertTrue("File was not created in expected location. ", exists(expectedPath));
         assertEquals(content, new String(readFile(expectedPath)));
         Map<String, String[]> expectedProperties = new HashMap<>(1);
-        expectedProperties.put("vfs:mimeType", new String[]{"text/plain"});
+        expectedProperties.put("vfs:mimeType", new String[]{MediaType.TEXT_PLAIN});
         validateProperties(expectedPath, expectedProperties);
     }
 
     public void testCreateFileNoContent() throws Exception {
         String name = "testCreateFileNoContent";
         String requestPath = SERVICE_URI + "file/" + folderId + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         String expectedPath = folderPath + '/' + name;
         assertTrue("File was not created in expected location. ", exists(expectedPath));
@@ -125,7 +130,7 @@ public class CreateTest extends LocalFileSystemTest {
         String content = "test create file without media type";
         String requestPath = SERVICE_URI + "file/" + folderId + '?' + "name=" + name;
         ContainerResponse response =
-                launcher.service("POST", requestPath, BASE_URI, null, content.getBytes(), writer, null);
+                launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, content.getBytes(), writer, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         String expectedPath = folderPath + '/' + name;
         assertTrue("File was not created in expected location. ", exists(expectedPath));
@@ -136,7 +141,7 @@ public class CreateTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "file/" + folderId;
         ContainerResponse response =
-                launcher.service("POST", requestPath, BASE_URI, null, DEFAULT_CONTENT_BYTES, writer, null);
+                launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, DEFAULT_CONTENT_BYTES, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(500, response.getStatus());
     }
@@ -150,7 +155,7 @@ public class CreateTest extends LocalFileSystemTest {
         EnvironmentContext.getCurrent().setUser(new UserImpl("andrew", "andrew", null, Arrays.asList("workspace/developer"), false));
         // --
         ContainerResponse response =
-                launcher.service("POST", requestPath, BASE_URI, null, content.getBytes(), writer, null);
+                launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, content.getBytes(), writer, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         String expectedPath = protectedFolderPath + '/' + name;
         assertTrue("File was not created in expected location. ", exists(expectedPath));
@@ -162,7 +167,7 @@ public class CreateTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "file/" + protectedFolderId + '?' + "name=" + name;
         ContainerResponse response =
-                launcher.service("POST", requestPath, BASE_URI, null, DEFAULT_CONTENT_BYTES, writer, null);
+                launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, DEFAULT_CONTENT_BYTES, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
         assertFalse(exists(protectedFolderPath + '/' + name));
@@ -174,7 +179,7 @@ public class CreateTest extends LocalFileSystemTest {
         // Try to create new file in other file.
         String requestPath = SERVICE_URI + "file/" + fileId + '?' + "name=" + name;
         ContainerResponse response =
-                launcher.service("POST", requestPath, BASE_URI, null, DEFAULT_CONTENT_BYTES, writer, null);
+                launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, DEFAULT_CONTENT_BYTES, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
     }
@@ -184,7 +189,7 @@ public class CreateTest extends LocalFileSystemTest {
         String name = "testCreateFileWrongParentId";
         String requestPath = SERVICE_URI + "file/" + folderId + "_WRONG_ID" + '?' + "name=" + name;
         ContainerResponse response =
-                launcher.service("POST", requestPath, BASE_URI, null, DEFAULT_CONTENT_BYTES, writer, null);
+                launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, DEFAULT_CONTENT_BYTES, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(404, response.getStatus());
     }
@@ -193,7 +198,7 @@ public class CreateTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String name = "testCreateFolder";
         String requestPath = SERVICE_URI + "folder/" + folderId + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         String expectedPath = folderPath + '/' + name;
@@ -204,7 +209,7 @@ public class CreateTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String name = "FolderInRoot";
         String requestPath = SERVICE_URI + "folder/" + ROOT_ID + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         String expectedPath = '/' + name;
@@ -214,7 +219,7 @@ public class CreateTest extends LocalFileSystemTest {
     public void testCreateFolderNoName() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "folder/" + folderId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(500, response.getStatus());
     }
@@ -223,7 +228,7 @@ public class CreateTest extends LocalFileSystemTest {
         String name = "testCreateFolderNoPermissions";
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "folder/" + protectedFolderId + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
         String expectedPath = protectedFolderPath + '/' + name;
@@ -234,7 +239,7 @@ public class CreateTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String name = "testCreateFolderWrongParentId";
         String requestPath = SERVICE_URI + "folder/" + folderId + "_WRONG_ID" + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(404, response.getStatus());
     }
@@ -243,7 +248,7 @@ public class CreateTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String name = "testCreateFolderHierarchy/1/2/3/4/5";
         String requestPath = SERVICE_URI + "folder/" + folderId + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         String expectedPath = folderPath + '/' + name;
@@ -255,7 +260,7 @@ public class CreateTest extends LocalFileSystemTest {
         String name = "testCreateFolderHierarchyExists/1/2/3/4/5";
         createDirectory(folderPath, name);
         String requestPath = SERVICE_URI + "folder/" + folderId + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, DEFAULT_CONTENT_BYTES, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, DEFAULT_CONTENT_BYTES, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(409, response.getStatus());
     }
@@ -268,7 +273,7 @@ public class CreateTest extends LocalFileSystemTest {
         name += "/4/5";
         String requestPath = SERVICE_URI + "folder/" + folderId + '?' + "name=" + name;
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         assertEquals(folderPath + "/testCreateFolderHierarchy2/1/2/3/4/5", ((Folder)response.getEntity()).getPath());

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/DeleteTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/DeleteTest.java
@@ -14,6 +14,7 @@ import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.user.UserImpl;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -25,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+
+import javax.ws.rs.HttpMethod;
 
 import static org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
 
@@ -113,7 +116,7 @@ public class DeleteTest extends LocalFileSystemTest {
 
     public void testDeleteFile() throws Exception {
         String requestPath = SERVICE_URI + "delete/" + fileId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals(204, response.getStatus());
         assertFalse("File must be removed. ", exists(filePath));
         assertNull("Properties must be removed. ", readProperties(filePath));
@@ -121,7 +124,7 @@ public class DeleteTest extends LocalFileSystemTest {
 
     public void testDeleteFileLocked() throws Exception {
         String requestPath = SERVICE_URI + "delete/" + lockedFileId + '?' + "lockToken=" + lockToken;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals(204, response.getStatus());
         assertFalse("File must be removed. ", exists(lockedFilePath));
         assertNull("Lock file must be removed. ", readLock(lockedFilePath));
@@ -130,7 +133,7 @@ public class DeleteTest extends LocalFileSystemTest {
     public void testDeleteFileLockedNoLockToken() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "delete/" + lockedFileId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         assertTrue("File must not be removed. ", exists(lockedFilePath));
@@ -143,7 +146,7 @@ public class DeleteTest extends LocalFileSystemTest {
         // File is protected and default principal 'andrew' has not write permission.
         // Replace default principal by principal who has write permission.
         EnvironmentContext.getCurrent().setUser(new UserImpl("andrew", "andrew", null, Arrays.asList("workspace/developer"), false));
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(204, response.getStatus());
         assertFalse("File must not be removed. ", exists(protectedFilePath));
         assertNull("ACL file must be removed. ", readPermissions(protectedFilePath)); // file which stored ACL must be removed
@@ -152,7 +155,7 @@ public class DeleteTest extends LocalFileSystemTest {
     public void testDeleteFileNoPermissions() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "delete/" + protectedFileId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
         assertTrue("File must not be removed. ", exists(protectedFilePath));
@@ -161,7 +164,7 @@ public class DeleteTest extends LocalFileSystemTest {
     public void testDeleteFileWrongId() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "delete/" + fileId + "_WRONG_ID";
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(404, response.getStatus());
         assertTrue(exists(filePath));
@@ -169,14 +172,14 @@ public class DeleteTest extends LocalFileSystemTest {
 
     public void testDeleteFolder() throws Exception {
         String requestPath = SERVICE_URI + "delete/" + folderId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals(204, response.getStatus());
         assertFalse("Folder must be removed. ", exists(folderPath));
     }
 
     public void testDeleteRootFolder() throws Exception {
         String requestPath = SERVICE_URI + "delete/" + ROOT_ID;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals(403, response.getStatus()); // must not be able delete root folder
         assertTrue("Folder must not be removed. ", exists("/"));
     }
@@ -185,7 +188,7 @@ public class DeleteTest extends LocalFileSystemTest {
         List<String> before = flattenDirectory(protectedFolderPath);
         String requestPath = SERVICE_URI + "delete/" + protectedFolderId;
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         assertTrue("Folder must not be removed. ", exists(protectedFolderPath));
@@ -198,7 +201,7 @@ public class DeleteTest extends LocalFileSystemTest {
         List<String> before = flattenDirectory(protectedChildFolderPath);
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "delete/" + protectedChildFolderId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         assertTrue("Folder must not be removed. ", exists(protectedChildFolderPath));
@@ -211,7 +214,7 @@ public class DeleteTest extends LocalFileSystemTest {
         List<String> before = flattenDirectory(lockedChildFolderPath);
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "delete/" + lockedChildFolderId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         assertTrue("Folder must not be removed. ", exists(lockedChildFolderPath));
@@ -222,7 +225,7 @@ public class DeleteTest extends LocalFileSystemTest {
 
     public void testDeleteTree() throws Exception {
         String requestPath = SERVICE_URI + "delete/" + notEmptyFolderId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals(204, response.getStatus());
         assertFalse("Folder must be removed. ", exists(notEmptyFolderPath));
     }

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/EventsTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/EventsTest.java
@@ -19,7 +19,6 @@ import org.eclipse.che.api.vfs.server.observation.UpdateACLEvent;
 import org.eclipse.che.api.vfs.server.observation.UpdateContentEvent;
 import org.eclipse.che.api.vfs.server.observation.UpdatePropertiesEvent;
 import org.eclipse.che.api.vfs.server.observation.VirtualFileEvent;
-
 import org.everrest.core.impl.ContainerResponse;
 
 import java.util.ArrayList;
@@ -27,6 +26,10 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 
 /**
  * @author <a href="mailto:andrew00x@gmail.com">Andrey Parfonov</a>
@@ -52,7 +55,7 @@ public class EventsTest extends LocalFileSystemTest {
         folderPath = createDirectory(testRootPath, folderName);
         filePath = createFile(testRootPath, fileName, DEFAULT_CONTENT_BYTES);
         Map<String, String[]> fileProperties = new HashMap<>(1);
-        fileProperties.put("vfs:mimeType", new String[]{"text/plain"});
+        fileProperties.put("vfs:mimeType", new String[]{MediaType.TEXT_PLAIN});
         writeProperties(filePath, fileProperties);
         destinationFolderPath = createDirectory(testRootPath, "EventsTest_DestinationFolder");
         folderId = pathToId(folderPath);
@@ -108,8 +111,8 @@ public class EventsTest extends LocalFileSystemTest {
         String content = "test create file";
         String requestPath = SERVICE_URI + "file/" + folderId + '?' + "name=" + name;
         Map<String, List<String>> headers = new HashMap<>(1);
-        headers.put("Content-Type", Arrays.asList("text/plain;charset=utf8"));
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, headers, content.getBytes(), null);
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList("text/plain;charset=utf8"));
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, headers, content.getBytes(), null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
 
         String expectedPath = folderPath + '/' + name;
@@ -124,7 +127,7 @@ public class EventsTest extends LocalFileSystemTest {
     public void testCreateFolder() throws Exception {
         String name = "testCreateFolder";
         String requestPath = SERVICE_URI + "folder/" + folderId + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
 
         String expectedPath = folderPath + '/' + name;
@@ -138,7 +141,7 @@ public class EventsTest extends LocalFileSystemTest {
 
     public void testCopy() throws Exception {
         String requestPath = SERVICE_URI + "copy/" + fileId + '?' + "parentId=" + destinationFolderId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
 
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
 
@@ -153,7 +156,7 @@ public class EventsTest extends LocalFileSystemTest {
 
     public void testMove() throws Exception {
         String requestPath = SERVICE_URI + "move/" + fileId + '?' + "parentId=" + destinationFolderId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
 
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
 
@@ -169,12 +172,12 @@ public class EventsTest extends LocalFileSystemTest {
     }
 
     public void testUpdateContent() throws Exception {
-        String contentType = "application/xml";
+        String contentType = MediaType.APPLICATION_XML;
         String requestPath = SERVICE_URI + "content/" + fileId;
         Map<String, List<String>> headers = new HashMap<>(1);
-        headers.put("Content-Type", Arrays.asList(contentType));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(contentType));
         String content = "<?xml version='1.0'><root/>";
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, headers, content.getBytes(), null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, headers, content.getBytes(), null);
         assertEquals(204, response.getStatus());
 
         assertEquals(1, events.size());
@@ -187,9 +190,9 @@ public class EventsTest extends LocalFileSystemTest {
     public void testUpdateProperties() throws Exception {
         String requestPath = SERVICE_URI + "item/" + fileId;
         Map<String, List<String>> headers = new HashMap<>(1);
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
         String properties = "[{\"name\":\"MyProperty\", \"value\":[\"MyValue\"]}]";
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, headers, properties.getBytes(), null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, headers, properties.getBytes(), null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
 
         assertEquals(1, events.size());
@@ -202,10 +205,10 @@ public class EventsTest extends LocalFileSystemTest {
     public void testUpdateAcl() throws Exception {
         String requestPath = SERVICE_URI + "acl/" + fileId;
         Map<String, List<String>> headers = new HashMap<>(1);
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
         String acl = "[{\"principal\":{\"name\":\"admin\",\"type\":\"USER\"},\"permissions\":[\"all\"]}," +
                      "{\"principal\":{\"name\":\"john\",\"type\":\"USER\"},\"permissions\":[\"read\", \"write\"]}]";
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, headers, acl.getBytes(), null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, headers, acl.getBytes(), null);
         assertEquals("Error: " + response.getEntity(), 204, response.getStatus());
 
         assertEquals(1, events.size());
@@ -217,7 +220,7 @@ public class EventsTest extends LocalFileSystemTest {
 
     public void testDelete() throws Exception {
         String requestPath = SERVICE_URI + "delete/" + fileId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals("Error: " + response.getEntity(), 204, response.getStatus());
 
         assertFalse(exists(filePath));
@@ -230,7 +233,7 @@ public class EventsTest extends LocalFileSystemTest {
 
     public void testRename() throws Exception {
         String requestPath = SERVICE_URI + "rename/" + fileId + '?' + "newname=" + "_FILE_NEW_NAME_";
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
 
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
 

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/GetAvailableFileSystemsTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/GetAvailableFileSystemsTest.java
@@ -14,7 +14,6 @@ import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.ACLCapability;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.QueryCapability;
-
 import org.everrest.core.impl.ContainerResponse;
 import org.everrest.core.tools.ByteArrayContainerResponseWriter;
 
@@ -22,12 +21,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import javax.ws.rs.HttpMethod;
+
 public class GetAvailableFileSystemsTest extends LocalFileSystemTest {
     @SuppressWarnings("unchecked")
     public void testAvailableFS() throws Exception {
         String requestPath = BASE_URI + "/vfs/my-ws";
         ByteArrayContainerResponseWriter wr = new ByteArrayContainerResponseWriter();
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, wr, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, wr, null);
         //log.info(new String(wr.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         Collection<VirtualFileSystemInfo> entity = (Collection<VirtualFileSystemInfo>)response.getEntity();

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/GetItemTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/GetItemTest.java
@@ -16,6 +16,7 @@ import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.user.UserImpl;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -26,6 +27,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+
+import javax.ws.rs.HttpMethod;
 
 import static org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
 
@@ -75,7 +78,7 @@ public class GetItemTest extends LocalFileSystemTest {
     public void testGetFile() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "item/" + fileId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         Item item = (Item)response.getEntity();
@@ -88,7 +91,7 @@ public class GetItemTest extends LocalFileSystemTest {
     public void testGetFileByPath() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "itembypath" + filePath;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         Item item = (Item)response.getEntity();
@@ -105,7 +108,7 @@ public class GetItemTest extends LocalFileSystemTest {
     public void testGetFileByPathWithVersionId() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "itembypath" + filePath + '?' + "versionId=" + 0;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         Item item = (Item)response.getEntity();
@@ -118,7 +121,7 @@ public class GetItemTest extends LocalFileSystemTest {
     public void testGetFileByPathWithVersionId2() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "itembypath" + filePath + '?' + "versionId=" + 1; // must fail
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(404, response.getStatus());
     }
@@ -136,7 +139,7 @@ public class GetItemTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         // No filter - all properties
         String requestPath = SERVICE_URI + "item/" + fileId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         Item i = (Item)response.getEntity();
 
@@ -146,7 +149,7 @@ public class GetItemTest extends LocalFileSystemTest {
         // With filter
         requestPath = SERVICE_URI + "item/" + fileId + '?' + "propertyFilter=" + e1.getKey();
 
-        response = launcher.service("GET", requestPath, BASE_URI, null, null, null);
+        response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         i = (Item)response.getEntity();
 
@@ -157,7 +160,7 @@ public class GetItemTest extends LocalFileSystemTest {
     public void testGetFileNotFound() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "item/" + fileId + "_WRONG_ID_";
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(404, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -168,7 +171,7 @@ public class GetItemTest extends LocalFileSystemTest {
         // Replace default principal by principal who has read permission.
         EnvironmentContext.getCurrent().setUser(new UserImpl("andrew", "andrew", null, Arrays.asList("workspace/developer"), false));
         // ---
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         Item item = (Item)response.getEntity();
@@ -181,7 +184,7 @@ public class GetItemTest extends LocalFileSystemTest {
     public void testGetFileNoPermissions() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "item/" + protectedFileId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -189,7 +192,7 @@ public class GetItemTest extends LocalFileSystemTest {
     public void testGetFileParentNoPermissions() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "item/" + protectedParentId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -197,7 +200,7 @@ public class GetItemTest extends LocalFileSystemTest {
     public void testGetFileByPathNoPermissions() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "itembypath" + protectedFilePath;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -205,7 +208,7 @@ public class GetItemTest extends LocalFileSystemTest {
     public void testGetFolder() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "item/" + folderId;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         Item item = (Item)response.getEntity();
@@ -218,7 +221,7 @@ public class GetItemTest extends LocalFileSystemTest {
     public void testGetFolderByPath() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "itembypath" + folderPath;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         Item item = (Item)response.getEntity();
@@ -232,7 +235,7 @@ public class GetItemTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         // Parameter 'versionId' is not acceptable for folders, must be absent.
         String requestPath = SERVICE_URI + "itembypath" + folderPath + '?' + "versionId=" + 1;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
     }

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/GetVFSInfoTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/GetVFSInfoTest.java
@@ -14,7 +14,6 @@ import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.ACLCapability;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.QueryCapability;
-
 import org.everrest.core.impl.ContainerResponse;
 import org.everrest.core.tools.ByteArrayContainerResponseWriter;
 
@@ -22,10 +21,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import javax.ws.rs.HttpMethod;
+
 public class GetVFSInfoTest extends LocalFileSystemTest {
     public void testVFSInfo() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
-        ContainerResponse response = launcher.service("GET", SERVICE_URI, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, SERVICE_URI, BASE_URI, null, null, writer, null);
         assertNotNull(response.getEntity());
         assertEquals(response.getEntity().toString(), 200, response.getStatus());
         //log.info(new String(writer.getBody()));

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/ImportTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/ImportTest.java
@@ -14,7 +14,6 @@ import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.server.observation.CreateEvent;
 import org.eclipse.che.api.vfs.server.observation.VirtualFileEvent;
-
 import org.everrest.core.impl.ContainerResponse;
 
 import java.io.ByteArrayOutputStream;
@@ -24,6 +23,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
+import javax.ws.rs.HttpMethod;
 
 /**
  * @author andrew00x
@@ -76,7 +77,7 @@ public class ImportTest extends LocalFileSystemTest {
 
     public void testImportFolder() throws Exception {
         String path = SERVICE_URI + "import/" + importTestRootId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, zipFolder, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, zipFolder, null);
         assertEquals(204, response.getStatus());
         VirtualFile parent = mountPoint.getVirtualFileById(importTestRootId);
         VirtualFile folder1 = parent.getChild("folder1");

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/LocalFileSystemTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/LocalFileSystemTest.java
@@ -19,7 +19,6 @@ import org.eclipse.che.vfs.impl.fs.FileLockSerializer;
 import org.eclipse.che.vfs.impl.fs.FileMetadataSerializer;
 import org.eclipse.che.vfs.impl.fs.LocalFileSystemProvider;
 import org.eclipse.che.vfs.impl.fs.WorkspaceHashLocalFSMountStrategy;
-
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.vfs.server.URLHandlerFactorySetup;
 import org.eclipse.che.api.vfs.server.VirtualFileSystemApplication;
@@ -34,8 +33,8 @@ import org.eclipse.che.api.vfs.shared.dto.Property;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.lang.Pair;
+import org.eclipse.che.commons.lang.ws.rs.ExtMediaType;
 import org.eclipse.che.commons.user.UserImpl;
-
 import org.apache.commons.codec.binary.Base64;
 import org.everrest.core.ResourceBinder;
 import org.everrest.core.impl.ApplicationContextImpl;
@@ -53,8 +52,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.swing.event.EventListenerList;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
@@ -486,7 +487,7 @@ public abstract class LocalFileSystemTest extends TestCase {
 
     protected Item getItem(String id) throws Exception {
         String requestPath = SERVICE_URI + "item/" + id;
-        ContainerResponse response = launcher.service("GET", requestPath, BASE_URI, null, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, requestPath, BASE_URI, null, null, null, null);
         if (response.getStatus() == 200) {
             return (Item)response.getEntity();
         }
@@ -730,21 +731,21 @@ public abstract class LocalFileSystemTest extends TestCase {
 
             link = links.get(Link.REL_EXPORT);
             assertNotNull(String.format("'%s' link not found. ", Link.REL_EXPORT), link);
-            assertEquals("application/zip", link.getType());
+            assertEquals(ExtMediaType.APPLICATION_ZIP, link.getType());
             assertEquals(Link.REL_EXPORT, link.getRel());
             assertEquals(UriBuilder.fromPath(SERVICE_URI).path("export").path(item.getId()).build().toString(),
                          link.getHref());
 
             link = links.get(Link.REL_IMPORT);
             assertNotNull(String.format("'%s' link not found. ", Link.REL_IMPORT), link);
-            assertEquals("application/zip", link.getType());
+            assertEquals(ExtMediaType.APPLICATION_ZIP, link.getType());
             assertEquals(Link.REL_IMPORT, link.getRel());
             assertEquals(UriBuilder.fromPath(SERVICE_URI).path("import").path(item.getId()).build().toString(),
                          link.getHref());
 
             link = links.get(Link.REL_DOWNLOAD_ZIP);
             assertNotNull(String.format("'%s' link not found. ", Link.REL_DOWNLOAD_ZIP), link);
-            assertEquals("application/zip", link.getType());
+            assertEquals(ExtMediaType.APPLICATION_ZIP, link.getType());
             assertEquals(Link.REL_DOWNLOAD_ZIP, link.getRel());
             assertEquals(UriBuilder.fromPath(SERVICE_URI).path("downloadzip").path(item.getId()).build().toString(),
                          link.getHref());

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/LockTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/LockTest.java
@@ -15,6 +15,7 @@ import org.eclipse.che.api.vfs.shared.dto.File;
 import org.eclipse.che.api.vfs.shared.dto.Lock;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -23,6 +24,8 @@ import org.everrest.core.tools.ByteArrayContainerResponseWriter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import javax.ws.rs.HttpMethod;
 
 import static org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
 
@@ -68,7 +71,7 @@ public class LockTest extends LocalFileSystemTest {
     public void testLockFile() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "lock/" + fileId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         Lock result = (Lock)response.getEntity();
@@ -79,7 +82,7 @@ public class LockTest extends LocalFileSystemTest {
     public void testLockFileAlreadyLocked() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "lock/" + lockedFileId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(409, response.getStatus());
         // lock file must not be updated.
@@ -89,7 +92,7 @@ public class LockTest extends LocalFileSystemTest {
     public void testLockFileNoPermissions() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "lock/" + protectedFileId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
         assertNull("Lock file must not be created. ", readLock(protectedFilePath));
@@ -99,7 +102,7 @@ public class LockTest extends LocalFileSystemTest {
     public void testLockFolder() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "lock/" + folderId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
         // Lock file must not be created
@@ -108,7 +111,7 @@ public class LockTest extends LocalFileSystemTest {
 
     public void testUnlockFile() throws Exception {
         String requestPath = SERVICE_URI + "unlock/" + lockedFileId + '?' + "lockToken=" + lockToken;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals(204, response.getStatus());
         assertNull("Lock must be removed. ", readLock(lockedFilePath));
         assertFalse("File must be unlocked. ", ((File)getItem(lockedFileId)).isLocked());
@@ -117,7 +120,7 @@ public class LockTest extends LocalFileSystemTest {
     public void testUnlockFileNoLockToken() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "unlock/" + lockedFileId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
         assertEquals("Lock must be kept. ", lockToken, readLock(lockedFilePath).getLockToken());
@@ -127,7 +130,7 @@ public class LockTest extends LocalFileSystemTest {
     public void testUnlockFileWrongLockToken() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "unlock/" + lockedFileId + '?' + "lockToken=" + lockToken + "_WRONG";
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
         assertEquals("Lock must be kept. ", lockToken, readLock(lockedFilePath).getLockToken());
@@ -137,7 +140,7 @@ public class LockTest extends LocalFileSystemTest {
     public void testUnlockFileNotLocked() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "unlock/" + fileId + '?' + "lockToken=some_token";
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(409, response.getStatus());
         assertFalse(((File)getItem(fileId)).isLocked());

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/MoveTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/MoveTest.java
@@ -12,6 +12,7 @@ package org.eclipse.che.vfs.impl.fs;
 
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -24,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+
+import javax.ws.rs.HttpMethod;
 
 import static org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
 
@@ -129,7 +132,7 @@ public class MoveTest extends LocalFileSystemTest {
     public void testMoveFile() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "move/" + fileId + '?' + "parentId=" + destinationId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         String expectedPath = destinationPath + '/' + fileName;
@@ -141,7 +144,7 @@ public class MoveTest extends LocalFileSystemTest {
         byte[] existedFileContent = "existed file".getBytes();
         String existedFile = createFile(destinationPath, fileName, existedFileContent);
         String requestPath = SERVICE_URI + "move/" + fileId + '?' + "parentId=" + destinationId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals(409, response.getStatus());
         // untouched ??
         assertTrue(exists(existedFile));
@@ -151,7 +154,7 @@ public class MoveTest extends LocalFileSystemTest {
     public void testMoveLockedFile() throws Exception {
         String requestPath = SERVICE_URI + "move/" + lockedFileId +
                              '?' + "parentId=" + destinationId + '&' + "lockToken=" + lockToken;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         assertFalse("File must be moved. ", exists(lockedFilePath));
         String expectedPath = destinationPath + '/' + lockedFileName;
@@ -161,7 +164,7 @@ public class MoveTest extends LocalFileSystemTest {
     public void testMoveLockedFileNoLockToken() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "move/" + lockedFileId + '?' + "parentId=" + destinationId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         assertTrue("File must not be moved. ", exists(lockedFilePath));
@@ -172,7 +175,7 @@ public class MoveTest extends LocalFileSystemTest {
     public void testMoveFileNoPermissions() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "move/" + protectedFileId + '?' + "parentId=" + destinationId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         assertTrue("Source file not found. ", exists(protectedFilePath));
@@ -183,7 +186,7 @@ public class MoveTest extends LocalFileSystemTest {
     public void testMoveFileNoPermissions_Destination() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "move/" + fileId + '?' + "parentId=" + protectedDestinationId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         assertTrue("Source file not found. ", exists(protectedFilePath));
@@ -196,7 +199,7 @@ public class MoveTest extends LocalFileSystemTest {
         String requestPath = SERVICE_URI + "move/" + folderId + '?' + "parentId=" + destinationId;
         List<String> before = flattenDirectory(folderPath);
         final long start = System.currentTimeMillis();
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         final long end = System.currentTimeMillis();
         log.info(">>>>> Move tree time: {}ms", (end - start));
         log.info(new String(writer.getBody()));
@@ -213,7 +216,7 @@ public class MoveTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "move/" + protectedFolderId + '?' + "parentId=" + destinationId;
         List<String> before = flattenDirectory(protectedFolderPath);
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         String expectedPath = destinationPath + '/' + protectedFolderName;
@@ -228,7 +231,7 @@ public class MoveTest extends LocalFileSystemTest {
     public void testMoveFolderAlreadyExist() throws Exception {
         createDirectory(destinationPath, folderName);
         String requestPath = SERVICE_URI + "move/" + folderId + '?' + "parentId=" + destinationId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals(409, response.getStatus());
         // untouched ??
         assertTrue("Source folder not found. ", exists(folderPath));
@@ -238,7 +241,7 @@ public class MoveTest extends LocalFileSystemTest {
         List<String> sourceBefore = flattenDirectory(lockedChildFolderPath);
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "move/" + lockedChildFolderId + '?' + "parentId=" + destinationId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         // Items copied but we are fail when try delete source tree
@@ -257,7 +260,7 @@ public class MoveTest extends LocalFileSystemTest {
         List<String> sourceBefore = flattenDirectory(protectedChildFolderPath);
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "move/" + protectedChildFolderId + '?' + "parentId=" + destinationId;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         // Items copied but we are fail when try delete source tree.

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/RenameTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/RenameTest.java
@@ -15,6 +15,7 @@ import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.user.UserImpl;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -25,6 +26,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import javax.ws.rs.HttpMethod;
 
 public class RenameTest extends LocalFileSystemTest {
     private final String lockToken = "01234567890abcdef";
@@ -94,7 +97,7 @@ public class RenameTest extends LocalFileSystemTest {
         final String newMediaType = "text/*;charset=ISO-8859-1";
         String requestPath = SERVICE_URI + "rename/" + fileId + '?' + "newname=" + newName + '&' +
                              "mediaType=" + newMediaType;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         assertFalse("File must be removed. ", exists(filePath));
         String expectedPath = testRootPath + '/' + newName;
@@ -111,7 +114,7 @@ public class RenameTest extends LocalFileSystemTest {
         final String existedFile = createFile(testRootPath, newName, existedFileContent);
         String requestPath = SERVICE_URI + "rename/" + fileId + '?' + "newname=" + newName + '&' + "mediaType=" +
                              "text/*;charset=ISO-8859-1";
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals(409, response.getStatus());
         // Be sure file exists.
         assertTrue(exists(existedFile));
@@ -124,7 +127,7 @@ public class RenameTest extends LocalFileSystemTest {
         final String newMediaType = "text/*;charset=ISO-8859-1";
         String requestPath = SERVICE_URI + "rename/" + lockedFileId +
                              '?' + "newname=" + newName + '&' + "mediaType=" + newMediaType + '&' + "lockToken=" + lockToken;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         String expectedPath = testRootPath + '/' + newName;
         assertFalse("File must be removed. ", exists(lockedFilePath));
@@ -141,7 +144,7 @@ public class RenameTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "rename/" + lockedFileId +
                              '?' + "newname=" + newName + '&' + "mediaType=" + "text/*;charset=ISO-8859-1";
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         assertTrue("File must not be removed. ", exists(lockedFilePath));
@@ -154,7 +157,7 @@ public class RenameTest extends LocalFileSystemTest {
         final String newName = "_FILE_NEW_NAME_";
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "rename/" + protectedFileId + '?' + "newname=" + newName;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         assertTrue("File must not be removed. ", exists(protectedFilePath));
@@ -168,7 +171,7 @@ public class RenameTest extends LocalFileSystemTest {
 
         final String newName = "_FOLDER_NEW_NAME_";
         String path = SERVICE_URI + "rename/" + folderId + '?' + "newname=" + newName;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
 
         assertFalse("Folder must be removed. ", exists(folderPath));
@@ -188,7 +191,7 @@ public class RenameTest extends LocalFileSystemTest {
         List<String> before = flattenDirectory(protectedFolderPath);
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "rename/" + protectedFolderId + '?' + "newname=" + newName;
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         assertTrue("Folder must not be removed. ", exists(protectedFolderPath));
@@ -205,7 +208,7 @@ public class RenameTest extends LocalFileSystemTest {
         final String newMediaType = "text/directory%2BFOO"; // text/directory+FOO
         String path = SERVICE_URI + "rename/" + folderId + '?' + "newname=" + newName + '&' +
                       "mediaType=" + newMediaType;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         String expectedPath = testRootPath + '/' + newName;
         assertTrue(exists(expectedPath));
@@ -220,7 +223,7 @@ public class RenameTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "rename/" + protectedFileId + '?' + "newname=" + newName;
         EnvironmentContext.getCurrent().setUser(new UserImpl("andrew", "andrew", null, Arrays.asList("workspace/developer"), false));
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
         assertEquals(200, response.getStatus());
         String expectedPath = testRootPath + '/' + newName;
         assertTrue(exists(expectedPath));

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/SearcherTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/SearcherTest.java
@@ -15,7 +15,6 @@ import org.eclipse.che.api.vfs.server.VirtualFileFilter;
 import org.eclipse.che.api.vfs.shared.dto.Item;
 import org.eclipse.che.api.vfs.shared.dto.ItemList;
 import org.eclipse.che.commons.lang.Pair;
-
 import org.apache.lucene.analysis.core.SimpleAnalyzer;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.queryparser.classic.QueryParser;
@@ -35,6 +34,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 
 public class SearcherTest extends LocalFileSystemTest {
     private static final String FILE_NAME          = "SearcherTest_File1";
@@ -63,11 +66,11 @@ public class SearcherTest extends LocalFileSystemTest {
                 .singletonMap("vfs:mimeType", new String[]{"text/xml"})); // text/xml just for test, it is not xml content
 
         file2 = createFile(searchTestPath, "SearcherTest_File02.txt", "to be or not to be".getBytes());
-        writeProperties(file2, Collections.singletonMap("vfs:mimeType", new String[]{"text/plain"}));
+        writeProperties(file2, Collections.singletonMap("vfs:mimeType", new String[]{MediaType.TEXT_PLAIN}));
 
         String folder1 = createDirectory(searchTestPath, "folder01");
         file3 = createFile(folder1, "SearcherTest_File03.txt", "to be or not to be".getBytes());
-        writeProperties(file3, Collections.singletonMap("vfs:mimeType", new String[]{"text/plain"}));
+        writeProperties(file3, Collections.singletonMap("vfs:mimeType", new String[]{MediaType.TEXT_PLAIN}));
 
         file4 = createFile(searchTestPath, FILE_NAME, "maybe you should think twice".getBytes());
 
@@ -119,9 +122,9 @@ public class SearcherTest extends LocalFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String requestPath = SERVICE_URI + "search";
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/x-www-form-urlencoded"));
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_FORM_URLENCODED));
         for (Pair<String[], String> pair : queryToResult) {
-            ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, h, pair.second.getBytes(), writer, null);
+            ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, h, pair.second.getBytes(), writer, null);
             //log.info(new String(writer.getBody()));
             assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
             List<Item> result = ((ItemList)response.getEntity()).getItems();

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/UpdateTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/UpdateTest.java
@@ -15,6 +15,7 @@ import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.user.UserImpl;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -25,6 +26,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 
 import static org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
 
@@ -72,8 +77,8 @@ public class UpdateTest extends LocalFileSystemTest {
 
         String requestPath = SERVICE_URI + "item/" + fileId;
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, h, update.getBytes(), null);
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, h, update.getBytes(), null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
 
         Map<String, String[]> expectedProperties = new HashMap<>(1);
@@ -97,8 +102,8 @@ public class UpdateTest extends LocalFileSystemTest {
 
         String requestPath = SERVICE_URI + "item/" + fileId;
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, h, update.getBytes(), null);
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, h, update.getBytes(), null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
 
         Map<String, String[]> expectedProperties = new HashMap<>(4);
@@ -120,8 +125,8 @@ public class UpdateTest extends LocalFileSystemTest {
 
         String requestPath = SERVICE_URI + "item/" + lockedFileId + '?' + "lockToken=" + lockToken;
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, h, properties.getBytes(), null);
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, h, properties.getBytes(), null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
 
         Map<String, String[]> expectedProperties = new HashMap<>(1);
@@ -137,9 +142,9 @@ public class UpdateTest extends LocalFileSystemTest {
 
         String requestPath = SERVICE_URI + "item/" + lockedFileId;
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, h, properties.getBytes(), writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, h, properties.getBytes(), writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
 
@@ -154,12 +159,12 @@ public class UpdateTest extends LocalFileSystemTest {
 
         String requestPath = SERVICE_URI + "item/" + protectedFileId;
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         // File is protected and default principal 'andrew' has not write permission.
         // Replace default principal by principal who has write permission.
         EnvironmentContext.getCurrent().setUser(new UserImpl("andrew", "andrew", null, Arrays.asList("workspace/developer"), false));
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, h, properties.getBytes(), writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, h, properties.getBytes(), writer, null);
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
 
         Map<String, String[]> expectedProperties = new HashMap<>(1);
@@ -175,9 +180,9 @@ public class UpdateTest extends LocalFileSystemTest {
 
         String requestPath = SERVICE_URI + "item/" + protectedFileId;
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
-        ContainerResponse response = launcher.service("POST", requestPath, BASE_URI, h, properties.getBytes(), writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, h, properties.getBytes(), writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
 

--- a/commons/che-core-commons-lang/pom.xml
+++ b/commons/che-core-commons-lang/pom.xml
@@ -23,6 +23,11 @@
     <name>Che Core :: Commons :: Java API extension classes</name>
     <dependencies>
         <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>${javax.ws.rs.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <version>${commons-compress.version}</version>

--- a/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/IoUtil.java
+++ b/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/IoUtil.java
@@ -27,6 +27,8 @@ import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
 
+import javax.ws.rs.HttpMethod;
+
 import static java.nio.file.FileVisitResult.CONTINUE;
 import static java.nio.file.FileVisitResult.TERMINATE;
 
@@ -243,7 +245,7 @@ public class IoUtil {
             if ("http".equals(protocol) || "https".equals(protocol)) {
                 HttpURLConnection http = (HttpURLConnection)conn;
                 http.setInstanceFollowRedirects(false);
-                http.setRequestMethod("GET");
+                http.setRequestMethod(HttpMethod.GET);
             }
             try (InputStream input = conn.getInputStream();
                  FileOutputStream fOutput = new FileOutputStream(file)) {

--- a/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/ws/rs/ExtMediaType.java
+++ b/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/ws/rs/ExtMediaType.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.commons.lang.ws.rs;
+
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Extended media type.
+ * 
+ * @author Tareq Sharafy (tareq.sharafy@sap.com)
+ */
+public interface ExtMediaType {
+    /**
+     * A {@code String} constant representing "{@value #APPLICATION_ZIP}" media type.
+     */
+    public final static String APPLICATION_ZIP = "application/zip";
+    /**
+     * A {@link MediaType} constant representing "{@value #APPLICATION_ZIP}" media type.
+     */
+    public final static MediaType APPLICATION_ZIP_TYPE = new MediaType("application", "zip");
+
+}

--- a/platform-api/che-core-api-account/src/test/java/org/eclipse/che/api/account/AccountServiceTest.java
+++ b/platform-api/che-core-api-account/src/test/java/org/eclipse/che/api/account/AccountServiceTest.java
@@ -47,9 +47,11 @@ import org.testng.annotations.Test;
 
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
+
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -192,7 +194,7 @@ public class AccountServiceTest {
     public void shouldNotBeAbleToCreateAccountWithNotValidAttributes() throws Exception {
         account.getAttributes().put("codenvy:god_mode", "true");
 
-        ContainerResponse response = makeRequest("POST", SERVICE_PATH, MediaType.APPLICATION_JSON, account);
+        ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH, MediaType.APPLICATION_JSON, account);
         assertEquals(response.getEntity().toString(), "Attribute name 'codenvy:god_mode' is not valid");
     }
 
@@ -386,9 +388,9 @@ public class AccountServiceTest {
                                                       .withUserId(USER_ID)
                                                       .withRoles(singletonList("account/member"));
 
-        final ContainerResponse response = makeRequest("POST",
+        final ContainerResponse response = makeRequest(HttpMethod.POST,
                                                        SERVICE_PATH + "/" + account.getId() + "/members",
-                                                       "application/json",
+                                                       MediaType.APPLICATION_JSON,
                                                        newMembership);
 
         assertEquals(response.getStatus(), Response.Status.CREATED.getStatusCode());
@@ -492,7 +494,7 @@ public class AccountServiceTest {
         Map<String, List<String>> headers = null;
         if (contentType != null) {
             headers = new HashMap<>();
-            headers.put("Content-Type", Arrays.asList(contentType));
+            headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(contentType));
         }
         byte[] data = null;
         if (toSend != null) {

--- a/platform-api/che-core-api-analytics/src/main/java/org/eclipse/che/api/analytics/impl/RemoteMetricHandler.java
+++ b/platform-api/che-core-api-analytics/src/main/java/org/eclipse/che/api/analytics/impl/RemoteMetricHandler.java
@@ -26,10 +26,12 @@ import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.dto.server.JsonArrayImpl;
 import org.eclipse.che.dto.server.JsonStringMapImpl;
 
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -68,7 +70,7 @@ public class RemoteMetricHandler implements MetricHandler {
             List<Pair<String, String>> pairs = mapToParisList(executionContext);
             return request(MetricValueDTO.class,
                            proxyUrl,
-                           "GET",
+                           HttpMethod.GET,
                            null,
                            pairs.toArray(new Pair[pairs.size()]));
         } catch (Exception e) {
@@ -90,7 +92,7 @@ public class RemoteMetricHandler implements MetricHandler {
             List<Pair<String, String>> pairs = mapToParisList(executionContext);
             return request(MetricValueListDTO.class,
                            proxyUrl,
-                           "POST",
+                           HttpMethod.POST,
                            new JsonArrayImpl<>(parameters),
                            pairs.toArray(new Pair[pairs.size()]));
         } catch (Exception e) {
@@ -108,7 +110,7 @@ public class RemoteMetricHandler implements MetricHandler {
             List<Pair<String, String>> pairs = mapToParisList(executionContext);
             return request(MetricValueDTO.class,
                            proxyUrl,
-                           "POST",
+                           HttpMethod.POST,
                            parameters,
                            pairs.toArray(new Pair[pairs.size()]));
         } catch (Exception e) {
@@ -126,7 +128,7 @@ public class RemoteMetricHandler implements MetricHandler {
             List<Pair<String, String>> pairs = mapToParisList(executionContext);
             return request(MetricValueDTO.class,
                            proxyUrl,
-                           "GET",
+                           HttpMethod.GET,
                            null,
                            pairs.toArray(new Pair[pairs.size()]));
         } catch (Exception e) {
@@ -144,7 +146,7 @@ public class RemoteMetricHandler implements MetricHandler {
             List<Pair<String, String>> pairs = mapToParisList(executionContext);
             return request(MetricValueListDTO.class,
                            proxyUrl,
-                           "POST",
+                           HttpMethod.POST,
                            metricNames,
                            pairs.toArray(new Pair[pairs.size()]));
         } catch (Exception e) {
@@ -160,7 +162,7 @@ public class RemoteMetricHandler implements MetricHandler {
             List<Pair<String, String>> pairs = mapToParisList(Collections.<String, String>emptyMap());
             MetricInfoDTO metricInfoDTO = request(MetricInfoDTO.class,
                                                   proxyUrl,
-                                                  "GET",
+                                                  HttpMethod.GET,
                                                   null,
                                                   pairs.toArray(new Pair[pairs.size()]));
             updateLinks(uriInfo, metricInfoDTO);
@@ -178,7 +180,7 @@ public class RemoteMetricHandler implements MetricHandler {
             @SuppressWarnings("unchecked")
             MetricInfoListDTO metricInfoListDTO = request(MetricInfoListDTO.class,
                                                           proxyUrl,
-                                                          "GET",
+                                                          HttpMethod.GET,
                                                           null,
                                                           pairs.toArray(new Pair[pairs.size()]));
             updateLinks(uriInfo, metricInfoListDTO);
@@ -255,7 +257,7 @@ public class RemoteMetricHandler implements MetricHandler {
         try {
             conn.setRequestMethod(method);
             if (body != null) {
-                conn.addRequestProperty("content-type", "application/json");
+                conn.addRequestProperty("content-type", MediaType.APPLICATION_JSON);
                 conn.setDoOutput(true);
                 try (OutputStream output = conn.getOutputStream()) {
                     output.write(DtoFactory.getInstance().toJson(body).getBytes());
@@ -272,7 +274,7 @@ public class RemoteMetricHandler implements MetricHandler {
                 throw new IOException(IoUtil.readAndCloseQuietly(in));
             }
             final String contentType = conn.getContentType();
-            if (!contentType.startsWith("application/json")) {
+            if (!contentType.startsWith(MediaType.APPLICATION_JSON)) {
                 throw new IOException("Unsupported type of response from remote server. ");
             }
             try (InputStream input = conn.getInputStream()) {
@@ -295,7 +297,7 @@ public class RemoteMetricHandler implements MetricHandler {
                                    .path(getMethod("getValue"))
                                    .build(metricName, "name")
                                    .toString());
-        statusLink.setMethod("GET");
+        statusLink.setMethod(HttpMethod.GET);
         statusLink.setProduces(MediaType.APPLICATION_JSON);
         links.add(statusLink);
         return links;

--- a/platform-api/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth1/OAuthAuthenticator.java
+++ b/platform-api/che-core-api-auth/src/main/java/org/eclipse/che/security/oauth1/OAuthAuthenticator.java
@@ -25,6 +25,10 @@ import org.eclipse.che.commons.json.JsonParseException;
 import org.eclipse.che.security.oauth1.shared.User;
 
 import javax.annotation.Nonnull;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -49,10 +53,10 @@ public abstract class OAuthAuthenticator {
     private static final String OAUTH_TOKEN_PARAM_KEY    = "oauth_token";
     private static final String OAUTH_VERIFIER_PARAM_KEY = "oauth_verifier";
 
-    private static final String GET              = "GET";
+    private static final String GET              = HttpMethod.GET;
     private static final String AUTHORIZATION    = "Authorization";
-    private static final String ACCEPT           = "Accept";
-    private static final String APPLICATION_JSON = "application/json";
+    private static final String ACCEPT           = HttpHeaders.ACCEPT;
+    private static final String APPLICATION_JSON = MediaType.APPLICATION_JSON;
 
     private final String                                clientId;
     private final String                                clientSecret;

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuildQueueTask.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuildQueueTask.java
@@ -23,8 +23,10 @@ import org.eclipse.che.api.core.rest.shared.dto.Link;
 import org.eclipse.che.api.core.util.Cancellable;
 import org.eclipse.che.dto.server.DtoFactory;
 
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -151,12 +153,12 @@ public class BuildQueueTask implements Cancellable {
                                 .withRel(Constants.LINK_REL_GET_STATUS)
                                 .withHref(getUriBuilder().path(BuilderService.class, "getStatus").build(request.getWorkspace(), id)
                                                          .toString())
-                                .withMethod("GET")
+                                .withMethod(HttpMethod.GET)
                                 .withProduces(MediaType.APPLICATION_JSON));
             links.add(dtoFactory.createDto(Link.class)
                                 .withRel(Constants.LINK_REL_CANCEL)
                                 .withHref(getUriBuilder().path(BuilderService.class, "cancel").build(request.getWorkspace(), id).toString())
-                                .withMethod("POST")
+                                .withMethod(HttpMethod.POST)
                                 .withProduces(MediaType.APPLICATION_JSON));
             final List<BuilderMetric> buildStats = new ArrayList<>(1);
             buildStats.add(dtoFactory.createDto(BuilderMetric.class)

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuilderService.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuilderService.java
@@ -333,7 +333,7 @@ public class BuilderService extends Service {
                                       @PathParam("ws-id") String workspace,
                                       @ApiParam(value = "Build ID", required = true)
                                       @PathParam("id") Long id,
-                                      @ApiParam(value = "Archive type", defaultValue = "tar", allowableValues = "tar,zip")
+                                      @ApiParam(value = "Archive type", defaultValue = Constants.RESULT_ARCHIVE_TAR, allowableValues = "tar,zip")
                                       @Required @QueryParam("arch") String arch,
                                       @Context HttpServletResponse httpServletResponse) throws Exception {
         // Response write directly to the servlet request stream

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/RemoteTask.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/RemoteTask.java
@@ -21,6 +21,7 @@ import org.eclipse.che.api.core.rest.HttpJsonHelper;
 import org.eclipse.che.api.core.rest.HttpOutputMessage;
 import org.eclipse.che.api.core.rest.shared.dto.Link;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closer;
 
@@ -31,6 +32,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
 
 /**
  * Representation of remote builder's task.
@@ -213,9 +217,9 @@ public class RemoteTask {
     public void downloadResultArchive(String archType, HttpOutputMessage output) throws IOException, BuilderException, NotFoundException {
         final BuildTaskDescriptor descriptor = getBuildTaskDescriptor();
         Link link = null;
-        if (archType.equals("zip")) {
+        if (archType.equals(Constants.RESULT_ARCHIVE_ZIP)) {
             link = descriptor.getLink(Constants.LINK_REL_DOWNLOAD_RESULTS_ZIPBALL);
-        } else if (archType.equals("tar")) {
+        } else if (archType.equals(Constants.RESULT_ARCHIVE_TAR)) {
             link = descriptor.getLink(Constants.LINK_REL_DOWNLOAD_RESULTS_TARBALL);
         }
         if (link == null) {
@@ -228,7 +232,7 @@ public class RemoteTask {
         final HttpURLConnection conn = (HttpURLConnection)new URL(url).openConnection();
         conn.setConnectTimeout(60 * 1000);
         conn.setReadTimeout(60 * 1000);
-        conn.setRequestMethod("GET");
+        conn.setRequestMethod(HttpMethod.GET);
         try {
             output.setStatus(conn.getResponseCode());
             final String contentType = conn.getContentType();
@@ -236,9 +240,9 @@ public class RemoteTask {
                 output.setContentType(contentType);
             }
             // for download files
-            final String contentDisposition = conn.getHeaderField("Content-Disposition");
+            final String contentDisposition = conn.getHeaderField(HttpHeaders.CONTENT_DISPOSITION);
             if (contentDisposition != null) {
-                output.addHttpHeader("Content-Disposition", contentDisposition);
+                output.addHttpHeader(HttpHeaders.CONTENT_DISPOSITION, contentDisposition);
             }
 
 

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/Builder.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/Builder.java
@@ -29,6 +29,7 @@ import org.eclipse.che.api.core.util.StreamPump;
 import org.eclipse.che.api.core.util.Watchdog;
 import org.eclipse.che.commons.lang.IoUtil;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import org.slf4j.Logger;
@@ -36,6 +37,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+import javax.ws.rs.core.MediaType;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
@@ -413,7 +416,7 @@ public abstract class Builder {
 
     protected BuildLogger createBuildLogger(BuilderConfiguration buildConfiguration, java.io.File logFile) throws BuilderException {
         try {
-            return new DefaultBuildLogger(logFile, "text/plain");
+            return new DefaultBuildLogger(logFile, MediaType.TEXT_PLAIN);
         } catch (IOException e) {
             throw new BuilderException(e);
         }

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/Constants.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/Constants.java
@@ -65,6 +65,11 @@ public class Constants {
      */
     public static final String MAX_EXECUTION_TIME         = "builder.max_execution_time";
 
+    /** Build results archive type: .zip */
+    public static final String RESULT_ARCHIVE_ZIP         = "zip";
+    /** Build results archive type: .tar */
+    public static final String RESULT_ARCHIVE_TAR         = "tar";
+
     /* ================================================= */
 
     /** @deprecated use {@link #BASE_DIRECTORY} */

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/SourcesManagerImpl.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/SourcesManagerImpl.java
@@ -17,6 +17,7 @@ import org.eclipse.che.commons.json.JsonParseException;
 import org.eclipse.che.commons.lang.IoUtil;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.commons.lang.ZipUtils;
+
 import com.google.common.hash.Hashing;
 import com.google.common.io.CharStreams;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -53,6 +54,10 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 
 /**
  * Implementation of SourcesManager that stores sources locally and gets only updated files over virtual file system RESt API.
@@ -215,9 +220,9 @@ public class SourcesManagerImpl implements SourcesManager {
             conn.setConnectTimeout(CONNECT_TIMEOUT);
             conn.setReadTimeout(READ_TIMEOUT);
             if (!md5sums.isEmpty()) {
-                conn.setRequestMethod("POST");
-                conn.setRequestProperty("Content-type", "text/plain");
-                conn.setRequestProperty("Accept", "multipart/form-data");
+                conn.setRequestMethod(HttpMethod.POST);
+                conn.setRequestProperty("Content-type", MediaType.TEXT_PLAIN);
+                conn.setRequestProperty(HttpHeaders.ACCEPT, MediaType.MULTIPART_FORM_DATA);
                 conn.setDoOutput(true);
                 try (OutputStream output = conn.getOutputStream();
                      Writer writer = new OutputStreamWriter(output)) {
@@ -232,7 +237,7 @@ public class SourcesManagerImpl implements SourcesManager {
             final int responseCode = conn.getResponseCode();
             if (responseCode == HttpURLConnection.HTTP_OK) {
                 final String contentType = conn.getHeaderField("content-type");
-                if (contentType.startsWith("multipart/form-data")) {
+                if (contentType.startsWith(MediaType.MULTIPART_FORM_DATA)) {
                     final HeaderParameterParser headerParameterParser = new HeaderParameterParser();
                     final String boundary = headerParameterParser.parse(contentType).get("boundary");
                     try (InputStream in = conn.getInputStream()) {

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/Messages.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/Messages.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.api.core.notification;
 
 import org.eclipse.che.commons.lang.NameGenerator;
-
 import org.everrest.core.impl.provider.json.JsonGenerator;
 import org.everrest.core.impl.provider.json.JsonParser;
 import org.everrest.core.impl.provider.json.JsonValue;
@@ -27,6 +26,9 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.MediaType;
+
 /**
  * @author andrew00x
  */
@@ -34,9 +36,9 @@ class Messages {
     static RestInputMessage clientMessage(Object event) throws Exception {
         RestInputMessage message = new RestInputMessage();
         message.setBody(toJson(event));
-        message.setMethod("POST");
+        message.setMethod(HttpMethod.POST);
         message.setHeaders(new org.everrest.websockets.message.Pair[]{
-                new org.everrest.websockets.message.Pair("Content-type", "application/json")});
+                new org.everrest.websockets.message.Pair("Content-type", MediaType.APPLICATION_JSON)});
         message.setUuid(NameGenerator.generate(null, 8));
         message.setPath("/event-bus");
         return message;

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpJsonHelper.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpJsonHelper.java
@@ -21,10 +21,14 @@ import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.commons.user.User;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.io.CharStreams;
 
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -206,12 +210,12 @@ public class HttpJsonHelper {
      */
     public static <DTO> DTO get(Class<DTO> dtoInterface, String url, Pair<String, ?>... parameters)
             throws IOException, ServerException, NotFoundException, ForbiddenException, UnauthorizedException, ConflictException {
-        return request(dtoInterface, url, "GET", null, parameters);
+        return request(dtoInterface, url, HttpMethod.GET, null, parameters);
     }
 
     public static <DTO> DTO get(Class<DTO> dtoInterface, int timeout, String url, Pair<String, ?>... parameters)
             throws IOException, ServerException, NotFoundException, ForbiddenException, UnauthorizedException, ConflictException {
-        return request(dtoInterface, timeout, url, "GET", null, parameters);
+        return request(dtoInterface, timeout, url, HttpMethod.GET, null, parameters);
     }
 
     /**
@@ -235,12 +239,12 @@ public class HttpJsonHelper {
      */
     public static <DTO> DTO post(Class<DTO> dtoInterface, String url, Object body, Pair<String, ?>... parameters)
             throws IOException, ServerException, NotFoundException, ForbiddenException, UnauthorizedException, ConflictException {
-        return request(dtoInterface, url, "POST", body, parameters);
+        return request(dtoInterface, url, HttpMethod.POST, body, parameters);
     }
 
     public static <DTO> DTO post(Class<DTO> dtoInterface, int timeout, String url, Object body, Pair<String, ?>... parameters)
             throws IOException, ServerException, NotFoundException, ForbiddenException, UnauthorizedException, ConflictException {
-        return request(dtoInterface, timeout, url, "POST", body, parameters);
+        return request(dtoInterface, timeout, url, HttpMethod.POST, body, parameters);
     }
 
     /**
@@ -264,12 +268,12 @@ public class HttpJsonHelper {
      */
     public static <DTO> DTO put(Class<DTO> dtoInterface, String url, Object body, Pair<String, ?>... parameters)
             throws IOException, ServerException, NotFoundException, ForbiddenException, UnauthorizedException, ConflictException {
-        return request(dtoInterface, url, "PUT", body, parameters);
+        return request(dtoInterface, url, HttpMethod.PUT, body, parameters);
     }
 
     public static <DTO> DTO put(Class<DTO> dtoInterface, int timeout, String url, Object body, Pair<String, ?>... parameters)
             throws IOException, ServerException, NotFoundException, ForbiddenException, UnauthorizedException, ConflictException {
-        return request(dtoInterface, timeout, url, "PUT", body, parameters);
+        return request(dtoInterface, timeout, url, HttpMethod.PUT, body, parameters);
     }
 
     /**
@@ -291,12 +295,12 @@ public class HttpJsonHelper {
      */
     public static <DTO> DTO options(Class<DTO> dtoInterface, String url, Pair<String, ?>... parameters)
             throws IOException, ServerException, NotFoundException, ForbiddenException, UnauthorizedException, ConflictException {
-        return request(dtoInterface, url, "OPTIONS", null, parameters);
+        return request(dtoInterface, url, HttpMethod.OPTIONS, null, parameters);
     }
 
     public static <DTO> DTO options(Class<DTO> dtoInterface, int timeout, String url, Pair<String, ?>... parameters)
             throws IOException, ServerException, NotFoundException, ForbiddenException, UnauthorizedException, ConflictException {
-        return request(dtoInterface, timeout, url, "OPTIONS", null, parameters);
+        return request(dtoInterface, timeout, url, HttpMethod.OPTIONS, null, parameters);
     }
 
     /**
@@ -318,12 +322,12 @@ public class HttpJsonHelper {
      */
     public static <DTO> DTO delete(Class<DTO> dtoInterface, String url, Pair<String, ?>... parameters)
             throws IOException, ServerException, NotFoundException, ForbiddenException, UnauthorizedException, ConflictException {
-        return request(dtoInterface, url, "DELETE", null, parameters);
+        return request(dtoInterface, url, HttpMethod.DELETE, null, parameters);
     }
 
     public static <DTO> DTO delete(Class<DTO> dtoInterface, int timeout, String url, Pair<String, ?>... parameters)
             throws IOException, ServerException, NotFoundException, ForbiddenException, UnauthorizedException, ConflictException {
-        return request(dtoInterface, timeout, url, "DELETE", null, parameters);
+        return request(dtoInterface, timeout, url, HttpMethod.DELETE, null, parameters);
     }
 
     private HttpJsonHelper() {
@@ -424,12 +428,12 @@ public class HttpJsonHelper {
             try {
                 conn.setRequestMethod(method);
                 if (body != null) {
-                    conn.addRequestProperty("content-type", "application/json");
+                    conn.addRequestProperty("content-type", MediaType.APPLICATION_JSON);
                     conn.setDoOutput(true);
 
-                    if ("DELETE".equals(method)) { //to avoid jdk bug described here http://bugs.java.com/view_bug.do?bug_id=7157360
-                        conn.setRequestMethod("POST");
-                        conn.setRequestProperty("X-HTTP-Method-Override", "DELETE");
+                    if (HttpMethod.DELETE.equals(method)) { //to avoid jdk bug described here http://bugs.java.com/view_bug.do?bug_id=7157360
+                        conn.setRequestMethod(HttpMethod.POST);
+                        conn.setRequestProperty("X-HTTP-Method-Override", HttpMethod.DELETE);
                     }
 
                     try (OutputStream output = conn.getOutputStream()) {
@@ -446,7 +450,7 @@ public class HttpJsonHelper {
                     final InputStream fIn = in;
                     final String str = CharStreams.toString(new InputStreamReader(fIn));
                     final String contentType = conn.getContentType();
-                    if (contentType != null && contentType.startsWith("application/json")) {
+                    if (contentType != null && contentType.startsWith(MediaType.APPLICATION_JSON)) {
                         final ServiceError serviceError = DtoFactory.getInstance().createDtoFromJson(str, ServiceError.class);
                         if (serviceError.getMessage() != null) {
                             if (responseCode == Response.Status.FORBIDDEN.getStatusCode()) {
@@ -468,7 +472,7 @@ public class HttpJsonHelper {
                                                         UriBuilder.fromUri(url).replaceQuery("token").build(), method, responseCode, str));
                 }
                 final String contentType = conn.getContentType();
-                if (!(contentType == null || contentType.startsWith("application/json"))) {
+                if (!(contentType == null || contentType.startsWith(MediaType.APPLICATION_JSON))) {
                     throw new IOException("We received an error response from the Codenvy server." +
                                           " Retry the request. If this issue continues, contact. support.");
                 }

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpServletProxyResponse.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpServletProxyResponse.java
@@ -13,6 +13,8 @@ package org.eclipse.che.api.core.rest;
 import org.eclipse.che.commons.lang.Pair;
 
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -45,7 +47,7 @@ public final class HttpServletProxyResponse implements HttpOutputMessage {
 
     @Override
     public void setContentType(String contentType) {
-        setHttpHeader("Content-Type", contentType);
+        setHttpHeader(HttpHeaders.CONTENT_TYPE, contentType);
     }
 
     @Override

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/RemoteServiceDescriptor.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/RemoteServiceDescriptor.java
@@ -28,6 +28,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.ws.rs.HttpMethod;
+
 /**
  * Provides basic functionality to access remote {@link Service Service}. Basically provides next information about {@code Service}:
  * <ul>
@@ -118,7 +120,7 @@ public class RemoteServiceDescriptor {
             conn = (HttpURLConnection)baseUrlURL.openConnection();
             conn.setConnectTimeout(3 * 1000);
             conn.setReadTimeout(10 * 1000);
-            conn.setRequestMethod("OPTIONS");
+            conn.setRequestMethod(HttpMethod.OPTIONS);
             int responseCode = conn.getResponseCode();
             LOG.debug("OPTIONS {} response {}", baseUrlURL, responseCode);
             return 200 == responseCode;

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/annotations/OPTIONS.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/annotations/OPTIONS.java
@@ -21,6 +21,6 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-@HttpMethod("OPTIONS")
+@HttpMethod(HttpMethod.OPTIONS)
 public @interface OPTIONS {
 }

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/annotations/Valid.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/annotations/Valid.java
@@ -49,7 +49,7 @@ import java.lang.annotation.Target;
  *       "href":"${base_uri}/echo/say",
  *       "produces":"plain/text",
  *       "rel":"message",
- *       "method":"GET",
+ *       "method":HttpMethod.GET,
  *       "parameters":[
  *         {
  *           "name":"message",

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/ContentTypeGuesser.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/ContentTypeGuesser.java
@@ -18,6 +18,8 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Properties;
 
+import javax.ws.rs.core.MediaType;
+
 /**
  * Helps getting content type of file.
  *
@@ -26,7 +28,7 @@ import java.util.Properties;
 public class ContentTypeGuesser {
     private static final Logger LOG = LoggerFactory.getLogger(ContentTypeGuesser.class);
 
-    private static String defaultContentType = "application/octet-stream";
+    private static String defaultContentType = MediaType.APPLICATION_OCTET_STREAM;
 
     public synchronized static void setDefaultContentType(String myDefaultContentType) {
         defaultContentType = myDefaultContentType;

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/HttpDownloadPlugin.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/HttpDownloadPlugin.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.api.core.util;
 
 import org.eclipse.che.commons.lang.NameGenerator;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +21,8 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.concurrent.TimeUnit;
+
+import javax.ws.rs.core.HttpHeaders;
 
 /**
  * DownloadPlugin that downloads single file.
@@ -45,7 +46,7 @@ public final class HttpDownloadPlugin implements DownloadPlugin {
             if (responseCode != 200) {
                 throw new IOException(String.format("Invalid response status %d from remote server. ", responseCode));
             }
-            final String contentDisposition = conn.getHeaderField("Content-Disposition");
+            final String contentDisposition = conn.getHeaderField(HttpHeaders.CONTENT_DISPOSITION);
             String fileName = null;
             if (contentDisposition != null) {
                 int fNameStart = contentDisposition.indexOf("filename=");

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/everrest/ETagResponseFilter.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/everrest/ETagResponseFilter.java
@@ -23,10 +23,12 @@ import org.everrest.core.GenericContainerResponse;
 import org.everrest.core.ResponseFilter;
 import org.everrest.core.impl.ApplicationContextImpl;
 
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
+
 import java.nio.charset.Charset;
 import java.util.List;
 
@@ -76,7 +78,7 @@ public class ETagResponseFilter implements ResponseFilter {
         Request request = applicationContext.getRequest();
 
         // manage only GET requests
-        if (!"GET".equals(request.getMethod())) {
+        if (!HttpMethod.GET.equals(request.getMethod())) {
             return;
         }
 

--- a/platform-api/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/ServiceDescriptorTest.java
+++ b/platform-api/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/ServiceDescriptorTest.java
@@ -18,7 +18,6 @@ import org.eclipse.che.api.core.rest.shared.ParameterType;
 import org.eclipse.che.api.core.rest.shared.dto.Link;
 import org.eclipse.che.api.core.rest.shared.dto.LinkParameter;
 import org.eclipse.che.api.core.rest.shared.dto.ServiceDescriptor;
-
 import org.everrest.core.ResourceBinder;
 import org.everrest.core.impl.ApplicationContextImpl;
 import org.everrest.core.impl.ApplicationProviderBinder;
@@ -35,10 +34,13 @@ import org.testng.annotations.Test;
 
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Application;
+import javax.ws.rs.core.MediaType;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -55,7 +57,7 @@ public class ServiceDescriptorTest {
         @GET
         @Path("my_method")
         @GenerateLink(rel = "echo")
-        @Produces("text/plain")
+        @Produces(MediaType.TEXT_PLAIN)
         public String echo(@Description("some text") @Required @Valid({"a", "b"}) @DefaultValue("a") @QueryParam("text") String test) {
             return test;
         }
@@ -114,9 +116,9 @@ public class ServiceDescriptorTest {
     @Test
     public void testLinkInfo() throws Exception {
         Link link = getLink("echo");
-        Assert.assertEquals(link.getMethod(), "GET");
+        Assert.assertEquals(link.getMethod(), HttpMethod.GET);
         Assert.assertEquals(link.getHref(), SERVICE_URI + "/my_method");
-        Assert.assertEquals(link.getProduces(), "text/plain");
+        Assert.assertEquals(link.getProduces(), MediaType.TEXT_PLAIN);
     }
 
     @Test
@@ -148,7 +150,7 @@ public class ServiceDescriptorTest {
 
     private ServiceDescriptor getDescriptor() throws Exception {
         String path = SERVICE_URI;
-        ContainerResponse response = launcher.service("OPTIONS", path, BASE_URI, null, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.OPTIONS, path, BASE_URI, null, null, null, null);
         Assert.assertEquals(response.getStatus(), 200);
         return (ServiceDescriptor)response.getEntity();
     }

--- a/platform-api/che-core-api-core/src/test/java/org/eclipse/che/everrest/ETagResponseFilterTest.java
+++ b/platform-api/che-core-api-core/src/test/java/org/eclipse/che/everrest/ETagResponseFilterTest.java
@@ -26,10 +26,13 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
+
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
@@ -85,7 +88,7 @@ public class ETagResponseFilterTest {
         @Produces(APPLICATION_JSON)
         public Response modifyHeader() {
             return Response.ok("helloContent")
-                           .header("Content-Disposition", "attachment; filename=my.json")
+                           .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=my.json")
                            .build();
         }
 
@@ -130,7 +133,7 @@ public class ETagResponseFilterTest {
     @Test
     public void filterListEntityTest() throws Exception {
 
-        final ContainerResponse response = resourceLauncher.service("GET", SERVICE_PATH + "/list", BASE_URI, null, null, null);
+        final ContainerResponse response = resourceLauncher.service(HttpMethod.GET, SERVICE_PATH + "/list", BASE_URI, null, null, null);
         assertEquals(response.getStatus(), OK.getStatusCode());
         // check entity
         Assert.assertEquals(response.getEntity(), Arrays.asList("a", "b", "c"));
@@ -147,7 +150,7 @@ public class ETagResponseFilterTest {
     @Test
     public void useExistingHeaders() throws Exception {
 
-        final ContainerResponse response = resourceLauncher.service("GET", SERVICE_PATH + "/modify", BASE_URI, null, null, null);
+        final ContainerResponse response = resourceLauncher.service(HttpMethod.GET, SERVICE_PATH + "/modify", BASE_URI, null, null, null);
         assertEquals(response.getStatus(), OK.getStatusCode());
         // check entity
         Assert.assertEquals(response.getEntity(), "helloContent");
@@ -156,7 +159,7 @@ public class ETagResponseFilterTest {
         Assert.assertEquals(response.getHttpHeaders().keySet().size(), 3);
 
         // Check custom header
-        List<Object> customTags = response.getHttpHeaders().get("Content-Disposition");
+        List<Object> customTags = response.getHttpHeaders().get(HttpHeaders.CONTENT_DISPOSITION);
         Assert.assertNotNull(customTags);
         Assert.assertEquals(customTags.size(), 1);
         Assert.assertEquals(customTags.get(0), "attachment; filename=my.json");
@@ -174,7 +177,7 @@ public class ETagResponseFilterTest {
     @Test
     public void filterSingleEntityTest() throws Exception {
 
-        final ContainerResponse response = resourceLauncher.service("GET", SERVICE_PATH + "/single", BASE_URI, null, null, null);
+        final ContainerResponse response = resourceLauncher.service(HttpMethod.GET, SERVICE_PATH + "/single", BASE_URI, null, null, null);
         assertEquals(response.getStatus(), OK.getStatusCode());
         // check entity
         Assert.assertEquals(response.getEntity(), "hello");
@@ -197,7 +200,7 @@ public class ETagResponseFilterTest {
         headers.put("If-None-Match", Collections.singletonList(new EntityTag("900150983cd24fb0d6963f7d28e17f72").toString()));
 
 
-        final ContainerResponse response = resourceLauncher.service("GET", SERVICE_PATH + "/list", BASE_URI, headers, null, null);
+        final ContainerResponse response = resourceLauncher.service(HttpMethod.GET, SERVICE_PATH + "/list", BASE_URI, headers, null, null);
         assertEquals(response.getStatus(), NOT_MODIFIED.getStatusCode());
         // check null body
         Assert.assertNull(response.getEntity());
@@ -213,7 +216,7 @@ public class ETagResponseFilterTest {
         headers.put("If-None-Match", Collections.singletonList(new EntityTag("5d41402abc4b2a76b9719d911017c592").toString()));
 
 
-        final ContainerResponse response = resourceLauncher.service("GET", SERVICE_PATH + "/single", BASE_URI, headers, null, null);
+        final ContainerResponse response = resourceLauncher.service(HttpMethod.GET, SERVICE_PATH + "/single", BASE_URI, headers, null, null);
         assertEquals(response.getStatus(), NOT_MODIFIED.getStatusCode());
         // check null body
         Assert.assertNull(response.getEntity());

--- a/platform-api/che-core-api-docs/src/main/java/org/eclipse/che/docs/DocsModule.java
+++ b/platform-api/che-core-api-docs/src/main/java/org/eclipse/che/docs/DocsModule.java
@@ -30,6 +30,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 
 /**
  * @author andrew00x
@@ -78,7 +79,7 @@ public class DocsModule extends AbstractModule {
     }
 
     @Path("/docs")
-    @Produces("application/json")
+    @Produces(MediaType.APPLICATION_JSON)
     public static class CodenvyApiDocsService extends ApiListingResource {
     }
 

--- a/platform-api/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/FactoryService.java
+++ b/platform-api/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/FactoryService.java
@@ -61,6 +61,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -68,10 +69,12 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -417,7 +420,7 @@ public class FactoryService extends Service {
         List<Factory> factories = factoryStore.findByAttribute(pairs.toArray(new Pair[pairs.size()]));
         for (Factory factory : factories) {
             result.add(DtoFactory.getInstance().createDto(Link.class)
-                                 .withMethod("GET")
+                                 .withMethod(HttpMethod.GET)
                                  .withRel("self")
                                  .withProduces(MediaType.APPLICATION_JSON)
                                  .withConsumes(null)
@@ -575,7 +578,7 @@ public class FactoryService extends Service {
             Map<String, AttributeValue> attributes = projectDescription.getAttributes();
             if (attributes.containsKey("vcs.provider.name") && attributes.get("vcs.provider.name").getList().contains("git")) {
                 final Link importSourceLink = dtoFactory.createDto(Link.class)
-                                                        .withMethod("GET")
+                                                        .withMethod(HttpMethod.GET)
                                                         .withHref(UriBuilder.fromUri(baseApiUrl)
                                                                             .path("git")
                                                                             .path(workspace)
@@ -614,7 +617,7 @@ public class FactoryService extends Service {
                                      .withProject(newProject)
                                      .withSource(dtoFactory.createDto(Source.class).withProject(source))
                                      .withV("2.1"), MediaType.APPLICATION_JSON)
-                       .header("Content-Disposition", "attachment; filename=" + path + ".json")
+                       .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + path + ".json")
                        .build();
     }
 

--- a/platform-api/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/LinksHelper.java
+++ b/platform-api/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/LinksHelper.java
@@ -13,11 +13,12 @@ package org.eclipse.che.api.factory;
 import org.eclipse.che.api.core.rest.shared.dto.Link;
 import org.eclipse.che.api.core.rest.shared.dto.LinkParameter;
 import org.eclipse.che.api.factory.dto.Factory;
-
 import org.eclipse.che.dto.server.DtoFactory;
 
 import javax.inject.Singleton;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.*;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.*;
@@ -44,30 +45,30 @@ public class LinksHelper {
         Link createProject;
 
         // uri to retrieve factory
-        links.add(createLink("GET", "self", null, MediaType.APPLICATION_JSON,
+        links.add(createLink(HttpMethod.GET, "self", null, MediaType.APPLICATION_JSON,
                              factoryUriBuilder.clone().path(FactoryService.class, "getFactory").build(factoryId).toString(), null));
 
         // uri's to retrieve images
         for (FactoryImage image : images) {
-            links.add(createLink("GET", "image", null, image.getMediaType(),
+            links.add(createLink(HttpMethod.GET, "image", null, image.getMediaType(),
                                  factoryUriBuilder.clone().path(FactoryService.class, "getImage").queryParam("imgId", image.getName())
                                                   .build(factoryId).toString(), null));
         }
 
         // uri's of snippets
         for (String snippetType : snippetTypes) {
-            links.add(createLink("GET", "snippet/" + snippetType, null, MediaType.TEXT_PLAIN,
+            links.add(createLink(HttpMethod.GET, "snippet/" + snippetType, null, MediaType.TEXT_PLAIN,
                                  factoryUriBuilder.clone().path(FactoryService.class, "getFactorySnippet").queryParam("type", snippetType)
                                                   .build(factoryId).toString(), null));
         }
 
         // uri to accept factory
-        createProject = createLink("GET", "create-project", null, MediaType.TEXT_HTML,
+        createProject = createLink(HttpMethod.GET, "create-project", null, MediaType.TEXT_HTML,
                                    baseUriBuilder.clone().replacePath("f").queryParam("id", factoryId).build().toString(), null);
         links.add(createProject);
 
         // links of analytics
-        links.add(createLink("GET", "accepted", null, MediaType.TEXT_PLAIN,
+        links.add(createLink(HttpMethod.GET, "accepted", null, MediaType.TEXT_PLAIN,
                              baseUriBuilder.clone().path("analytics").path("public-metric/factory_used")
                                            .queryParam("factory", URLEncoder.encode(createProject.getHref(), "UTF-8")).build().toString(),
                              null));

--- a/platform-api/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/FactoryServiceTest.java
+++ b/platform-api/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/FactoryServiceTest.java
@@ -49,7 +49,9 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.MediaType;
+
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -242,7 +244,7 @@ public class FactoryServiceTest {
 
 
         Link expectedCreateProject =
-                dto.createDto(Link.class).withMethod("GET").withProduces("text/html").withRel("create-project")
+                dto.createDto(Link.class).withMethod(HttpMethod.GET).withProduces("text/html").withRel("create-project")
                    .withHref(getServerUrl(context) + "/f?id=" + CORRECT_FACTORY_ID);
 
         FactorySaveAnswer factorySaveAnswer = new FactorySaveAnswer();
@@ -259,29 +261,29 @@ public class FactoryServiceTest {
         assertEquals(response.getStatusCode(), 200);
         Factory responseFactoryUrl = dto.createDtoFromJson(response.getBody().asString(), Factory.class);
         assertTrue(responseFactoryUrl.getLinks().contains(
-                dto.createDto(Link.class).withMethod("GET").withProduces("application/json")
+                dto.createDto(Link.class).withMethod(HttpMethod.GET).withProduces(MediaType.APPLICATION_JSON)
                    .withHref(getServerUrl(context) + "/rest/private/factory/" +
                              CORRECT_FACTORY_ID).withRel("self")
                                                          ));
         assertTrue(responseFactoryUrl.getLinks().contains(expectedCreateProject));
         assertTrue(responseFactoryUrl.getLinks()
-                                     .contains(dto.createDto(Link.class).withMethod("GET").withProduces("text/plain")
+                                     .contains(dto.createDto(Link.class).withMethod(HttpMethod.GET).withProduces(MediaType.TEXT_PLAIN)
                                                   .withHref(getServerUrl(context) +
                                                             "/rest/private/analytics/public-metric/factory_used?factory=" +
                                                             encode(expectedCreateProject.getHref(), "UTF-8"))
                                                   .withRel("accepted")));
         assertTrue(responseFactoryUrl.getLinks()
-                                     .contains(dto.createDto(Link.class).withMethod("GET").withProduces("text/plain")
+                                     .contains(dto.createDto(Link.class).withMethod(HttpMethod.GET).withProduces(MediaType.TEXT_PLAIN)
                                                   .withHref(getServerUrl(context) + "/rest/private/factory/" +
                                                             CORRECT_FACTORY_ID + "/snippet?type=url")
                                                   .withRel("snippet/url")));
         assertTrue(responseFactoryUrl.getLinks()
-                                     .contains(dto.createDto(Link.class).withMethod("GET").withProduces("text/plain")
+                                     .contains(dto.createDto(Link.class).withMethod(HttpMethod.GET).withProduces(MediaType.TEXT_PLAIN)
                                                   .withHref(getServerUrl(context) + "/rest/private/factory/" +
                                                             CORRECT_FACTORY_ID + "/snippet?type=html")
                                                   .withRel("snippet/html")));
         assertTrue(responseFactoryUrl.getLinks()
-                                     .contains(dto.createDto(Link.class).withMethod("GET").withProduces("text/plain")
+                                     .contains(dto.createDto(Link.class).withMethod(HttpMethod.GET).withProduces(MediaType.TEXT_PLAIN)
                                                   .withHref(getServerUrl(context) + "/rest/private/factory/" +
                                                             CORRECT_FACTORY_ID + "/snippet?type=markdown")
                                                   .withRel("snippet/markdown")));
@@ -291,49 +293,49 @@ public class FactoryServiceTest {
         expectedLinks.add(expectedCreateProject);
 
         Link self = dto.createDto(Link.class);
-        self.setMethod("GET");
-        self.setProduces("application/json");
+        self.setMethod(HttpMethod.GET);
+        self.setProduces(MediaType.APPLICATION_JSON);
         self.setHref(getServerUrl(context) + "/rest/private/factory/" + CORRECT_FACTORY_ID);
         self.setRel("self");
         expectedLinks.add(self);
 
         Link accepted = dto.createDto(Link.class);
-        accepted.setMethod("GET");
-        accepted.setProduces("text/plain");
+        accepted.setMethod(HttpMethod.GET);
+        accepted.setProduces(MediaType.TEXT_PLAIN);
         accepted.setHref(getServerUrl(context) + "/rest/private/analytics/public-metric/factory_used?factory=" +
                          encode(expectedCreateProject.getHref(), "UTF-8"));
         accepted.setRel("accepted");
         expectedLinks.add(accepted);
 
         Link snippetUrl = dto.createDto(Link.class);
-        snippetUrl.setProduces("text/plain");
+        snippetUrl.setProduces(MediaType.TEXT_PLAIN);
         snippetUrl.setHref(getServerUrl(context) + "/rest/private/factory/" + CORRECT_FACTORY_ID + "/snippet?type=url");
         snippetUrl.setRel("snippet/url");
-        snippetUrl.setMethod("GET");
+        snippetUrl.setMethod(HttpMethod.GET);
         expectedLinks.add(snippetUrl);
 
         Link snippetHtml = dto.createDto(Link.class);
-        snippetHtml.setProduces("text/plain");
+        snippetHtml.setProduces(MediaType.TEXT_PLAIN);
         snippetHtml.setHref(getServerUrl(context) + "/rest/private/factory/" + CORRECT_FACTORY_ID +
                             "/snippet?type=html");
-        snippetHtml.setMethod("GET");
+        snippetHtml.setMethod(HttpMethod.GET);
         snippetHtml.setRel("snippet/html");
         expectedLinks.add(snippetHtml);
 
         Link snippetMarkdown = dto.createDto(Link.class);
-        snippetMarkdown.setProduces("text/plain");
+        snippetMarkdown.setProduces(MediaType.TEXT_PLAIN);
         snippetMarkdown.setHref(getServerUrl(context) + "/rest/private/factory/" + CORRECT_FACTORY_ID +
                                 "/snippet?type=markdown");
         snippetMarkdown.setRel("snippet/markdown");
-        snippetMarkdown.setMethod("GET");
+        snippetMarkdown.setMethod(HttpMethod.GET);
         expectedLinks.add(snippetMarkdown);
 
         Link snippetiFrame = dto.createDto(Link.class);
-        snippetiFrame.setProduces("text/plain");
+        snippetiFrame.setProduces(MediaType.TEXT_PLAIN);
         snippetiFrame.setHref(getServerUrl(context) + "/rest/private/factory/" + CORRECT_FACTORY_ID +
                               "/snippet?type=iframe");
         snippetiFrame.setRel("snippet/iframe");
-        snippetiFrame.setMethod("GET");
+        snippetiFrame.setMethod(HttpMethod.GET);
         expectedLinks.add(snippetiFrame);
 
         for (Link link : responseFactoryUrl.getLinks()) {
@@ -342,7 +344,7 @@ public class FactoryServiceTest {
             testLink.setProduces(link.getProduces());
             testLink.setHref(link.getHref());
             testLink.setRel(link.getRel());
-            testLink.setMethod("GET");
+            testLink.setMethod(HttpMethod.GET);
             assertTrue(expectedLinks.contains(testLink));
         }
 
@@ -465,7 +467,7 @@ public class FactoryServiceTest {
         expectedLinks.add(expectedCreateProject);
 
         Link self = dto.createDto(Link.class);
-        self.setProduces("application/json");
+        self.setProduces(MediaType.APPLICATION_JSON);
         self.setHref(getServerUrl(context) + "/rest/factory/" + CORRECT_FACTORY_ID);
         self.setRel("self");
         expectedLinks.add(self);
@@ -484,33 +486,33 @@ public class FactoryServiceTest {
         expectedLinks.add(imagePng);
 
         Link accepted = dto.createDto(Link.class);
-        accepted.setProduces("text/plain");
+        accepted.setProduces(MediaType.TEXT_PLAIN);
         accepted.setHref(getServerUrl(context) + "/rest/analytics/public-metric/factory_used?factory=" +
                          encode(expectedCreateProject.getHref(), "UTF-8"));
         accepted.setRel("accepted");
         expectedLinks.add(accepted);
 
         Link snippetUrl = dto.createDto(Link.class);
-        snippetUrl.setProduces("text/plain");
+        snippetUrl.setProduces(MediaType.TEXT_PLAIN);
         snippetUrl.setHref(getServerUrl(context) + "/rest/factory/" + CORRECT_FACTORY_ID + "/snippet?type=url");
         snippetUrl.setRel("snippet/url");
         expectedLinks.add(snippetUrl);
 
         Link snippetHtml = dto.createDto(Link.class);
-        snippetHtml.setProduces("text/plain");
+        snippetHtml.setProduces(MediaType.TEXT_PLAIN);
         snippetHtml.setHref(getServerUrl(context) + "/rest/factory/" + CORRECT_FACTORY_ID + "/snippet?type=html");
         snippetHtml.setRel("snippet/html");
         expectedLinks.add(snippetHtml);
 
         Link snippetMarkdown = dto.createDto(Link.class);
-        snippetMarkdown.setProduces("text/plain");
+        snippetMarkdown.setProduces(MediaType.TEXT_PLAIN);
         snippetMarkdown.setHref(getServerUrl(context) + "/rest/factory/" + CORRECT_FACTORY_ID +
                                 "/snippet?type=markdown");
         snippetMarkdown.setRel("snippet/markdown");
         expectedLinks.add(snippetMarkdown);
 
         Link snippetiFrame = dto.createDto(Link.class);
-        snippetiFrame.setProduces("text/plain");
+        snippetiFrame.setProduces(MediaType.TEXT_PLAIN);
         snippetiFrame.setHref(getServerUrl(context) + "/rest/factory/" + CORRECT_FACTORY_ID +
                               "/snippet?type=iframe");
         snippetiFrame.setRel("snippet/iframe");
@@ -913,7 +915,7 @@ public class FactoryServiceTest {
         // when, then
         Response response =
                 given().auth().basic(JettyHttpServer.ADMIN_USER_NAME, JettyHttpServer.ADMIN_USER_PASSWORD).//
-                        contentType("application/json").
+                        contentType(MediaType.APPLICATION_JSON).
                                body(JsonHelper.toJson(afterFactory)).
                                when().//
                         put("/private" + SERVICE_PATH + "/" + CORRECT_FACTORY_ID);
@@ -951,7 +953,7 @@ public class FactoryServiceTest {
         // when, then
         Response response =
                 given().auth().basic(JettyHttpServer.ADMIN_USER_NAME, JettyHttpServer.ADMIN_USER_PASSWORD).//
-                        contentType("application/json").
+                        contentType(MediaType.APPLICATION_JSON).
                                body(JsonHelper.toJson(testFactory)).
                                when().//
                         put("/private" + SERVICE_PATH + "/" + ILLEGAL_FACTORY_ID);
@@ -975,7 +977,7 @@ public class FactoryServiceTest {
         // when, then
         Response response =
                 given().auth().basic(JettyHttpServer.ADMIN_USER_NAME, JettyHttpServer.ADMIN_USER_PASSWORD).//
-                        contentType("application/json").
+                        contentType(MediaType.APPLICATION_JSON).
                                when().//
                         put("/private" + SERVICE_PATH + "/" + ILLEGAL_FACTORY_ID);
         assertEquals(response.getStatusCode(), 500);

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/DtoConverter.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/DtoConverter.java
@@ -32,18 +32,20 @@ import org.eclipse.che.api.project.shared.dto.ProjectTypeDefinition;
 import org.eclipse.che.api.project.shared.dto.ProjectUpdate;
 import org.eclipse.che.api.project.shared.dto.RunnerConfiguration;
 import org.eclipse.che.api.project.shared.dto.RunnersDescriptor;
-
 import org.eclipse.che.api.project.server.type.Attribute;
 import org.eclipse.che.api.project.server.type.BaseProjectType;
 import org.eclipse.che.api.project.server.type.ProjectTypeRegistry;
 import org.eclipse.che.api.vfs.shared.dto.AccessControlEntry;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.lang.ws.rs.ExtMediaType;
 import org.eclipse.che.commons.user.User;
 import org.eclipse.che.dto.server.DtoFactory;
 
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
+
 import java.util.*;
 
 /**
@@ -427,11 +429,11 @@ public class DtoConverter {
         final String relPath = project.getPath().substring(1);
         final String workspace = project.getWorkspace();
         links.add(
-                LinksHelper.createLink("PUT",
+                LinksHelper.createLink(HttpMethod.PUT,
                                        uriBuilder.clone().path(ProjectService.class, "updateProject").build(workspace, relPath).toString(),
                                        MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON, Constants.LINK_REL_UPDATE_PROJECT));
         links.add(
-                LinksHelper.createLink("GET",
+                LinksHelper.createLink(HttpMethod.GET,
                                        uriBuilder.clone().path(ProjectService.class, "getRunnerEnvironments").build(workspace, relPath)
                                                  .toString(),
                                        MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON, Constants.LINK_REL_GET_RUNNER_ENVIRONMENTS));
@@ -443,19 +445,19 @@ public class DtoConverter {
         final String workspace = folder.getWorkspace();
         final String relPath = folder.getPath().substring(1);
         //String method, String href, String produces, String rel
-        links.add(LinksHelper.createLink("GET",
+        links.add(LinksHelper.createLink(HttpMethod.GET,
                                          uriBuilder.clone().path(ProjectService.class, "exportZip").build(workspace, relPath).toString(),
-                                         "application/zip", Constants.LINK_REL_EXPORT_ZIP));
-        links.add(LinksHelper.createLink("GET",
+                                         ExtMediaType.APPLICATION_ZIP, Constants.LINK_REL_EXPORT_ZIP));
+        links.add(LinksHelper.createLink(HttpMethod.GET,
                                          uriBuilder.clone().path(ProjectService.class, "getChildren").build(workspace, relPath).toString(),
                                          MediaType.APPLICATION_JSON, Constants.LINK_REL_CHILDREN));
         links.add(
-                LinksHelper.createLink("GET", uriBuilder.clone().path(ProjectService.class, "getTree").build(workspace, relPath).toString(),
+                LinksHelper.createLink(HttpMethod.GET, uriBuilder.clone().path(ProjectService.class, "getTree").build(workspace, relPath).toString(),
                                        null, MediaType.APPLICATION_JSON, Constants.LINK_REL_TREE));
-        links.add(LinksHelper.createLink("GET",
+        links.add(LinksHelper.createLink(HttpMethod.GET,
                                          uriBuilder.clone().path(ProjectService.class, "getModules").build(workspace, relPath).toString(),
                                          MediaType.APPLICATION_JSON, Constants.LINK_REL_MODULES));
-        links.add(LinksHelper.createLink("DELETE",
+        links.add(LinksHelper.createLink(HttpMethod.DELETE,
                                          uriBuilder.clone().path(ProjectService.class, "delete").build(workspace, relPath).toString(),
                                          Constants.LINK_REL_DELETE));
         return links;
@@ -466,12 +468,12 @@ public class DtoConverter {
         final String workspace = file.getWorkspace();
         final String relPath = file.getPath().substring(1);
         links.add(
-                LinksHelper.createLink("GET", uriBuilder.clone().path(ProjectService.class, "getFile").build(workspace, relPath).toString(),
+                LinksHelper.createLink(HttpMethod.GET, uriBuilder.clone().path(ProjectService.class, "getFile").build(workspace, relPath).toString(),
                                        null, file.getMediaType(), Constants.LINK_REL_GET_CONTENT));
-        links.add(LinksHelper.createLink("PUT",
+        links.add(LinksHelper.createLink(HttpMethod.PUT,
                                          uriBuilder.clone().path(ProjectService.class, "updateFile").build(workspace, relPath).toString(),
                                          MediaType.WILDCARD, null, Constants.LINK_REL_UPDATE_CONTENT));
-        links.add(LinksHelper.createLink("DELETE",
+        links.add(LinksHelper.createLink(HttpMethod.DELETE,
                                          uriBuilder.clone().path(ProjectService.class, "delete").build(workspace, relPath).toString(),
                                          Constants.LINK_REL_DELETE));
         return links;

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/Project.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/Project.java
@@ -22,7 +22,6 @@ import org.eclipse.che.api.project.server.type.Variable;
 import org.eclipse.che.api.project.shared.Builders;
 import org.eclipse.che.api.project.shared.Runners;
 import org.eclipse.che.api.project.shared.dto.SourceEstimation;
-
 import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.shared.dto.AccessControlEntry;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
@@ -43,6 +42,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+
+import javax.ws.rs.core.MediaType;
 
 /**
  * Server side representation for codenvy project.
@@ -457,7 +458,7 @@ public class Project {
             file = baseFolder.getChild(MODULES_PATH);
 
             if (file == null && !modules.isEmpty())
-                file = ((FolderEntry)baseFolder.getChild(".codenvy")).createFile("modules", new byte[0], "text/plain");
+                file = ((FolderEntry)baseFolder.getChild(".codenvy")).createFile("modules", new byte[0], MediaType.TEXT_PLAIN);
 
 //                if(modules.isEmpty() && file != null)
 //                    file.remove();

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
@@ -47,7 +47,6 @@ import org.eclipse.che.api.project.shared.dto.RunnerSource;
 import org.eclipse.che.api.project.shared.dto.Source;
 import org.eclipse.che.api.project.shared.dto.SourceEstimation;
 import org.eclipse.che.api.project.shared.dto.TreeElement;
-
 import org.eclipse.che.api.vfs.server.ContentStream;
 import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.server.VirtualFileSystemImpl;
@@ -56,7 +55,9 @@ import org.eclipse.che.api.vfs.server.search.SearcherProvider;
 import org.eclipse.che.api.vfs.shared.dto.AccessControlEntry;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.lang.ws.rs.ExtMediaType;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
@@ -87,6 +88,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -103,6 +105,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+
 import org.eclipse.che.api.project.shared.dto.CopyOptions;
 import org.eclipse.che.api.project.shared.dto.MoveOptions;
 
@@ -1135,7 +1138,7 @@ public class ProjectService extends Service {
             @ApiResponse(code = 500, message = "Internal Server Error")})
     @POST
     @Path("/import/{path:.*}")
-    @Consumes("application/zip")
+    @Consumes(ExtMediaType.APPLICATION_ZIP)
     public Response importZip(@ApiParam(value = "Workspace ID", required = true)
                               @PathParam("ws-id") String workspace,
                               @ApiParam(value = "Path to a location (where import to?)")
@@ -1166,7 +1169,7 @@ public class ProjectService extends Service {
             @ApiResponse(code = 500, message = "Internal Server Error")})
     @GET
     @Path("/export/{path:.*}")
-    @Produces("application/zip")
+    @Produces(ExtMediaType.APPLICATION_ZIP)
     public ContentStream exportZip(@ApiParam(value = "Workspace ID", required = true)
                                    @PathParam("ws-id") String workspace,
                                    @ApiParam(value = "Path to resource to be imported")
@@ -1179,7 +1182,7 @@ public class ProjectService extends Service {
     @POST
     @Path("/export/{path:.*}")
     @Consumes(MediaType.TEXT_PLAIN)
-    @Produces("application/zip")
+    @Produces(ExtMediaType.APPLICATION_ZIP)
     public Response exportDiffZip(@PathParam("ws-id") String workspace, @PathParam("path") String path, InputStream in)
             throws NotFoundException, ForbiddenException, ServerException {
         final FolderEntry folder = asFolder(workspace, path);

--- a/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/FileEntryTest.java
+++ b/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/FileEntryTest.java
@@ -15,6 +15,7 @@ import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.server.VirtualFileSystemUser;
 import org.eclipse.che.api.vfs.server.VirtualFileSystemUserContext;
 import org.eclipse.che.api.vfs.server.impl.memory.MemoryMountPoint;
+
 import com.google.common.io.ByteStreams;
 
 import org.testng.Assert;
@@ -26,6 +27,8 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
+
+import javax.ws.rs.core.MediaType;
 
 /**
  * @author andrew00x
@@ -51,7 +54,7 @@ public class FileEntryTest {
         VirtualFile myVfRoot = mmp.getRoot();
         myVfProject = myVfRoot.createFolder("my_project");
         myVfProject.createFolder(".codenvy").createFile("project", null, null);
-        myVfFile = myVfProject.createFile("test", "text/plain", new ByteArrayInputStream("to be or not to be".getBytes()));
+        myVfFile = myVfProject.createFile("test", MediaType.TEXT_PLAIN, new ByteArrayInputStream("to be or not to be".getBytes()));
         myFile = new FileEntry(workspace, myVfFile);
         Assert.assertTrue(myFile.isFile());
     }

--- a/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/FolderEntryTest.java
+++ b/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/FolderEntryTest.java
@@ -15,7 +15,6 @@ import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.server.VirtualFileSystemUser;
 import org.eclipse.che.api.vfs.server.VirtualFileSystemUserContext;
 import org.eclipse.che.api.vfs.server.impl.memory.MemoryMountPoint;
-
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -24,6 +23,8 @@ import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.Set;
+
+import javax.ws.rs.core.MediaType;
 
 /**
  * @author andrew00x
@@ -50,7 +51,7 @@ public class FolderEntryTest {
         myVfProject = myVfRoot.createFolder("my_project");
         myVfProject.createFolder(".codenvy").createFile("project", null, null);
         myVfFolder = myVfProject.createFolder("test_folder");
-        myVfFolder.createFile("child_file", "text/plain", new ByteArrayInputStream("to be or not to be".getBytes()));
+        myVfFolder.createFile("child_file", MediaType.TEXT_PLAIN, new ByteArrayInputStream("to be or not to be".getBytes()));
         myVfFolder.createFolder("child_folder");
         myFolder = new FolderEntry(workspace, myVfFolder);
         Assert.assertTrue(myFolder.isFolder());

--- a/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectEventTest.java
+++ b/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectEventTest.java
@@ -96,7 +96,7 @@ public class ProjectEventTest {
 //            }
 //        }));
 //
-//        pm.getProject("my_ws", "my_project").getBaseFolder().createFile("test.txt", "test".getBytes(), "text/plain");
+//        pm.getProject("my_ws", "my_project").getBaseFolder().createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
 //        Assert.assertEquals(events.size(), 1);
 //        Assert.assertEquals(events.get(0).getType(), ProjectEvent.EventType.CREATED);
 //        Assert.assertFalse(events.get(0).isFolder());
@@ -125,7 +125,7 @@ public class ProjectEventTest {
 //
 //    @Test
 //    public void testUpdateFile() throws Exception {
-//        FileEntry file = pm.getProject("my_ws", "my_project").getBaseFolder().createFile("test.txt", "test".getBytes(), "text/plain");
+//        FileEntry file = pm.getProject("my_ws", "my_project").getBaseFolder().createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
 //        final List<ProjectEvent> events = new ArrayList<>();
 //        Assert.assertTrue(projectEventService.addListener("my_ws", "my_project", new ProjectEventListener() {
 //            @Override
@@ -144,7 +144,7 @@ public class ProjectEventTest {
 //
 //    @Test
 //    public void testDelete() throws Exception {
-//        FileEntry file = pm.getProject("my_ws", "my_project").getBaseFolder().createFile("test.txt", "test".getBytes(), "text/plain");
+//        FileEntry file = pm.getProject("my_ws", "my_project").getBaseFolder().createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
 //        final List<ProjectEvent> events = new ArrayList<>();
 //        Assert.assertTrue(projectEventService.addListener("my_ws", "my_project", new ProjectEventListener() {
 //            @Override
@@ -163,7 +163,7 @@ public class ProjectEventTest {
 //
 //    @Test
 //    public void testMove() throws Exception {
-//        FileEntry file = pm.getProject("my_ws", "my_project").getBaseFolder().createFile("test.txt", "test".getBytes(), "text/plain");
+//        FileEntry file = pm.getProject("my_ws", "my_project").getBaseFolder().createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
 //        FolderEntry folder = pm.getProject("my_ws", "my_project").getBaseFolder().createFolder("a/b/c");
 //        final List<ProjectEvent> events = new ArrayList<>();
 //        Assert.assertTrue(projectEventService.addListener("my_ws", "my_project", new ProjectEventListener() {
@@ -188,7 +188,7 @@ public class ProjectEventTest {
 //
 //    @Test
 //    public void testRename() throws Exception {
-//        FileEntry file = pm.getProject("my_ws", "my_project").getBaseFolder().createFile("test.txt", "test".getBytes(), "text/plain");
+//        FileEntry file = pm.getProject("my_ws", "my_project").getBaseFolder().createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
 //        final List<ProjectEvent> events = new ArrayList<>();
 //        Assert.assertTrue(projectEventService.addListener("my_ws", "my_project", new ProjectEventListener() {
 //            @Override

--- a/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
+++ b/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
@@ -57,6 +57,7 @@ import org.eclipse.che.api.vfs.shared.dto.AccessControlEntry;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo;
 import org.eclipse.che.commons.json.JsonHelper;
+import org.eclipse.che.commons.lang.ws.rs.ExtMediaType;
 import org.eclipse.che.commons.user.UserImpl;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.everrest.core.ResourceBinder;
@@ -80,7 +81,11 @@ import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.Application;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -98,6 +103,7 @@ import java.util.Scanner;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
 import org.eclipse.che.api.project.shared.dto.CopyOptions;
 import org.eclipse.che.api.project.shared.dto.MoveOptions;
 
@@ -241,7 +247,7 @@ public class ProjectServiceTest {
 
 
         ContainerResponse response =
-                launcher.service("GET", "http://localhost:8080/api/project/my_ws", "http://localhost:8080/api", null, null, null);
+                launcher.service(HttpMethod.GET, "http://localhost:8080/api/project/my_ws", "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
         List<ProjectReference> result = (List<ProjectReference>)response.getEntity();
         assertNotNull(result);
@@ -290,7 +296,7 @@ public class ProjectServiceTest {
         module.updateConfig(config);
         myProject.getModules().add("my_module");
 
-        ContainerResponse response = launcher.service("GET",
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format("http://localhost:8080/api/project/%s/modules/my_project", workspace),
                                                       "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
@@ -350,7 +356,7 @@ public class ProjectServiceTest {
             }
         });
 
-        ContainerResponse response = launcher.service("GET",
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format("http://localhost:8080/api/project/%s/modules/my_project", workspace),
                                                       "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
@@ -368,7 +374,7 @@ public class ProjectServiceTest {
 
     @Test
     public void testGetProject() throws Exception {
-        ContainerResponse response = launcher.service("GET", String.format("http://localhost:8080/api/project/%s/my_project", workspace),
+        ContainerResponse response = launcher.service(HttpMethod.GET, String.format("http://localhost:8080/api/project/%s/my_project", workspace),
                                                       "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
         ProjectDescriptor result = (ProjectDescriptor)response.getEntity();
@@ -390,7 +396,7 @@ public class ProjectServiceTest {
     public void testGetNotValidProject() throws Exception {
         MountPoint mountPoint = pm.getProjectsRoot(workspace).getVirtualFile().getMountPoint();
         mountPoint.getRoot().createFolder("not_project");
-        ContainerResponse response = launcher.service("GET", String.format("http://localhost:8080/api/project/%s/not_project", workspace),
+        ContainerResponse response = launcher.service(HttpMethod.GET, String.format("http://localhost:8080/api/project/%s/not_project", workspace),
                                                       "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
         ProjectDescriptor badProject = (ProjectDescriptor)response.getEntity();
@@ -411,7 +417,7 @@ public class ProjectServiceTest {
     public void testGetProjectCheckUserPermissions() throws Exception {
         // Without roles Collections.<String>emptySet() should get default set of permissions
         env.setUser(new UserImpl(vfsUser, vfsUser, "dummy_token", Collections.<String>emptySet(), false));
-        ContainerResponse response = launcher.service("GET", String.format("http://localhost:8080/api/project/%s/my_project", workspace),
+        ContainerResponse response = launcher.service(HttpMethod.GET, String.format("http://localhost:8080/api/project/%s/my_project", workspace),
                                                       "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
         ProjectDescriptor result = (ProjectDescriptor)response.getEntity();
@@ -441,7 +447,7 @@ public class ProjectServiceTest {
         module.updateConfig(config);
 
         ContainerResponse response =
-                launcher.service("GET", String.format("http://localhost:8080/api/project/%s/my_project/my_module", workspace),
+                launcher.service(HttpMethod.GET, String.format("http://localhost:8080/api/project/%s/my_project/my_module", workspace),
                                  "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
         ProjectDescriptor result = (ProjectDescriptor)response.getEntity();
@@ -461,7 +467,7 @@ public class ProjectServiceTest {
 
     @Test
     public void testGetProjectInvalidPath() throws Exception {
-        ContainerResponse response = launcher.service("GET",
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format("http://localhost:8080/api/project/%s/my_project_invalid", workspace),
                                                       "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 404);
@@ -479,7 +485,7 @@ public class ProjectServiceTest {
             public void onCreateProject(FolderEntry baseFolder, Map<String, AttributeValue> attributes, Map<String, String> options) throws ForbiddenException, ConflictException, ServerException {
                 baseFolder.createFolder("a");
                 baseFolder.createFolder("b");
-                baseFolder.createFile("test.txt", "test".getBytes(), "text/plain");
+                baseFolder.createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
             }
 
             @Override
@@ -489,7 +495,7 @@ public class ProjectServiceTest {
         });
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
 
         ProjectType pt = new ProjectType("testCreateProject", "my project type", true, false) {
@@ -515,7 +521,7 @@ public class ProjectServiceTest {
                                           .withGeneratorDescription(generatorDescription);
 
 
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s?name=new_project", workspace),
                                                       "http://localhost:8080/api",
                                                       headers,
@@ -574,12 +580,12 @@ public class ProjectServiceTest {
                     throws ConflictException, ForbiddenException, ServerException {
                 baseFolder.createFolder("a");
                 baseFolder.createFolder("b");
-                baseFolder.createFile("test.txt", "test".getBytes(), "text/plain");
+                baseFolder.createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
             }
         });
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
 
 
@@ -597,7 +603,7 @@ public class ProjectServiceTest {
                                           .withAttributes(attributeValues)
                                           .withGeneratorDescription(generatorDescription);
 
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/my_project?path=%s",
                                                                     workspace, "new_module"),
                                                       "http://localhost:8080/api",
@@ -651,14 +657,14 @@ public class ProjectServiceTest {
     @Test
     public void testCreateModuleAbsolutePath() throws Exception {
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         pm.createProject(workspace, "another", new ProjectConfig("", "my_project_type"), null, null);
 
         assertEquals(pm.getProject(workspace, "my_project").getModules().get().size(), 0);
 
 
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                 String.format("http://localhost:8080/api/project/%s/my_project?path=%s",
                         workspace, "/another"),
                 "http://localhost:8080/api",
@@ -678,7 +684,7 @@ public class ProjectServiceTest {
     @Test
     public void testRemoveModule() throws Exception {
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         pm.createProject(workspace, "todel", new ProjectConfig("", "my_project_type"), null, null);
 
@@ -687,7 +693,7 @@ public class ProjectServiceTest {
         assertEquals(pm.getProject(workspace, "my_project").getModules().get().size(), 1);
         assertEquals(pm.getProject(workspace, "my_project").getModules().get().iterator().next(), "/todel");
 
-        ContainerResponse response = launcher.service("DELETE",
+        ContainerResponse response = launcher.service(HttpMethod.DELETE,
                 String.format("http://localhost:8080/api/project/%s/my_project?module=/todel", workspace),
                 "http://localhost:8080/api", null, null, null);
 
@@ -700,7 +706,7 @@ public class ProjectServiceTest {
     public void testCreateProjectUnknownProjectType() throws Exception {
         final String newProjectTypeId = "new_project_type";
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
         Map<String, List<String>> attributeValues = new LinkedHashMap<>();
         attributeValues.put("new project attribute", Arrays.asList("to be or not to be"));
         ProjectDescriptor descriptor = DtoFactory.getInstance().createDto(ProjectDescriptor.class)
@@ -708,7 +714,7 @@ public class ProjectServiceTest {
                                                  .withDescription("new project")
                                                  .withAttributes(attributeValues);
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
-        ContainerResponse response = launcher.service("POST", "http://localhost:8080/api/project/my_ws?name=new_project",
+        ContainerResponse response = launcher.service(HttpMethod.POST, "http://localhost:8080/api/project/my_ws?name=new_project",
                                                       "http://localhost:8080/api",
                                                       headers,
                                                       DtoFactory.getInstance().toJson(descriptor).getBytes(),
@@ -724,7 +730,7 @@ public class ProjectServiceTest {
     @Test
     public void testUpdateProject() throws Exception {
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         ProjectType pt = new ProjectType("testUpdateProject", "my project type", true, false) {
 
@@ -744,7 +750,7 @@ public class ProjectServiceTest {
                 .withAttributes(attributeValues);
 
 
-        ContainerResponse response = launcher.service("PUT",
+        ContainerResponse response = launcher.service(HttpMethod.PUT,
                                                       String.format("http://localhost:8080/api/project/%s/testUpdateProject", workspace),
                                                       "http://localhost:8080/api",
                                                       headers,
@@ -772,14 +778,14 @@ public class ProjectServiceTest {
         mountPoint.getRoot().createFolder("not_project");
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
         Map<String, List<String>> attributeValues = new LinkedHashMap<>();
         attributeValues.put("my_attribute", Arrays.asList("to be or not to be"));
         ProjectUpdate descriptor = DtoFactory.getInstance().createDto(ProjectUpdate.class)
                                              .withType("my_project_type")
                                              .withDescription("updated project")
                                              .withAttributes(attributeValues);
-        ContainerResponse response = launcher.service("PUT",
+        ContainerResponse response = launcher.service(HttpMethod.PUT,
                                                       String.format("http://localhost:8080/api/project/%s/not_project", workspace),
                                                       "http://localhost:8080/api",
                                                       headers,
@@ -802,14 +808,14 @@ public class ProjectServiceTest {
     @Test
     public void testUpdateProjectInvalidPath() throws Exception {
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
         Map<String, List<String>> attributeValues = new LinkedHashMap<>();
         attributeValues.put("my_attribute", Arrays.asList("to be or not to be"));
         ProjectUpdate descriptor = DtoFactory.getInstance().createDto(ProjectUpdate.class)
                                              .withType("my_project_type")
                                              .withDescription("updated project")
                                              .withAttributes(attributeValues);
-        ContainerResponse response = launcher.service("PUT",
+        ContainerResponse response = launcher.service(HttpMethod.PUT,
                                                       String.format("http://localhost:8080/api/project/%s/my_project_invalid",
                                                                     workspace),
                                                       "http://localhost:8080/api",
@@ -823,8 +829,8 @@ public class ProjectServiceTest {
     public void testCreateFile() throws Exception {
         String myContent = "to be or not to be";
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("text/plain"));
-        ContainerResponse response = launcher.service("POST",
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.TEXT_PLAIN));
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/file/my_project?name=test.txt",
                                                                     workspace),
                                                       "http://localhost:8080/api",
@@ -834,7 +840,7 @@ public class ProjectServiceTest {
         assertEquals(response.getStatus(), 201, "Error: " + response.getEntity());
         ItemReference fileItem = (ItemReference)response.getEntity();
         assertEquals(fileItem.getType(), "file");
-        assertEquals(fileItem.getMediaType(), "text/plain");
+        assertEquals(fileItem.getMediaType(), MediaType.TEXT_PLAIN);
         assertEquals(fileItem.getName(), "test.txt");
         assertEquals(fileItem.getPath(), "/my_project/test.txt");
         validateFileLinks(fileItem);
@@ -843,7 +849,7 @@ public class ProjectServiceTest {
         VirtualFileEntry file = pm.getProject(workspace, "my_project").getBaseFolder().getChild("test.txt");
         Assert.assertTrue(file.isFile());
         FileEntry _file = (FileEntry)file;
-        assertEquals(_file.getMediaType(), "text/plain");
+        assertEquals(_file.getMediaType(), MediaType.TEXT_PLAIN);
         assertEquals(new String(_file.contentAsBytes()), myContent);
     }
 
@@ -851,9 +857,9 @@ public class ProjectServiceTest {
     public void testUploadFile() throws Exception {
         String fileContent = "to be or not to be";
         String fileName = "test.txt";
-        String fileMediaType = "text/plain";
+        String fileMediaType = MediaType.TEXT_PLAIN;
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("multipart/form-data; boundary=abcdef"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList("multipart/form-data; boundary=abcdef"));
         String uploadBodyPattern =
                 "--abcdef\r\nContent-Disposition: form-data; name=\"file\"; filename=\"%1$s\"\r\nContent-Type: %2$s\r\n\r\n%3$s"
                 + "\r\n--abcdef\r\nContent-Disposition: form-data; name=\"mimeType\"\r\n\r\n%4$s"
@@ -863,8 +869,8 @@ public class ProjectServiceTest {
         byte[] formData = String.format(uploadBodyPattern, fileName, fileMediaType, fileContent, fileMediaType, fileName, false).getBytes();
         EnvironmentContext env = new EnvironmentContext();
         env.put(HttpServletRequest.class, new MockHttpServletRequest("", new ByteArrayInputStream(formData),
-                                                                     formData.length, "POST", headers));
-        ContainerResponse response = launcher.service("POST",
+                                                                     formData.length, HttpMethod.POST, headers));
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/uploadfile/my_project",
                                                                     workspace),
                                                       "http://localhost:8080/api",
@@ -884,9 +890,9 @@ public class ProjectServiceTest {
         String oldFileContent = "to be or not to be";
         String newFileContent = "To be, or not to be, that is the question!";
         String fileName = "test.txt";
-        String fileMediaType = "text/plain";
+        String fileMediaType = MediaType.TEXT_PLAIN;
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("multipart/form-data; boundary=abcdef"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList("multipart/form-data; boundary=abcdef"));
         String uploadBodyPattern =
                 "--abcdef\r\nContent-Disposition: form-data; name=\"file\"; filename=\"%1$s\"\r\nContent-Type: %2$s\r\n\r\n%3$s"
                 + "\r\n--abcdef\r\nContent-Disposition: form-data; name=\"mimeType\"\r\n\r\n%4$s"
@@ -898,8 +904,8 @@ public class ProjectServiceTest {
 
         EnvironmentContext env = new EnvironmentContext();
         env.put(HttpServletRequest.class, new MockHttpServletRequest("", new ByteArrayInputStream(newFileData),
-                                                                     newFileData.length, "POST", headers));
-        ContainerResponse response = launcher.service("POST",
+                                                                     newFileData.length, HttpMethod.POST, headers));
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/uploadfile/my_project",
                                                                     workspace),
                                                       "http://localhost:8080/api",
@@ -919,9 +925,9 @@ public class ProjectServiceTest {
         String oldFileContent = "to be or not to be";
         String newFileContent = "To be, or not to be, that is the question!";
         String fileName = "test.txt";
-        String fileMediaType = "text/plain";
+        String fileMediaType = MediaType.TEXT_PLAIN;
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("multipart/form-data; boundary=abcdef"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList("multipart/form-data; boundary=abcdef"));
         String uploadBodyPattern =
                 "--abcdef\r\nContent-Disposition: form-data; name=\"file\"; filename=\"%1$s\"\r\nContent-Type: %2$s\r\n\r\n%3$s"
                 + "\r\n--abcdef\r\nContent-Disposition: form-data; name=\"mimeType\"\r\n\r\n%4$s"
@@ -933,8 +939,8 @@ public class ProjectServiceTest {
 
         EnvironmentContext env = new EnvironmentContext();
         env.put(HttpServletRequest.class, new MockHttpServletRequest("", new ByteArrayInputStream(newFileData),
-                                                                     newFileData.length, "POST", headers));
-        ContainerResponse response = launcher.service("POST",
+                                                                     newFileData.length, HttpMethod.POST, headers));
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/uploadfile/my_project",
                                                                     workspace),
                                                       "http://localhost:8080/api",
@@ -952,24 +958,24 @@ public class ProjectServiceTest {
     @Test
     public void testGetFileContent() throws Exception {
         String myContent = "to be or not to be";
-        pm.getProject(workspace, "my_project").getBaseFolder().createFile("test.txt", myContent.getBytes(), "text/plain");
+        pm.getProject(workspace, "my_project").getBaseFolder().createFile("test.txt", myContent.getBytes(), MediaType.TEXT_PLAIN);
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
-        ContainerResponse response = launcher.service("GET",
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format("http://localhost:8080/api/project/%s/file/my_project/test.txt",
                                                                     workspace),
                                                       "http://localhost:8080/api", null, null, writer, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
-        assertEquals(response.getContentType().toString(), "text/plain");
+        assertEquals(response.getContentType().toString(), MediaType.TEXT_PLAIN);
         assertEquals(new String(writer.getBody()), myContent);
     }
 
     @Test
     public void testUpdateFileContent() throws Exception {
         String myContent = "<test>hello</test>";
-        pm.getProject(workspace, "my_project").getBaseFolder().createFile("test", "to be or not to be".getBytes(), "text/plain");
+        pm.getProject(workspace, "my_project").getBaseFolder().createFile("test", "to be or not to be".getBytes(), MediaType.TEXT_PLAIN);
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("text/xml"));
-        ContainerResponse response = launcher.service("PUT",
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList("text/xml"));
+        ContainerResponse response = launcher.service(HttpMethod.PUT,
                                                       String.format("http://localhost:8080/api/project/%s/file/my_project/test", workspace),
                                                       "http://localhost:8080/api", headers, myContent.getBytes(), null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
@@ -982,7 +988,7 @@ public class ProjectServiceTest {
 
     @Test
     public void testCreateFolder() throws Exception {
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/folder/my_project/test",
                                                                     workspace),
                                                       "http://localhost:8080/api", null, null, null);
@@ -1001,7 +1007,7 @@ public class ProjectServiceTest {
 
     @Test
     public void testCreatePath() throws Exception {
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/folder/my_project/a/b/c",
                                                                     workspace),
                                                       "http://localhost:8080/api", null, null, null);
@@ -1014,8 +1020,8 @@ public class ProjectServiceTest {
 
     @Test
     public void testDeleteFile() throws Exception {
-        pm.getProject(workspace, "my_project").getBaseFolder().createFile("test.txt", "to be or not to be".getBytes(), "text/plain");
-        ContainerResponse response = launcher.service("DELETE",
+        pm.getProject(workspace, "my_project").getBaseFolder().createFile("test.txt", "to be or not to be".getBytes(), MediaType.TEXT_PLAIN);
+        ContainerResponse response = launcher.service(HttpMethod.DELETE,
                                                       String.format("http://localhost:8080/api/project/%s/my_project/test.txt", workspace),
                                                       "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 204, "Error: " + response.getEntity());
@@ -1025,7 +1031,7 @@ public class ProjectServiceTest {
     @Test
     public void testDeleteFolder() throws Exception {
         pm.getProject(workspace, "my_project").getBaseFolder().createFolder("test");
-        ContainerResponse response = launcher.service("DELETE",
+        ContainerResponse response = launcher.service(HttpMethod.DELETE,
                                                       String.format("http://localhost:8080/api/project/%s/my_project/test", workspace),
                                                       "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 204, "Error: " + response.getEntity());
@@ -1035,7 +1041,7 @@ public class ProjectServiceTest {
     @Test
     public void testDeletePath() throws Exception {
         pm.getProject(workspace, "my_project").getBaseFolder().createFolder("a/b/c");
-        ContainerResponse response = launcher.service("DELETE",
+        ContainerResponse response = launcher.service(HttpMethod.DELETE,
                                                       String.format("http://localhost:8080/api/project/%s/my_project/a/b/c", workspace),
                                                       "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 204, "Error: " + response.getEntity());
@@ -1044,7 +1050,7 @@ public class ProjectServiceTest {
 
     @Test
     public void testDeleteInvalidPath() throws Exception {
-        ContainerResponse response = launcher.service("DELETE",
+        ContainerResponse response = launcher.service(HttpMethod.DELETE,
                                                       String.format("http://localhost:8080/api/project/%s/my_project/a/b/c", workspace),
                                                       "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 404);
@@ -1053,7 +1059,7 @@ public class ProjectServiceTest {
 
     @Test
     public void testDeleteProject() throws Exception {
-        ContainerResponse response = launcher.service("DELETE",
+        ContainerResponse response = launcher.service(HttpMethod.DELETE,
                                                       String.format("http://localhost:8080/api/project/%s/my_project", workspace),
                                                       "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 204, "Error: " + response.getEntity());
@@ -1064,8 +1070,8 @@ public class ProjectServiceTest {
     public void testCopyFile() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), "text/plain");
-        ContainerResponse response = launcher.service("POST",
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), MediaType.TEXT_PLAIN);
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format(
                                                               "http://localhost:8080/api/project/%s/copy/my_project/a/b/test.txt?to=/my_project/a/b/c",
                                                               workspace),
@@ -1081,16 +1087,16 @@ public class ProjectServiceTest {
     public void testCopyFileWithRename() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), "text/plain");
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), MediaType.TEXT_PLAIN);
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         CopyOptions descriptor = DtoFactory.getInstance().createDto(CopyOptions.class);
         descriptor.setName("copyOfTest.txt");
         descriptor.setOverWrite(false);
 
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                 String.format(
                         "http://localhost:8080/api/project/%s/copy/my_project/a/b/test.txt?to=/my_project/a/b/c",
                         workspace),
@@ -1115,17 +1121,17 @@ public class ProjectServiceTest {
         String originContent = "to be or not no be";
         String overwritenContent = "that is the question";
 
-        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes(), "text/plain");
-        ((FolderEntry) myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwritenContent.getBytes(), "text/plain");
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes(), MediaType.TEXT_PLAIN);
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwritenContent.getBytes(), MediaType.TEXT_PLAIN);
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         CopyOptions descriptor = DtoFactory.getInstance().createDto(CopyOptions.class);
         descriptor.setName(destinationFileName);
         descriptor.setOverWrite(true);
 
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                 String.format(
                         "http://localhost:8080/api/project/%s/copy/my_project/a/b/" + originFileName + "?to=/my_project/a/b/c",
                         workspace),
@@ -1157,8 +1163,8 @@ public class ProjectServiceTest {
     public void testCopyFolder() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), "text/plain");
-        ContainerResponse response = launcher.service("POST",
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), MediaType.TEXT_PLAIN);
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format(
                                                               "http://localhost:8080/api/project/%s/copy/my_project/a/b?to=/my_project/a/b/c",
                                                               workspace),
@@ -1174,19 +1180,19 @@ public class ProjectServiceTest {
     public void testCopyFolderWithRename() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), "text/plain");
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), MediaType.TEXT_PLAIN);
 
         // new name for folder
         final String renamedFolder = "renamedFolder";
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         CopyOptions descriptor = DtoFactory.getInstance().createDto(CopyOptions.class);
         descriptor.setName(renamedFolder);
         descriptor.setOverWrite(false);
 
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                 String.format(
                         "http://localhost:8080/api/project/%s/copy/my_project/a/b?to=/my_project/a/b/c",
                         workspace),
@@ -1214,17 +1220,17 @@ public class ProjectServiceTest {
         // new name for folder
         final String renamedFolder = "renamedFolder";
 
-        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes(), "text/plain");
-        ((FolderEntry) myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwritenContent.getBytes(), "text/plain");
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes(), MediaType.TEXT_PLAIN);
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwritenContent.getBytes(), MediaType.TEXT_PLAIN);
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         CopyOptions descriptor = DtoFactory.getInstance().createDto(CopyOptions.class);
         descriptor.setName(renamedFolder);
         descriptor.setOverWrite(true);
 
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                 String.format(
                         "http://localhost:8080/api/project/%s/copy/my_project/a/b?to=/my_project/a/b/c",
                         workspace),
@@ -1241,8 +1247,8 @@ public class ProjectServiceTest {
     public void testMoveFile() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), "text/plain");
-        ContainerResponse response = launcher.service("POST",
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), MediaType.TEXT_PLAIN);
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format(
                                                               "http://localhost:8080/api/project/%s/move/my_project/a/b/test.txt?to=/my_project/a/b/c",
                                                               workspace),
@@ -1258,19 +1264,19 @@ public class ProjectServiceTest {
     public void testMoveFileWithRename() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), "text/plain");
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), MediaType.TEXT_PLAIN);
         
         // name for file after move
         final String destinationName = "copyOfTestForMove.txt";
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         MoveOptions descriptor = DtoFactory.getInstance().createDto(MoveOptions.class);
         descriptor.setName(destinationName);
         descriptor.setOverWrite(false);
 
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                 String.format(
                         "http://localhost:8080/api/project/%s/move/my_project/a/b/test.txt?to=/my_project/a/b/c",
                         workspace),
@@ -1295,17 +1301,17 @@ public class ProjectServiceTest {
         String originContent = "to be or not no be";
         String overwritenContent = "that is the question";
 
-        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes(), "text/plain");
-        ((FolderEntry) myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwritenContent.getBytes(), "text/plain");
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes(), MediaType.TEXT_PLAIN);
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwritenContent.getBytes(), MediaType.TEXT_PLAIN);
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         MoveOptions descriptor = DtoFactory.getInstance().createDto(MoveOptions.class);
         descriptor.setName(destinationFileName);
         descriptor.setOverWrite(true);
 
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                 String.format(
                         "http://localhost:8080/api/project/%s/move/my_project/a/b/" + originFileName + "?to=/my_project/a/b/c",
                         workspace),
@@ -1336,8 +1342,8 @@ public class ProjectServiceTest {
     public void testMoveFolder() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ((FolderEntry)myProject.getBaseFolder().getChild("a/b/c")).createFile("test.txt", "to be or not no be".getBytes(), "text/plain");
-        ContainerResponse response = launcher.service("POST",
+        ((FolderEntry)myProject.getBaseFolder().getChild("a/b/c")).createFile("test.txt", "to be or not no be".getBytes(), MediaType.TEXT_PLAIN);
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format(
                                                               "http://localhost:8080/api/project/%s/move/my_project/a/b/c?to=/my_project/a",
                                                               workspace),
@@ -1354,19 +1360,19 @@ public class ProjectServiceTest {
     public void testMoveFolderWithRename() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), "text/plain");
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile("test.txt", "to be or not no be".getBytes(), MediaType.TEXT_PLAIN);
 
         // new name for folder
         final String renamedFolder = "renamedFolder";
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         MoveOptions descriptor = DtoFactory.getInstance().createDto(MoveOptions.class);
         descriptor.setName(renamedFolder);
         descriptor.setOverWrite(false);
 
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                 String.format(
                         "http://localhost:8080/api/project/%s/copy/my_project/a/b?to=/my_project/a/b/c",
                         workspace),
@@ -1393,17 +1399,17 @@ public class ProjectServiceTest {
         // new name for folder
         final String renamedFolder = "renamedFolder";
 
-        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes(), "text/plain");
-        ((FolderEntry) myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwritenContent.getBytes(), "text/plain");
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b")).createFile(originFileName, originContent.getBytes(), MediaType.TEXT_PLAIN);
+        ((FolderEntry) myProject.getBaseFolder().getChild("a/b/c")).createFile(destinationFileName, overwritenContent.getBytes(), MediaType.TEXT_PLAIN);
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         MoveOptions descriptor = DtoFactory.getInstance().createDto(MoveOptions.class);
         descriptor.setName(renamedFolder);
         descriptor.setOverWrite(true);
 
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                 String.format(
                         "http://localhost:8080/api/project/%s/copy/my_project/a/b?to=/my_project/a/b/c",
                         workspace),
@@ -1417,8 +1423,8 @@ public class ProjectServiceTest {
     @Test
     public void testRenameFile() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
-        myProject.getBaseFolder().createFile("test.txt", "hello".getBytes(), "text/plain");
-        ContainerResponse response = launcher.service("POST",
+        myProject.getBaseFolder().createFile("test.txt", "hello".getBytes(), MediaType.TEXT_PLAIN);
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format(
                                                               "http://localhost:8080/api/project/%s/rename/my_project/test.txt?name=_test.txt",
                                                               workspace),
@@ -1434,7 +1440,7 @@ public class ProjectServiceTest {
     public void testRenameFileAndUpdateMediaType() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
         myProject.getBaseFolder().createFile("test.txt", "hello".getBytes(), "text/*");
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format(
                                                               "http://localhost:8080/api/project/%s/rename/my_project/test.txt?name=_test.txt&mediaType=text/plain",
                                                               workspace),
@@ -1444,7 +1450,7 @@ public class ProjectServiceTest {
                      URI.create(String.format("http://localhost:8080/api/project/%s/file/my_project/_test.txt", workspace)));
         FileEntry renamed = (FileEntry)myProject.getBaseFolder().getChild("_test.txt");
         assertNotNull(renamed);
-        assertEquals(renamed.getMediaType(), "text/plain");
+        assertEquals(renamed.getMediaType(), MediaType.TEXT_PLAIN);
         Assert.assertNull(myProject.getBaseFolder().getChild("test.txt"));
     }
 
@@ -1452,7 +1458,7 @@ public class ProjectServiceTest {
     public void testRenameFolder() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
         myProject.getBaseFolder().createFolder("a/b/c");
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/rename/my_project/a/b?name=x",
                                                                     workspace),
                                                       "http://localhost:8080/api", null, null, null);
@@ -1479,12 +1485,12 @@ public class ProjectServiceTest {
                     throws ConflictException, ForbiddenException, ServerException {
                 baseFolder.createFolder("a");
                 baseFolder.createFolder("b");
-                baseFolder.createFile("test.txt", "test".getBytes(), "text/plain");
+                baseFolder.createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
             }
         });
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
 
         Map<String, List<String>> attributeValues = new LinkedHashMap<>();
@@ -1497,7 +1503,7 @@ public class ProjectServiceTest {
                 .withAttributes(attributeValues)
                 .withGeneratorDescription(generatorDescription);
 
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                 String.format("http://localhost:8080/api/project/%s/my_project?path=%s",
                         workspace, "new_module"),
                 "http://localhost:8080/api",
@@ -1513,7 +1519,7 @@ public class ProjectServiceTest {
 
         final String newName = "moduleRenamed";
 
-        response = launcher.service("POST",
+        response = launcher.service(HttpMethod.POST,
                 String.format("http://localhost:8080/api/project/%s/rename/my_project/new_module?name=%s",
                         workspace, newName),
                 "http://localhost:8080/api", null, null, null);
@@ -1587,9 +1593,9 @@ public class ProjectServiceTest {
         });
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
         byte[] b = String.format("{\"source\":{\"project\":{\"location\":null,\"type\":\"%s\",\"parameters\":{}},\"runners\":{}}}", importType).getBytes();
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/import/new_project", workspace),
                                                       "http://localhost:8080/api", headers, b, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
@@ -1681,9 +1687,9 @@ public class ProjectServiceTest {
 
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
         byte[] b = String.format("{\"source\":{\"project\":{\"location\":null,\"type\":\"%s\",\"parameters\":{}},\"runners\":{}}}", importType).getBytes();
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/import/new_project", workspace),
                                                       "http://localhost:8080/api", headers, b, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
@@ -1756,12 +1762,12 @@ public class ProjectServiceTest {
 
         String visibility = "private";
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         byte[] b = String.format("{\"project\":{\"name\":null,\"type\":\"%s\",\"attributes\":{},\"visibility\":\"%s\",\"description\":null," +
                                  "\"builders\":null,\"runners\":null},\"source\":{\"project\":{\"location\":null,\"type\":\"%s\"," +
                                  "\"parameters\":{}},\"runners\":{}}}", "chuck_project_type", visibility, importType).getBytes();
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/import/new_project", workspace),
                                                       "http://localhost:8080/api", headers, b, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
@@ -1832,12 +1838,12 @@ public class ProjectServiceTest {
         String myType = "chuck_project_type";
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         byte[] b = String.format("{\"project\":{\"name\":null,\"type\":\"%s\",\"attributes\":{},\"visibility\":null,\"description\":null," +
                                  "\"builders\":null,\"runners\":null},\"source\":{\"project\":{\"location\":null,\"type\":\"%s\"," +
                                  "\"parameters\":{}},\"runners\":{}}}",myType, importType).getBytes();
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/import/new_project", workspace),
                                                       "http://localhost:8080/api", headers, b, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
@@ -1917,7 +1923,7 @@ public class ProjectServiceTest {
         });
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         byte[] b = String.format(
                 "{\"source\":{\"project\":{\"location\":\"host.com/some/path\",\"type\":\"%s\",\"parameters\":{}},\"runners\":{}}," +
@@ -1925,7 +1931,7 @@ public class ProjectServiceTest {
                 "\"variables\":{},\"ram\":256}},\"default\":\"system:/java/web/tomcat7\"},\"builders\":{\"default\":\"maven\"}," +
                 "\"type\":\"chuck_project_type\",\"attributes\":{},\"description\":\"import test\"},\"variables\":[],\"v\":\"2.0\"}",
                 importType).getBytes();
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/import/new_project", workspace),
                                                       "http://localhost:8080/api", headers, b, null);
 
@@ -2002,14 +2008,14 @@ public class ProjectServiceTest {
         });
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         byte[] b = String.format(
                 "{\"source\":{\"project\":{\"location\":\"host.com/some/path\",\"type\":\"%s\",\"parameters\":{}},\"runners\":{}}," +
                 "\"project\":{\"name\":\"spring\",\"visibility\":\"public\",\"runners\":{},\"builders\":{\"default\":\"maven\"}," +
                 "\"type\":\"chuck_project_type\",\"attributes\":{},\"description\":\"import test\"},\"variables\":[],\"v\":\"2.0\"}",
                 importType).getBytes();
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/import/new_project", workspace),
                                                       "http://localhost:8080/api", headers, b, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
@@ -2084,7 +2090,7 @@ public class ProjectServiceTest {
         });
 
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         byte[] b = String.format(
                 "{\"source\":{\"project\":{\"location\":\"host.com/some/path\",\"type\":\"%s\",\"parameters\":{}},\"runners\":{}}," +
@@ -2092,7 +2098,7 @@ public class ProjectServiceTest {
                 "\"variables\":{},\"ram\":256}},\"default\":\"system:/java/web/tomcat7\"},\"builders\":{\"default\":\"maven\"}," +
                 "\"type\":\"chuck_project_type\",\"attributes\":{\"y\": [\"q\",\"z\"]},\"description\":\"import test\"},\"variables\":[],\"v\":\"2.0\"}",
                 importType).getBytes();
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/import/new_project", workspace),
                                                       "http://localhost:8080/api", headers, b, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
@@ -2120,8 +2126,8 @@ public class ProjectServiceTest {
         zipOut.close();
         byte[] zip = bout.toByteArray();
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/zip"));
-        ContainerResponse response = launcher.service("POST",
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(ExtMediaType.APPLICATION_ZIP));
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/import/my_project/a/b",
                                                                     workspace),
                                                       "http://localhost:8080/api", headers, zip, null);
@@ -2146,8 +2152,8 @@ public class ProjectServiceTest {
         zipOut.close();
         byte[] zip = bout.toByteArray();
         Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", Arrays.asList("application/zip"));
-        ContainerResponse response = launcher.service("POST",
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(ExtMediaType.APPLICATION_ZIP));
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format("http://localhost:8080/api/project/%s/import/my_project/a/b?skipFirstLevel=false",
                                                                     workspace),
                                                       "http://localhost:8080/api", headers, zip, null);
@@ -2163,12 +2169,12 @@ public class ProjectServiceTest {
     @Test
     public void testExportZip() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
-        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "hello".getBytes(), "text/plain");
-        ContainerResponse response = launcher.service("GET",
+        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "hello".getBytes(), MediaType.TEXT_PLAIN);
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format("http://localhost:8080/api/project/%s/export/my_project", workspace),
                                                       "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
-        assertEquals(response.getContentType().toString(), "application/zip");
+        assertEquals(response.getContentType().toString(), ExtMediaType.APPLICATION_ZIP);
     }
 
     @Test
@@ -2177,8 +2183,8 @@ public class ProjectServiceTest {
         Project myProject = pm.getProject(workspace, "my_project");
         FolderEntry a = myProject.getBaseFolder().createFolder("a");
         a.createFolder("b");
-        a.createFile("test.txt", "test".getBytes(), "text/plain");
-        ContainerResponse response = launcher.service("GET",
+        a.createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format("http://localhost:8080/api/project/%s/children/my_project/a",
                                                                     workspace),
                                                       "http://localhost:8080/api", null, null, null);
@@ -2199,8 +2205,8 @@ public class ProjectServiceTest {
         Project myProject = pm.getProject(workspace, "my_project");
         FolderEntry a = myProject.getBaseFolder().createFolder("a");
         a.createFolder("b");
-        a.createFile("test.txt", "test".getBytes(), "text/plain");
-        ContainerResponse response = launcher.service("GET",
+        a.createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                 String.format("http://localhost:8080/api/project/%s/item/my_project/a/b",
                         workspace),
                 "http://localhost:8080/api", null, null, null);
@@ -2210,14 +2216,14 @@ public class ProjectServiceTest {
         assertEquals(result.getType(), "folder");
         assertEquals(result.getName(), "b");
 
-        response = launcher.service("GET",
+        response = launcher.service(HttpMethod.GET,
                 String.format("http://localhost:8080/api/project/%s/item/my_project/a/test.txt",
                         workspace),
                 "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
         result = (ItemReference)response.getEntity();
         assertEquals(result.getType(), "file");
-        assertEquals(result.getMediaType(), "text/plain");
+        assertEquals(result.getMediaType(), MediaType.TEXT_PLAIN);
 
     }
 
@@ -2252,8 +2258,8 @@ public class ProjectServiceTest {
 
         FolderEntry a = myProject.getBaseFolder().createFolder("a");
         a.createFolder("b");
-        a.createFile("test.txt", "test".getBytes(), "text/plain");
-        ContainerResponse response = launcher.service("GET",
+        a.createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                 String.format("http://localhost:8080/api/project/%s/item/my_project/a/b",
                         workspace),
                 "http://localhost:8080/api", null, null, null);
@@ -2266,14 +2272,14 @@ public class ProjectServiceTest {
         assertNotNull(result.getModified());
         assertEquals(result.getAttributes().size(), 1);
 
-        response = launcher.service("GET",
+        response = launcher.service(HttpMethod.GET,
                 String.format("http://localhost:8080/api/project/%s/item/my_project/a/test.txt",
                         workspace),
                 "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
         result = (ItemReference)response.getEntity();
         assertEquals(result.getType(), "file");
-        assertEquals(result.getMediaType(), "text/plain");
+        assertEquals(result.getMediaType(), MediaType.TEXT_PLAIN);
         assertNotNull(result.getContentLength());
         assertEquals(result.getAttributes().size(), 2);
 
@@ -2289,8 +2295,8 @@ public class ProjectServiceTest {
         FolderEntry a = myProject.getBaseFolder().createFolder("a");
         a.createFolder("b/c");
         a.createFolder("x/y");
-        a.createFile("test.txt", "test".getBytes(), "text/plain");
-        ContainerResponse response = launcher.service("GET",
+        a.createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format("http://localhost:8080/api/project/%s/tree/my_project/a", workspace),
                                                       "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
@@ -2318,8 +2324,8 @@ public class ProjectServiceTest {
         FolderEntry a = myProject.getBaseFolder().createFolder("a");
         a.createFolder("b/c");
         a.createFolder("x/y");
-        a.createFile("test.txt", "test".getBytes(), "text/plain");
-        ContainerResponse response = launcher.service("GET",
+        a.createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format("http://localhost:8080/api/project/%s/tree/my_project/a?depth=2",
                                                                     workspace),
                                                       "http://localhost:8080/api", null, null, null);
@@ -2353,8 +2359,8 @@ public class ProjectServiceTest {
         Project myProject = pm.getProject(workspace, "my_project");
         FolderEntry a = myProject.getBaseFolder().createFolder("a");
         a.createFolder("b/c");
-        a.createFolder("x").createFile("test.txt", "test".getBytes(), "text/plain");
-        ContainerResponse response = launcher.service("GET",
+        a.createFolder("x").createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format("http://localhost:8080/api/project/%s/tree/my_project/a?depth=100&includeFiles=true",
                                                                     workspace),
                                                       "http://localhost:8080/api", null, null, null);
@@ -2392,7 +2398,7 @@ public class ProjectServiceTest {
         FolderEntry a = myProject.getBaseFolder().createFolder("a");
         a.createFolder("b/c");
         a.createFolder("x");
-        ContainerResponse response = launcher.service("GET",
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format("http://localhost:8080/api/project/%s/tree/my_project/a?depth=100&includeFiles=true",
                                                                     workspace),
                                                       "http://localhost:8080/api", null, null, null);
@@ -2424,7 +2430,7 @@ public class ProjectServiceTest {
     @Test
     public void testSwitchProjectVisibilityToPrivate() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format(
                                                               "http://localhost:8080/api/project/%s/switch_visibility/my_project?visibility=private",
                                                               workspace),
@@ -2438,7 +2444,7 @@ public class ProjectServiceTest {
                                         .withType(Principal.Type.GROUP);
         assertEquals(permissions.get(principal), Arrays.asList(VirtualFileSystemInfo.BasicPermissions.ALL.value()));
 
-        response = launcher.service("GET",
+        response = launcher.service(HttpMethod.GET,
                                     String.format("http://localhost:8080/api/project/%s/my_project", workspace),
                                     "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
@@ -2450,7 +2456,7 @@ public class ProjectServiceTest {
     public void testUpdateProjectVisibilityToPublic() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
         myProject.setVisibility("private");
-        ContainerResponse response = launcher.service("POST",
+        ContainerResponse response = launcher.service(HttpMethod.POST,
                                                       String.format(
                                                               "http://localhost:8080/api/project/%s/switch_visibility/my_project?visibility=public",
                                                               workspace),
@@ -2460,7 +2466,7 @@ public class ProjectServiceTest {
         Map<Principal, Set<String>> permissions = myProject.getBaseFolder().getVirtualFile().getPermissions();
         assertEquals(permissions.size(), 0);
 
-        response = launcher.service("GET",
+        response = launcher.service(HttpMethod.GET,
                                     String.format("http://localhost:8080/api/project/%s/my_project", workspace),
                                     "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
@@ -2472,11 +2478,11 @@ public class ProjectServiceTest {
     @Test
     public void testSearchByName() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
-        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "hello".getBytes(), "text/plain");
-        myProject.getBaseFolder().createFolder("x/y").createFile("test.txt", "test".getBytes(), "text/plain");
-        myProject.getBaseFolder().createFolder("c").createFile("exclude", "test".getBytes(), "text/plain");
+        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "hello".getBytes(), MediaType.TEXT_PLAIN);
+        myProject.getBaseFolder().createFolder("x/y").createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
+        myProject.getBaseFolder().createFolder("c").createFile("exclude", "test".getBytes(), MediaType.TEXT_PLAIN);
 
-        ContainerResponse response = launcher.service("GET",
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format("http://localhost:8080/api/project/%s/search/my_project?name=test.txt",
                                                                     workspace),
                                                       "http://localhost:8080/api", null, null, null);
@@ -2495,11 +2501,11 @@ public class ProjectServiceTest {
     @Test
     public void testSearchByText() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
-        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "hello".getBytes(), "text/plain");
-        myProject.getBaseFolder().createFolder("x/y").createFile("__test.txt", "searchhit".getBytes(), "text/plain");
-        myProject.getBaseFolder().createFolder("c").createFile("_test", "searchhit".getBytes(), "text/plain");
+        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "hello".getBytes(), MediaType.TEXT_PLAIN);
+        myProject.getBaseFolder().createFolder("x/y").createFile("__test.txt", "searchhit".getBytes(), MediaType.TEXT_PLAIN);
+        myProject.getBaseFolder().createFolder("c").createFile("_test", "searchhit".getBytes(), MediaType.TEXT_PLAIN);
 
-        ContainerResponse response = launcher.service("GET",
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format("http://localhost:8080/api/project/%s/search/my_project?text=searchhit",
                                                                     workspace),
                                                       "http://localhost:8080/api", null, null, null);
@@ -2518,11 +2524,11 @@ public class ProjectServiceTest {
     @Test
     public void testSearchByMediaType() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
-        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "6769675".getBytes(), "text/plain");
-        myProject.getBaseFolder().createFolder("x/y").createFile("test.txt", "132434".getBytes(), "text/plain");
-        myProject.getBaseFolder().createFolder("c").createFile("test", "2343124".getBytes(), "text/plain");
+        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "6769675".getBytes(), MediaType.TEXT_PLAIN);
+        myProject.getBaseFolder().createFolder("x/y").createFile("test.txt", "132434".getBytes(), MediaType.TEXT_PLAIN);
+        myProject.getBaseFolder().createFolder("c").createFile("test", "2343124".getBytes(), MediaType.TEXT_PLAIN);
 
-        ContainerResponse response = launcher.service("GET",
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format(
                                                               "http://localhost:8080/api/project/%s/search/my_project?mediatype=text/plain",
                                                               workspace),
@@ -2543,11 +2549,11 @@ public class ProjectServiceTest {
     @Test
     public void testSearchByNameAndTextAndMediaType() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
-        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "test".getBytes(), "text/plain");
+        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
         myProject.getBaseFolder().createFolder("x/y").createFile("test.txt", "test".getBytes(), "text/*");
-        myProject.getBaseFolder().createFolder("c").createFile("test", "test".getBytes(), "text/plain");
+        myProject.getBaseFolder().createFolder("c").createFile("test", "test".getBytes(), MediaType.TEXT_PLAIN);
 
-        ContainerResponse response = launcher.service("GET",
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format(
                                                               "http://localhost:8080/api/project/%s/search/my_project?text=test&name=test&mediatype=text/plain",
                                                               workspace),
@@ -2563,11 +2569,11 @@ public class ProjectServiceTest {
     @Test
     public void testSearchFromWSRoot() throws Exception {
         Project myProject = pm.getProject(workspace, "my_project");
-        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "test".getBytes(), "text/plain");
+        myProject.getBaseFolder().createFolder("a/b").createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
         myProject.getBaseFolder().createFolder("x/y").createFile("test.txt", "test".getBytes(), "text/*");
-        myProject.getBaseFolder().createFolder("c").createFile("test", "test".getBytes(), "text/plain");
+        myProject.getBaseFolder().createFolder("c").createFile("test", "test".getBytes(), MediaType.TEXT_PLAIN);
 
-        ContainerResponse response = launcher.service("GET",
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                 String.format(
                         "http://localhost:8080/api/project/%s/search/?text=test&name=test&mediatype=text/plain",
                         workspace),
@@ -2584,13 +2590,13 @@ public class ProjectServiceTest {
         clearAcl(myProject);
         String user = "user";
         HashMap<String, List<String>> headers = new HashMap<>(1);
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         AccessControlEntry entry1 = DtoFactory.getInstance().createDto(AccessControlEntry.class)
                                               .withPermissions(Arrays.asList("all"))
                                               .withPrincipal(DtoFactory.getInstance().createDto(Principal.class)
                                                                        .withName(user).withType(Principal.Type.USER));
-        launcher.service("POST",
+        launcher.service(HttpMethod.POST,
                          String.format("http://localhost:8080/api/project/%s/permissions/my_project", workspace),
                          "http://localhost:8080/api",
                          headers,
@@ -2616,13 +2622,13 @@ public class ProjectServiceTest {
         clearAcl(myProject);
         String user = "user";
         HashMap<String, List<String>> headers = new HashMap<>(1);
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         AccessControlEntry entry1 = DtoFactory.getInstance().createDto(AccessControlEntry.class)
                                               .withPermissions(Arrays.asList("custom"))
                                               .withPrincipal(DtoFactory.getInstance().createDto(Principal.class)
                                                                        .withName(user).withType(Principal.Type.USER));
-        launcher.service("POST",
+        launcher.service(HttpMethod.POST,
                          String.format("http://localhost:8080/api/project/%s/permissions/my_project", workspace),
                          "http://localhost:8080/api",
                          headers,
@@ -2648,13 +2654,13 @@ public class ProjectServiceTest {
         clearAcl(myProject);
         String user = "user";
         HashMap<String, List<String>> headers = new HashMap<>(1);
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         AccessControlEntry entry1 = DtoFactory.getInstance().createDto(AccessControlEntry.class)
                                               .withPermissions(Arrays.asList("build", "run", "update_acl", "read", "write"))
                                               .withPrincipal(DtoFactory.getInstance().createDto(Principal.class)
                                                                        .withName(user).withType(Principal.Type.USER));
-        launcher.service("POST",
+        launcher.service(HttpMethod.POST,
                          String.format("http://localhost:8080/api/project/%s/permissions/my_project", workspace),
                          "http://localhost:8080/api",
                          headers,
@@ -2691,13 +2697,13 @@ public class ProjectServiceTest {
         myProject.getBaseFolder().getVirtualFile().updateACL(Arrays.asList(newEntry, newEntry2), false, null);
 
         HashMap<String, List<String>> headers = new HashMap<>(1);
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         AccessControlEntry update = DtoFactory.getInstance().createDto(AccessControlEntry.class)
                                               .withPermissions(Arrays.asList("only_custom"))
                                               .withPrincipal(DtoFactory.getInstance().createDto(Principal.class)
                                                                        .withName(vfsUser).withType(Principal.Type.USER));
-        launcher.service("POST",
+        launcher.service(HttpMethod.POST,
                          String.format("http://localhost:8080/api/project/%s/permissions/my_project", workspace),
                          "http://localhost:8080/api",
                          headers,
@@ -2733,7 +2739,7 @@ public class ProjectServiceTest {
         //set up permissions
         myProject.getBaseFolder().getVirtualFile().updateACL(Arrays.asList(newEntry, newEntry2), false, null);
 
-        ContainerResponse response = launcher.service("GET",
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format("http://localhost:8080/api/project/%s/permissions/my_project?userid=%s",
                                                                     workspace, vfsUser),
                                                       "http://localhost:8080/api",
@@ -2769,7 +2775,7 @@ public class ProjectServiceTest {
         //set up permissions
         myProject.getBaseFolder().getVirtualFile().updateACL(Arrays.asList(newEntry, newEntry2), false, null);
 
-        ContainerResponse response = launcher.service("GET",
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format("http://localhost:8080/api/project/%s/permissions/my_project",
                                                                     workspace),
                                                       "http://localhost:8080/api",
@@ -2796,9 +2802,9 @@ public class ProjectServiceTest {
         myProject.getBaseFolder().getVirtualFile().updateACL(Arrays.asList(entry), false, null);
 
         HashMap<String, List<String>> headers = new HashMap<>(1);
-        headers.put("Content-Type", Arrays.asList("application/json"));
+        headers.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
-        launcher.service("POST",
+        launcher.service(HttpMethod.POST,
                          String.format("http://localhost:8080/api/project/%s/permissions/my_project", workspace),
                          "http://localhost:8080/api",
                          headers,
@@ -2815,7 +2821,7 @@ public class ProjectServiceTest {
         FolderEntry environmentsFolder = myProject.getBaseFolder().createFolder(".codenvy/runners/environments");
         environmentsFolder.createFolder("my_env_1");
         environmentsFolder.createFolder("my_env_2");
-        ContainerResponse response = launcher.service("GET",
+        ContainerResponse response = launcher.service(HttpMethod.GET,
                                                       String.format("http://localhost:8080/api/project/%s/runner_environments/my_project",
                                                                     workspace),
                                                       "http://localhost:8080/api", null, null, null);
@@ -2896,7 +2902,7 @@ public class ProjectServiceTest {
 
 
         ContainerResponse response =
-                launcher.service("GET", String.format("http://localhost:8080/api/project/%s/estimate/%s?type=%s",
+                launcher.service(HttpMethod.GET, String.format("http://localhost:8080/api/project/%s/estimate/%s?type=%s",
                                 workspace, "testEstimateProjectGood","testEstimateProjectPT"),
                         "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
@@ -2906,7 +2912,7 @@ public class ProjectServiceTest {
         assertEquals(result.get("calculated_attribute").get(0), "checked");
 
         response =
-                launcher.service("GET", String.format("http://localhost:8080/api/project/%s/estimate/%s?type=%s",
+                launcher.service(HttpMethod.GET, String.format("http://localhost:8080/api/project/%s/estimate/%s?type=%s",
                                 workspace, "testEstimateProjectBad","testEstimateProjectPT"),
                         "http://localhost:8080/api", null, null, null);
         assertEquals(response.getStatus(), 409, "Error: " + response.getEntity());
@@ -2918,18 +2924,18 @@ public class ProjectServiceTest {
     private void validateFileLinks(ItemReference item) {
         Link link = item.getLink("delete");
         assertNotNull(link);
-        assertEquals(link.getMethod(), "DELETE");
+        assertEquals(link.getMethod(), HttpMethod.DELETE);
         assertEquals(link.getHref(), "http://localhost:8080/api/project/" + workspace + item.getPath());
 
         link = item.getLink("get content");
         assertNotNull(link);
-        assertEquals(link.getMethod(), "GET");
+        assertEquals(link.getMethod(), HttpMethod.GET);
         assertEquals(link.getProduces(), item.getMediaType());
         assertEquals(link.getHref(), "http://localhost:8080/api/project/" + workspace + "/file" + item.getPath());
 
         link = item.getLink("update content");
         assertNotNull(link);
-        assertEquals(link.getMethod(), "PUT");
+        assertEquals(link.getMethod(), HttpMethod.PUT);
         assertEquals(link.getConsumes(), "*/*");
         assertEquals(link.getHref(), "http://localhost:8080/api/project/" + workspace + "/file" + item.getPath());
     }
@@ -2937,74 +2943,74 @@ public class ProjectServiceTest {
     private void validateFolderLinks(ItemReference item) {
         Link link = item.getLink("children");
         assertNotNull(link);
-        assertEquals(link.getMethod(), "GET");
+        assertEquals(link.getMethod(), HttpMethod.GET);
         assertEquals(link.getHref(), "http://localhost:8080/api/project/" + workspace + "/children" + item.getPath());
-        assertEquals(link.getProduces(), "application/json");
+        assertEquals(link.getProduces(), MediaType.APPLICATION_JSON);
 
         link = item.getLink("tree");
         assertNotNull(link);
-        assertEquals(link.getMethod(), "GET");
+        assertEquals(link.getMethod(), HttpMethod.GET);
         assertEquals(link.getHref(), "http://localhost:8080/api/project/" + workspace + "/tree" + item.getPath());
-        assertEquals(link.getProduces(), "application/json");
+        assertEquals(link.getProduces(), MediaType.APPLICATION_JSON);
 
         link = item.getLink("modules");
         assertNotNull(link);
-        assertEquals(link.getMethod(), "GET");
+        assertEquals(link.getMethod(), HttpMethod.GET);
         assertEquals(link.getHref(), "http://localhost:8080/api/project/" + workspace + "/modules" + item.getPath());
-        assertEquals(link.getProduces(), "application/json");
+        assertEquals(link.getProduces(), MediaType.APPLICATION_JSON);
 
         link = item.getLink("zipball sources");
         assertNotNull(link);
-        assertEquals(link.getMethod(), "GET");
+        assertEquals(link.getMethod(), HttpMethod.GET);
         assertEquals(link.getHref(), "http://localhost:8080/api/project/" + workspace + "/export" + item.getPath());
-        assertEquals(link.getProduces(), "application/zip");
+        assertEquals(link.getProduces(), ExtMediaType.APPLICATION_ZIP);
 
         link = item.getLink("delete");
         assertNotNull(link);
-        assertEquals(link.getMethod(), "DELETE");
+        assertEquals(link.getMethod(), HttpMethod.DELETE);
         assertEquals(link.getHref(), "http://localhost:8080/api/project/" + workspace + item.getPath());
     }
 
     private void validateProjectLinks(ProjectDescriptor project) {
         Link link = project.getLink("update project");
         assertNotNull(link);
-        assertEquals(link.getMethod(), "PUT");
+        assertEquals(link.getMethod(), HttpMethod.PUT);
         assertEquals(link.getHref(), "http://localhost:8080/api/project/" + workspace + project.getPath());
-        assertEquals(link.getConsumes(), "application/json");
-        assertEquals(link.getProduces(), "application/json");
+        assertEquals(link.getConsumes(), MediaType.APPLICATION_JSON);
+        assertEquals(link.getProduces(), MediaType.APPLICATION_JSON);
 
         link = project.getLink("children");
         assertNotNull(link);
-        assertEquals(link.getMethod(), "GET");
+        assertEquals(link.getMethod(), HttpMethod.GET);
         assertEquals(link.getHref(), "http://localhost:8080/api/project/" + workspace + "/children" + project.getPath());
-        assertEquals(link.getProduces(), "application/json");
+        assertEquals(link.getProduces(), MediaType.APPLICATION_JSON);
 
         link = project.getLink("tree");
         assertNotNull(link);
-        assertEquals(link.getMethod(), "GET");
+        assertEquals(link.getMethod(), HttpMethod.GET);
         assertEquals(link.getHref(), "http://localhost:8080/api/project/" + workspace + "/tree" + project.getPath());
-        assertEquals(link.getProduces(), "application/json");
+        assertEquals(link.getProduces(), MediaType.APPLICATION_JSON);
 
         link = project.getLink("modules");
         assertNotNull(link);
-        assertEquals(link.getMethod(), "GET");
+        assertEquals(link.getMethod(), HttpMethod.GET);
         assertEquals(link.getHref(), "http://localhost:8080/api/project/" + workspace + "/modules" + project.getPath());
-        assertEquals(link.getProduces(), "application/json");
+        assertEquals(link.getProduces(), MediaType.APPLICATION_JSON);
 
         link = project.getLink("zipball sources");
         assertNotNull(link);
-        assertEquals(link.getMethod(), "GET");
+        assertEquals(link.getMethod(), HttpMethod.GET);
         assertEquals(link.getHref(), "http://localhost:8080/api/project/" + workspace + "/export" + project.getPath());
-        assertEquals(link.getProduces(), "application/zip");
+        assertEquals(link.getProduces(), ExtMediaType.APPLICATION_ZIP);
 
         link = project.getLink("delete");
         assertNotNull(link);
-        assertEquals(link.getMethod(), "DELETE");
+        assertEquals(link.getMethod(), HttpMethod.DELETE);
         assertEquals(link.getHref(), "http://localhost:8080/api/project/" + workspace + project.getPath());
 
         link = project.getLink("get runner environments");
         assertNotNull(link);
-        assertEquals(link.getMethod(), "GET");
+        assertEquals(link.getMethod(), HttpMethod.GET);
         assertEquals(link.getHref(), "http://localhost:8080/api/project/" + workspace + "/runner_environments" + project.getPath());
     }
 

--- a/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectTemplateServiceTest.java
+++ b/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectTemplateServiceTest.java
@@ -15,7 +15,6 @@ import org.eclipse.che.api.core.rest.CodenvyJsonProvider;
 import org.eclipse.che.api.project.shared.dto.ProjectTemplateDescriptor;
 import org.eclipse.che.api.vfs.server.ContentStream;
 import org.eclipse.che.api.vfs.server.ContentStreamWriter;
-
 import org.everrest.core.ResourceBinder;
 import org.everrest.core.impl.ApplicationContextImpl;
 import org.everrest.core.impl.ApplicationProviderBinder;
@@ -30,7 +29,9 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.Application;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -84,7 +85,7 @@ public class ProjectTemplateServiceTest {
     @Test
     public void getTemplates() throws Exception {
         ContainerResponse response =
-                launcher.service("GET", "http://localhost:8080/api/project-template/test", "http://localhost:8080/api", null, null, null);
+                launcher.service(HttpMethod.GET, "http://localhost:8080/api/project-template/test", "http://localhost:8080/api", null, null, null);
         Assert.assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
         List<ProjectTemplateDescriptor> result = (List<ProjectTemplateDescriptor>)response.getEntity();
 

--- a/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectTest.java
+++ b/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectTest.java
@@ -20,14 +20,12 @@ import org.eclipse.che.api.project.server.type.ProjectType;
 import org.eclipse.che.api.project.server.type.ProjectTypeRegistry;
 import org.eclipse.che.api.project.shared.dto.ProjectUpdate;
 import org.eclipse.che.api.project.shared.dto.SourceEstimation;
-
 import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.server.VirtualFileSystemRegistry;
 import org.eclipse.che.api.vfs.server.VirtualFileSystemUser;
 import org.eclipse.che.api.vfs.server.VirtualFileSystemUserContext;
 import org.eclipse.che.api.vfs.server.impl.memory.MemoryFileSystemProvider;
 import org.eclipse.che.api.vfs.server.impl.memory.MemoryMountPoint;
-
 import org.eclipse.che.dto.server.DtoFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -35,6 +33,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.*;
+
+import javax.ws.rs.core.MediaType;
 
 /**
  * @author andrew00x
@@ -202,7 +202,7 @@ public class ProjectTest {
         Project myProject = pm.getProject("my_ws", "my_project");
         long modificationDate1 = myProject.getModificationDate();
         Thread.sleep(1000);
-        myProject.getBaseFolder().createFile("test.txt", "test".getBytes(), "text/plain");
+        myProject.getBaseFolder().createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
         long modificationDate2 = myProject.getModificationDate();
         Assert.assertTrue(modificationDate2 > modificationDate1);
     }

--- a/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RemoteRunnerProcess.java
+++ b/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RemoteRunnerProcess.java
@@ -21,6 +21,7 @@ import org.eclipse.che.api.core.rest.OutputProvider;
 import org.eclipse.che.api.core.rest.shared.dto.Link;
 import org.eclipse.che.api.runner.dto.ApplicationProcessDescriptor;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Closer;
 
@@ -31,6 +32,9 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
 
 /**
  * Representation of remote application process.
@@ -126,7 +130,7 @@ public class RemoteRunnerProcess {
     }
 
     public void readRecipeFile(OutputProvider output) throws IOException, RunnerException {
-        doRequest(String.format("%s/recipe/%s/%d", baseUrl, runner, processId), "GET", output);
+        doRequest(String.format("%s/recipe/%s/%d", baseUrl, runner, processId), HttpMethod.GET, output);
     }
 
     private void doRequest(String url, String method, final OutputProvider output) throws IOException {
@@ -140,12 +144,12 @@ public class RemoteRunnerProcess {
                 httpOutput.setStatus(conn.getResponseCode());
                 final String contentType = conn.getContentType();
                 if (contentType != null) {
-                    httpOutput.addHttpHeader("Content-Type", contentType);
+                    httpOutput.addHttpHeader(HttpHeaders.CONTENT_TYPE, contentType);
                 }
                 // for download files
-                final String contentDisposition = conn.getHeaderField("Content-Disposition");
+                final String contentDisposition = conn.getHeaderField(HttpHeaders.CONTENT_DISPOSITION);
                 if (contentDisposition != null) {
-                    httpOutput.addHttpHeader("Content-Disposition", contentDisposition);
+                    httpOutput.addHttpHeader(HttpHeaders.CONTENT_DISPOSITION, contentDisposition);
                 }
             }
             Closer closer = Closer.create();

--- a/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RunQueue.java
+++ b/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RunQueue.java
@@ -68,8 +68,10 @@ import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
+
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -1217,7 +1219,7 @@ public class RunQueue {
         @Override
         public void run() {
             boolean ok = false;
-            String requestMethod = "HEAD";
+            String requestMethod = HttpMethod.HEAD;
             for (int i = 0; !ok && i < healthCheckAttempts; i++) {
                 if (Thread.currentThread().isInterrupted()) {
                     return;
@@ -1240,7 +1242,7 @@ public class RunQueue {
                         // to weak and will trigger much more GET than with this fallback.
                         // Note: Response.Status in JAX-WS in JEE6 hasn't any status matching 405, so here we use int code comparison. Fixed
                         // in JEE7.
-                        requestMethod = "GET";
+                        requestMethod = HttpMethod.GET;
                     }
                     Response.Status status = Response.Status.fromStatusCode(conn.getResponseCode());
                     if (status == null) {

--- a/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RunQueueTask.java
+++ b/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RunQueueTask.java
@@ -25,8 +25,10 @@ import org.eclipse.che.api.runner.internal.Constants;
 import org.eclipse.che.api.runner.internal.RunnerEvent;
 import org.eclipse.che.dto.server.DtoFactory;
 
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -120,13 +122,13 @@ public class RunQueueTask implements Cancellable {
                 links.add(dtoFactory.createDto(Link.class)
                                     .withRel(Constants.LINK_REL_GET_STATUS)
                                     .withHref(getUriBuilder().path(RunnerService.class, "getStatus")
-                                                             .build(request.getWorkspace(), id).toString()).withMethod("GET")
+                                                             .build(request.getWorkspace(), id).toString()).withMethod(HttpMethod.GET)
                                     .withProduces(MediaType.APPLICATION_JSON));
                 links.add(dtoFactory.createDto(Link.class)
                                     .withRel(Constants.LINK_REL_STOP)
                                     .withHref(getUriBuilder().path(RunnerService.class, "stop")
                                                              .build(request.getWorkspace(), id).toString())
-                                    .withMethod("POST")
+                                    .withMethod(HttpMethod.POST)
                                     .withProduces(MediaType.APPLICATION_JSON));
                 final List<RunnerMetric> runStats = new ArrayList<>(2);
                 runStats.add(dtoFactory.createDto(RunnerMetric.class).withName(RunnerMetric.WAITING_TIME_LIMIT)

--- a/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RunnerService.java
+++ b/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RunnerService.java
@@ -45,6 +45,7 @@ import javax.inject.Inject;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -52,6 +53,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -367,7 +369,7 @@ public class RunnerService extends Service {
         }
 
         // TODO needs to improve this code
-        String json = HttpJsonHelper.requestString(link.getHref(), "GET", null, Pair.of("id", id));
+        String json = HttpJsonHelper.requestString(link.getHref(), HttpMethod.GET, null, Pair.of("id", id));
         json = json.substring(START.length());
         json = json.substring(0, json.length() - END.length());
 

--- a/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/internal/ApplicationLogger.java
+++ b/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/internal/ApplicationLogger.java
@@ -14,6 +14,8 @@ import org.eclipse.che.api.core.util.LineConsumer;
 
 import java.io.IOException;
 
+import javax.ws.rs.core.MediaType;
+
 /**
  * Collects application logs. A ApplicationLogger is open after creation, and may consumes applications logs with method {@link
  * #writeLine(String)}. Once a ApplicationLogger is closed, any attempt to write new lines upon it will cause a {@link java.io.IOException}
@@ -47,7 +49,7 @@ public interface ApplicationLogger extends LineConsumer {
 
         @Override
         public String getContentType() {
-            return "text/plain";
+            return MediaType.TEXT_PLAIN;
         }
 
         @Override

--- a/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/internal/SlaveRunnerService.java
+++ b/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/internal/SlaveRunnerService.java
@@ -29,8 +29,8 @@ import org.eclipse.che.api.runner.dto.ServerState;
 import org.eclipse.che.api.runner.dto.ApplicationProcessDescriptor;
 import org.eclipse.che.api.runner.dto.PortMapping;
 import org.eclipse.che.api.runner.dto.RunnerState;
-
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.io.Files;
 
 import javax.annotation.CheckForNull;
@@ -39,6 +39,7 @@ import javax.inject.Named;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -48,6 +49,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
+
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.nio.file.Paths;
@@ -128,7 +130,7 @@ public class SlaveRunnerService extends Service {
         final Throwable error = process.getError();
         if (error != null) {
             final PrintWriter output = httpServletResponse.getWriter();
-            httpServletResponse.setContentType("text/plain");
+            httpServletResponse.setContentType(MediaType.TEXT_PLAIN);
             if (error instanceof RunnerException) {
                 // expect ot have nice messages from our API
                 output.write(error.getMessage());
@@ -157,7 +159,7 @@ public class SlaveRunnerService extends Service {
             throw new NotFoundException("Recipe file isn't available. ");
         }
         final PrintWriter output = httpServletResponse.getWriter();
-        httpServletResponse.setContentType("text/plain");
+        httpServletResponse.setContentType(MediaType.TEXT_PLAIN);
         Files.copy(recipeFile, Charset.forName("UTF-8"), output);
         output.flush();
     }
@@ -238,13 +240,13 @@ public class SlaveRunnerService extends Service {
                             .withRel(Constants.LINK_REL_GET_STATUS)
                             .withHref(servicePathBuilder.clone().path(getClass(), "getStatus")
                                                         .build(process.getRunner(), process.getId()).toString())
-                            .withMethod("GET")
+                            .withMethod(HttpMethod.GET)
                             .withProduces(MediaType.APPLICATION_JSON));
         links.add(dtoFactory.createDto(Link.class)
                             .withRel(Constants.LINK_REL_VIEW_LOG)
                             .withHref(servicePathBuilder.clone().path(getClass(), "getLogs")
                                                         .build(process.getRunner(), process.getId()).toString())
-                            .withMethod("GET"));
+                            .withMethod(HttpMethod.GET));
         switch (status) {
             case NEW:
             case RUNNING:
@@ -252,7 +254,7 @@ public class SlaveRunnerService extends Service {
                                     .withRel(Constants.LINK_REL_STOP)
                                     .withHref(servicePathBuilder.clone().path(getClass(), "stop")
                                                                 .build(process.getRunner(), process.getId()).toString())
-                                    .withMethod("POST")
+                                    .withMethod(HttpMethod.POST)
                                     .withProduces(MediaType.APPLICATION_JSON));
                 break;
         }
@@ -264,7 +266,7 @@ public class SlaveRunnerService extends Service {
                                 .withRel(Constants.LINK_REL_RUNNER_RECIPE)
                                 .withHref(servicePathBuilder.clone().path(getClass(), "getRecipeFile")
                                                             .build(process.getRunner(), process.getId()).toString())
-                                .withMethod("GET")
+                                .withMethod(HttpMethod.GET)
                                 .withProduces(MediaType.TEXT_PLAIN));
         }
         final List<Link> additionalLinks = new LinkedList<>();

--- a/platform-api/che-core-api-runner/src/test/java/org/eclipse/che/api/runner/RunQueueTest.java
+++ b/platform-api/che-core-api-runner/src/test/java/org/eclipse/che/api/runner/RunQueueTest.java
@@ -50,7 +50,9 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.UriBuilder;
+
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -131,7 +133,7 @@ public class RunQueueTest {
         verify(runQueue, timeout(1000).times(1)).start();
 
         project = dto(ProjectDescriptor.class).withName(pName).withPath(pPath);
-        project.getLinks().add(dto(Link.class).withMethod("GET")
+        project.getLinks().add(dto(Link.class).withMethod(HttpMethod.GET)
                                               .withHref(String.format("http://localhost:8080/api/project/%s/%s", wsId, pPath))
                                               .withRel(org.eclipse.che.api.project.server.Constants.LINK_REL_EXPORT_ZIP));
         workspace = dto(WorkspaceDescriptor.class).withId(wsId).withName(wsName).withTemporary(false).withAccountId("my_account");
@@ -671,20 +673,20 @@ public class RunQueueTest {
         assertTrue(inProgressNum >= 1);
         final BuildTaskDescriptor buildTaskQueue = dto(BuildTaskDescriptor.class).withStatus(BuildStatus.IN_QUEUE);
         String statusLink = String.format("http://localhost:8080/api/builder/%s/status/%d", wsId, 1);
-        buildTaskQueue.getLinks().add(dto(Link.class).withMethod("GET")
+        buildTaskQueue.getLinks().add(dto(Link.class).withMethod(HttpMethod.GET)
                                                      .withHref(statusLink)
                                                      .withRel(org.eclipse.che.api.builder.internal.Constants.LINK_REL_GET_STATUS));
         doReturn(buildTaskQueue).when(runQueue).startBuild(any(RemoteServiceDescriptor.class), eq(pPath), any(BuildOptions.class));
 
         final BuildTaskDescriptor buildTaskProgress = dtoFactory.clone(buildTaskQueue).withStatus(BuildStatus.IN_PROGRESS);
         String cancelLink = String.format("http://localhost:8080/api/builder/%s/cancel/%d", wsId, 1);
-        buildTaskProgress.getLinks().add(dto(Link.class).withMethod("GET")
+        buildTaskProgress.getLinks().add(dto(Link.class).withMethod(HttpMethod.GET)
                                                         .withHref(cancelLink)
                                                         .withRel(org.eclipse.che.api.builder.internal.Constants.LINK_REL_CANCEL));
 
         final BuildTaskDescriptor buildTaskDone = dtoFactory.clone(buildTaskQueue).withStatus(BuildStatus.SUCCESSFUL);
         String downloadLink = String.format("http://localhost:8080/api/builder/%s/download/%d?path=artifact", wsId, 1);
-        buildTaskDone.getLinks().add(dto(Link.class).withMethod("GET")
+        buildTaskDone.getLinks().add(dto(Link.class).withMethod(HttpMethod.GET)
                                                     .withHref(downloadLink)
                                                     .withRel(org.eclipse.che.api.builder.internal.Constants.LINK_REL_DOWNLOAD_RESULT));
         doAnswer(new Answer<BuildTaskDescriptor>() {
@@ -701,7 +703,7 @@ public class RunQueueTest {
                 }
                 return buildTaskDone;
             }
-        }).when(httpJsonHelper).request(eq(BuildTaskDescriptor.class), eq(statusLink), eq("GET"), any());
+        }).when(httpJsonHelper).request(eq(BuildTaskDescriptor.class), eq(statusLink), eq(HttpMethod.GET), any());
         return downloadLink;
     }
 

--- a/platform-api/che-core-api-runner/src/test/java/org/eclipse/che/api/runner/RunnerAdminServiceTest.java
+++ b/platform-api/che-core-api-runner/src/test/java/org/eclipse/che/api/runner/RunnerAdminServiceTest.java
@@ -18,7 +18,6 @@ import org.eclipse.che.api.runner.dto.RunnerServer;
 import org.eclipse.che.api.runner.dto.ServerState;
 import org.eclipse.che.api.runner.internal.Constants;
 import org.eclipse.che.dto.server.DtoFactory;
-
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -29,6 +28,8 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.ws.rs.HttpMethod;
 
 import static junit.framework.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
@@ -89,11 +90,11 @@ public class RunnerAdminServiceTest {
         RemoteRunnerServer server1 = mock(RemoteRunnerServer.class);
         doReturn(serverUrl1).when(server1).getBaseUrl();
         ServiceDescriptor serviceDescriptor = dto(ServiceDescriptor.class);
-        Link availableLink = dto(Link.class).withRel(Constants.LINK_REL_AVAILABLE_RUNNERS).withMethod("GET").withHref(
+        Link availableLink = dto(Link.class).withRel(Constants.LINK_REL_AVAILABLE_RUNNERS).withMethod(HttpMethod.GET).withHref(
                 serverUrl1 + "/available");
-        Link serverStateLink = dto(Link.class).withRel(Constants.LINK_REL_SERVER_STATE).withMethod("GET").withHref(
+        Link serverStateLink = dto(Link.class).withRel(Constants.LINK_REL_SERVER_STATE).withMethod(HttpMethod.GET).withHref(
                 serverUrl1 + "/server-state");
-        Link runnerStateLink = dto(Link.class).withRel(Constants.LINK_REL_RUNNER_STATE).withMethod("GET").withHref(serverUrl1 + "/state");
+        Link runnerStateLink = dto(Link.class).withRel(Constants.LINK_REL_RUNNER_STATE).withMethod(HttpMethod.GET).withHref(serverUrl1 + "/state");
         serviceDescriptor.getLinks().add(availableLink);
         serviceDescriptor.getLinks().add(serverStateLink);
         serviceDescriptor.getLinks().add(runnerStateLink);

--- a/platform-api/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/UserProfileService.java
+++ b/platform-api/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/UserProfileService.java
@@ -26,7 +26,6 @@ import org.eclipse.che.api.user.server.dao.User;
 import org.eclipse.che.api.user.server.dao.UserDao;
 import org.eclipse.che.api.user.server.dao.UserProfileDao;
 import org.eclipse.che.api.user.shared.dto.ProfileDescriptor;
-
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.dto.server.DtoFactory;
 
@@ -44,6 +43,7 @@ import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -52,6 +52,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriBuilder;
+
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -65,7 +66,6 @@ import static org.eclipse.che.api.user.server.Constants.LINK_REL_REMOVE_ATTRIBUT
 import static org.eclipse.che.api.user.server.Constants.LINK_REL_REMOVE_PREFERENCES;
 import static org.eclipse.che.api.user.server.Constants.LINK_REL_UPDATE_PREFERENCES;
 import static org.eclipse.che.api.user.server.Constants.LINK_REL_UPDATE_USER_PROFILE_BY_ID;
-
 import static com.google.common.base.Strings.nullToEmpty;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -350,7 +350,7 @@ public class UserProfileService extends Service {
         final UriBuilder uriBuilder = getServiceContext().getServiceUriBuilder();
         final List<Link> links = new LinkedList<>();
         if (context.isUserInRole("user")) {
-            links.add(LinksHelper.createLink("GET",
+            links.add(LinksHelper.createLink(HttpMethod.GET,
                                              uriBuilder.clone()
                                                        .path(getClass(), "getCurrent")
                                                        .build()
@@ -358,7 +358,7 @@ public class UserProfileService extends Service {
                                              null,
                                              APPLICATION_JSON,
                                              LINK_REL_GET_CURRENT_USER_PROFILE));
-            links.add(LinksHelper.createLink("GET",
+            links.add(LinksHelper.createLink(HttpMethod.GET,
                                              uriBuilder.clone()
                                                        .path(getClass(), "getById")
                                                        .build(profile.getId())
@@ -366,7 +366,7 @@ public class UserProfileService extends Service {
                                              null,
                                              APPLICATION_JSON,
                                              LINK_REL_GET_USER_PROFILE_BY_ID));
-            links.add(LinksHelper.createLink("POST",
+            links.add(LinksHelper.createLink(HttpMethod.POST,
                                              uriBuilder.clone()
                                                        .path(getClass(), "updateCurrent")
                                                        .build()
@@ -374,7 +374,7 @@ public class UserProfileService extends Service {
                                              APPLICATION_JSON,
                                              APPLICATION_JSON,
                                              LINK_REL_UPDATE_CURRENT_USER_PROFILE));
-            links.add(LinksHelper.createLink("POST",
+            links.add(LinksHelper.createLink(HttpMethod.POST,
                                              uriBuilder.clone()
                                                        .path(getClass(), "updatePreferences")
                                                        .build()
@@ -384,7 +384,7 @@ public class UserProfileService extends Service {
                                              LINK_REL_UPDATE_PREFERENCES));
         }
         if (context.isUserInRole("system/admin") || context.isUserInRole("system/manager")) {
-            links.add(LinksHelper.createLink("GET",
+            links.add(LinksHelper.createLink(HttpMethod.GET,
                                              uriBuilder.clone()
                                                        .path(getClass(), "getById")
                                                        .build(profile.getId())
@@ -394,7 +394,7 @@ public class UserProfileService extends Service {
                                              LINK_REL_GET_USER_PROFILE_BY_ID));
         }
         if (context.isUserInRole("system/admin")) {
-            links.add(LinksHelper.createLink("POST",
+            links.add(LinksHelper.createLink(HttpMethod.POST,
                                              uriBuilder.clone()
                                                        .path(getClass(), "update")
                                                        .build(profile.getId())

--- a/platform-api/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/UserService.java
+++ b/platform-api/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/UserService.java
@@ -48,6 +48,7 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -57,6 +58,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriBuilder;
+
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -421,7 +423,7 @@ public class UserService extends Service {
         final List<Link> links = new LinkedList<>();
         final UriBuilder uriBuilder = getServiceContext().getServiceUriBuilder();
         if (context.isUserInRole("user")) {
-            links.add(LinksHelper.createLink("GET",
+            links.add(LinksHelper.createLink(HttpMethod.GET,
                                              getServiceContext().getBaseUriBuilder().path(UserProfileService.class)
                                                                 .path(UserProfileService.class, "getCurrent")
                                                                 .build()
@@ -429,7 +431,7 @@ public class UserService extends Service {
                                              null,
                                              APPLICATION_JSON,
                                              LINK_REL_GET_CURRENT_USER_PROFILE));
-            links.add(LinksHelper.createLink("GET",
+            links.add(LinksHelper.createLink(HttpMethod.GET,
                                              uriBuilder.clone()
                                                        .path(getClass(), "getCurrent")
                                                        .build()
@@ -437,7 +439,7 @@ public class UserService extends Service {
                                              null,
                                              APPLICATION_JSON,
                                              LINK_REL_GET_CURRENT_USER));
-            links.add(LinksHelper.createLink("POST",
+            links.add(LinksHelper.createLink(HttpMethod.POST,
                                              uriBuilder.clone()
                                                        .path(getClass(), "updatePassword")
                                                        .build()
@@ -447,7 +449,7 @@ public class UserService extends Service {
                                              LINK_REL_UPDATE_PASSWORD));
         }
         if (context.isUserInRole("system/admin") || context.isUserInRole("system/manager")) {
-            links.add(LinksHelper.createLink("GET",
+            links.add(LinksHelper.createLink(HttpMethod.GET,
                                              uriBuilder.clone()
                                                        .path(getClass(), "getById")
                                                        .build(user.getId())
@@ -455,7 +457,7 @@ public class UserService extends Service {
                                              null,
                                              APPLICATION_JSON,
                                              LINK_REL_GET_USER_BY_ID));
-            links.add(LinksHelper.createLink("GET",
+            links.add(LinksHelper.createLink(HttpMethod.GET,
                                              getServiceContext().getBaseUriBuilder()
                                                                 .path(UserProfileService.class).path(UserProfileService.class, "getById")
                                                                 .build(user.getId())
@@ -464,7 +466,7 @@ public class UserService extends Service {
                                              APPLICATION_JSON,
                                              LINK_REL_GET_USER_PROFILE_BY_ID));
             if (user.getEmail() != null) {
-                links.add(LinksHelper.createLink("GET",
+                links.add(LinksHelper.createLink(HttpMethod.GET,
                                                  uriBuilder.clone()
                                                            .path(getClass(), "getByEmail")
                                                            .queryParam("email", user.getEmail())
@@ -476,7 +478,7 @@ public class UserService extends Service {
             }
         }
         if (context.isUserInRole("system/admin")) {
-            links.add(LinksHelper.createLink("DELETE",
+            links.add(LinksHelper.createLink(HttpMethod.DELETE,
                                              uriBuilder.clone()
                                                        .path(getClass(), "remove")
                                                        .build(user.getId())

--- a/platform-api/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/UserProfileServiceTest.java
+++ b/platform-api/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/UserProfileServiceTest.java
@@ -20,9 +20,7 @@ import org.eclipse.che.api.user.server.dao.User;
 import org.eclipse.che.api.user.server.dao.UserDao;
 import org.eclipse.che.api.user.server.dao.UserProfileDao;
 import org.eclipse.che.api.user.shared.dto.ProfileDescriptor;
-
 import org.eclipse.che.commons.json.JsonHelper;
-
 import org.everrest.core.impl.ApplicationContextImpl;
 import org.everrest.core.impl.ApplicationProviderBinder;
 import org.everrest.core.impl.ContainerRequest;
@@ -40,6 +38,9 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
@@ -55,7 +56,6 @@ import static org.eclipse.che.api.user.server.Constants.LINK_REL_UPDATE_CURRENT_
 import static org.eclipse.che.api.user.server.Constants.LINK_REL_GET_CURRENT_USER_PROFILE;
 import static org.eclipse.che.api.user.server.Constants.LINK_REL_GET_USER_PROFILE_BY_ID;
 import static org.eclipse.che.api.user.server.Constants.LINK_REL_UPDATE_PREFERENCES;
-
 import static org.eclipse.che.api.user.server.Constants.LINK_REL_UPDATE_USER_PROFILE_BY_ID;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
@@ -64,7 +64,6 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
-
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -168,7 +167,7 @@ public class UserProfileServiceTest {
         final Profile current = new Profile().withId(testUser.getId()).withUserId(testUser.getId());
         when(profileDao.getById(current.getId())).thenReturn(current);
 
-        final ContainerResponse response = makeRequest("GET", SERVICE_PATH, null);
+        final ContainerResponse response = makeRequest(HttpMethod.GET, SERVICE_PATH, null);
 
         assertEquals(response.getStatus(), OK.getStatusCode());
         final ProfileDescriptor descriptor = (ProfileDescriptor)response.getEntity();
@@ -185,7 +184,7 @@ public class UserProfileServiceTest {
         preferences.put("test3", "test3");
         when(preferenceDao.getPreferences(testUser.getId())).thenReturn(preferences);
 
-        final ContainerResponse response = makeRequest("GET", SERVICE_PATH + "/prefs", null);
+        final ContainerResponse response = makeRequest(HttpMethod.GET, SERVICE_PATH + "/prefs", null);
 
         assertEquals(response.getStatus(), OK.getStatusCode());
         assertEquals(response.getEntity(), preferences);
@@ -200,7 +199,7 @@ public class UserProfileServiceTest {
         final Profile profile = new Profile().withId(testUser.getId()).withAttributes(attributes);
         when(profileDao.getById(profile.getId())).thenReturn(profile);
 
-        final ContainerResponse response = makeRequest("DELETE", SERVICE_PATH + "/attributes", asList("test", "test2"));
+        final ContainerResponse response = makeRequest(HttpMethod.DELETE, SERVICE_PATH + "/attributes", asList("test", "test2"));
 
         assertEquals(response.getStatus(), NO_CONTENT.getStatusCode());
         verify(profileDao, times(1)).update(profile);
@@ -217,7 +216,7 @@ public class UserProfileServiceTest {
         final Profile profile = new Profile().withId(testUser.getId()).withAttributes(attributes);
         when(profileDao.getById(profile.getId())).thenReturn(profile);
 
-        final ContainerResponse response = makeRequest("DELETE", SERVICE_PATH + "/attributes", null);
+        final ContainerResponse response = makeRequest(HttpMethod.DELETE, SERVICE_PATH + "/attributes", null);
 
         assertEquals(response.getStatus(), NO_CONTENT.getStatusCode());
         verify(profileDao, times(1)).update(profile);
@@ -233,7 +232,7 @@ public class UserProfileServiceTest {
         when(preferenceDao.getPreferences(testUser.getId())).thenReturn(preferences);
         final Map<String, String> update = singletonMap("test1", "new_value");
 
-        final ContainerResponse response = makeRequest("POST", SERVICE_PATH + "/prefs", update);
+        final ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH + "/prefs", update);
 
         preferences.putAll(update);
         assertEquals(response.getStatus(), OK.getStatusCode());
@@ -243,14 +242,14 @@ public class UserProfileServiceTest {
 
     @Test
     public void shouldThrowExceptionIfPreferencesUpdateIsNull() throws Exception {
-        final ContainerResponse response = makeRequest("POST", SERVICE_PATH + "/prefs", null);
+        final ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH + "/prefs", null);
 
         assertEquals(response.getStatus(), 409);
     }
 
     @Test
     public void shouldThrowExceptionIfPreferencesUpdateIsEmpty() throws Exception {
-        final ContainerResponse response = makeRequest("POST", SERVICE_PATH + "/prefs", emptyMap());
+        final ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH + "/prefs", emptyMap());
 
         assertEquals(response.getStatus(), 409);
     }
@@ -263,7 +262,7 @@ public class UserProfileServiceTest {
         preferences.put("test3", "test3");
         when(preferenceDao.getPreferences(testUser.getId())).thenReturn(preferences);
 
-        final ContainerResponse response = makeRequest("DELETE", SERVICE_PATH + "/prefs", singletonList("test1"));
+        final ContainerResponse response = makeRequest(HttpMethod.DELETE, SERVICE_PATH + "/prefs", singletonList("test1"));
 
         assertEquals(response.getStatus(), NO_CONTENT.getStatusCode());
         assertNull(preferences.get("test1"));
@@ -272,7 +271,7 @@ public class UserProfileServiceTest {
 
     @Test
     public void shouldRemoveAllPreferencesIfNullWasSend() throws Exception {
-        final ContainerResponse response = makeRequest("DELETE", SERVICE_PATH + "/prefs", null);
+        final ContainerResponse response = makeRequest(HttpMethod.DELETE, SERVICE_PATH + "/prefs", null);
 
         assertEquals(response.getStatus(), NO_CONTENT.getStatusCode());
         verify(preferenceDao).remove(testUser.getId());
@@ -284,7 +283,7 @@ public class UserProfileServiceTest {
                                              .withUserId(testUser.getId());
         when(profileDao.getById(profile.getId())).thenReturn(profile);
 
-        final ContainerResponse response = makeRequest("GET", SERVICE_PATH + "/" + profile.getId(), null);
+        final ContainerResponse response = makeRequest(HttpMethod.GET, SERVICE_PATH + "/" + profile.getId(), null);
 
         assertEquals(response.getStatus(), OK.getStatusCode());
         final ProfileDescriptor descriptor = (ProfileDescriptor)response.getEntity();
@@ -302,7 +301,7 @@ public class UserProfileServiceTest {
         attributes.put("existed", "new");
         attributes.put("new", "value");
 
-        final ContainerResponse response = makeRequest("POST", SERVICE_PATH, attributes);
+        final ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH, attributes);
 
         assertEquals(response.getStatus(), OK.getStatusCode());
         verify(profileDao, times(1)).update(profile);
@@ -311,28 +310,28 @@ public class UserProfileServiceTest {
 
     @Test
     public void shouldThrowExceptionIfAttributesUpdateForCurrentProfileIsNull() throws Exception {
-        final ContainerResponse response = makeRequest("POST", SERVICE_PATH, null);
+        final ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH, null);
 
         assertEquals(response.getStatus(), 409);
     }
 
     @Test
     public void shouldThrowExceptionIfAttributesUpdateForCurrentProfileIsEmpty() throws Exception {
-        final ContainerResponse response = makeRequest("POST", SERVICE_PATH, emptyMap());
+        final ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH, emptyMap());
 
         assertEquals(response.getStatus(), 409);
     }
 
     @Test
     public void shouldThrowExceptionIfAttributesUpdateForSpecificProfileIsNull() throws Exception {
-        final ContainerResponse response = makeRequest("POST", SERVICE_PATH + "/any_profile_id", null);
+        final ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH + "/any_profile_id", null);
 
         assertEquals(response.getStatus(), 409);
     }
 
     @Test
     public void shouldThrowExceptionIfAttributesUpdateForSpecificProfileIsEmpty() throws Exception {
-        final ContainerResponse response = makeRequest("POST", SERVICE_PATH + "/any_profile_id", emptyMap());
+        final ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH + "/any_profile_id", emptyMap());
 
         assertEquals(response.getStatus(), 409);
     }
@@ -347,7 +346,7 @@ public class UserProfileServiceTest {
         attributes.put("existed", "new");
         attributes.put("new", "value");
 
-        final ContainerResponse response = makeRequest("POST", SERVICE_PATH + "/" + profile.getId(), attributes);
+        final ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH + "/" + profile.getId(), attributes);
 
         assertEquals(response.getStatus(), OK.getStatusCode());
         assertEquals(((ProfileDescriptor)response.getEntity()).getAttributes(), attributes);
@@ -399,7 +398,7 @@ public class UserProfileServiceTest {
         byte[] data = null;
         if (entity != null) {
             headers = new HashMap<>();
-            headers.put("Content-Type", singletonList("application/json"));
+            headers.put(HttpHeaders.CONTENT_TYPE, singletonList(MediaType.APPLICATION_JSON));
             data = JsonHelper.toJson(entity).getBytes();
         }
         return launcher.service(method, path, BASE_URI, headers, data, null, environmentContext);

--- a/platform-api/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/UserServiceTest.java
+++ b/platform-api/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/UserServiceTest.java
@@ -39,8 +39,12 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -145,7 +149,7 @@ public class UserServiceTest {
         final String token = "test_token";
         when(tokenValidator.validateToken(token)).thenReturn(userEmail);
 
-        final ContainerResponse response = makeRequest("POST", SERVICE_PATH + "/create?token=" + token, null);
+        final ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH + "/create?token=" + token, null);
 
         assertEquals(response.getStatus(), CREATED.getStatusCode());
         final UserDescriptor user = (UserDescriptor) response.getEntity();
@@ -163,7 +167,7 @@ public class UserServiceTest {
                                           .withPassword("password123");
         when(securityContext.isUserInRole("system/admin")).thenReturn(true);
 
-        final ContainerResponse response = makeRequest("POST", SERVICE_PATH + "/create", newUser);
+        final ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH + "/create", newUser);
 
         assertEquals(response.getStatus(), CREATED.getStatusCode());
         final UserDescriptor descriptor = (UserDescriptor)response.getEntity();
@@ -181,7 +185,7 @@ public class UserServiceTest {
                                           .withPassword("password");
         when(securityContext.isUserInRole("system/admin")).thenReturn(true);
 
-        final ContainerResponse response = makeRequest("POST", SERVICE_PATH + "/create", newUser);
+        final ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH + "/create", newUser);
 
         assertEquals(response.getStatus(), FORBIDDEN.getStatusCode());
         verify(userDao, never()).create(any(User.class));
@@ -195,7 +199,7 @@ public class UserServiceTest {
                                           .withName("test");
         when(securityContext.isUserInRole("system/admin")).thenReturn(true);
 
-        final ContainerResponse response = makeRequest("POST", SERVICE_PATH + "/create", newUser);
+        final ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH + "/create", newUser);
 
         final UserDescriptor descriptor = (UserDescriptor)response.getEntity();
         assertEquals(descriptor.getName(), newUser.getName());
@@ -206,7 +210,7 @@ public class UserServiceTest {
 
     @Test
     public void shouldThrowUnauthorizedExceptionWhenCreatingUserBasedOnTokenAndItIsNull() throws Exception {
-        final ContainerResponse response = makeRequest("POST", SERVICE_PATH + "/create", null);
+        final ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH + "/create", null);
 
         assertEquals(response.getStatus(), UNAUTHORIZED.getStatusCode());
         verify(userDao, never()).create(any(User.class));
@@ -217,7 +221,7 @@ public class UserServiceTest {
     public void shouldThrowForbiddenExceptionWhenCreatingUserBasedOnEntityWhichIsNull() throws Exception {
         when(securityContext.isUserInRole("system/admin")).thenReturn(true);
 
-        final ContainerResponse response = makeRequest("POST", SERVICE_PATH + "/create", null);
+        final ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH + "/create", null);
 
         assertEquals(response.getStatus(), FORBIDDEN.getStatusCode());
         verify(userDao, never()).create(any(User.class));
@@ -229,7 +233,7 @@ public class UserServiceTest {
         final NewUser newUser = DtoFactory.getInstance().createDto(NewUser.class);
         when(securityContext.isUserInRole("system/admin")).thenReturn(true);
 
-        final ContainerResponse response = makeRequest("POST", SERVICE_PATH + "/create", newUser);
+        final ContainerResponse response = makeRequest(HttpMethod.POST, SERVICE_PATH + "/create", newUser);
 
         assertEquals(response.getStatus(), FORBIDDEN.getStatusCode());
         verify(userDao, never()).create(any(User.class));
@@ -240,7 +244,7 @@ public class UserServiceTest {
     public void shouldBeAbleToGetCurrentUser() throws Exception {
         final User user = createUser();
 
-        final ContainerResponse response = makeRequest("GET", SERVICE_PATH, null);
+        final ContainerResponse response = makeRequest(HttpMethod.GET, SERVICE_PATH, null);
 
         assertEquals(response.getStatus(), OK.getStatusCode());
         final UserDescriptor descriptor = (UserDescriptor)response.getEntity();
@@ -253,7 +257,7 @@ public class UserServiceTest {
     public void shouldBeAbleToGetUserById() throws Exception {
         final User user = createUser();
 
-        final ContainerResponse response = makeRequest("GET", SERVICE_PATH + "/" + user.getId(), null);
+        final ContainerResponse response = makeRequest(HttpMethod.GET, SERVICE_PATH + "/" + user.getId(), null);
 
         assertEquals(response.getStatus(), OK.getStatusCode());
         final UserDescriptor descriptor = (UserDescriptor)response.getEntity();
@@ -266,7 +270,7 @@ public class UserServiceTest {
     public void shouldBeAbleToGetUserByEmail() throws Exception {
         final User user = createUser();
 
-        final ContainerResponse response = makeRequest("GET", SERVICE_PATH + "?email=" + user.getEmail(), null);
+        final ContainerResponse response = makeRequest(HttpMethod.GET, SERVICE_PATH + "?email=" + user.getEmail(), null);
 
         assertEquals(response.getStatus(), OK.getStatusCode());
         final UserDescriptor descriptor = (UserDescriptor)response.getEntity();
@@ -280,9 +284,9 @@ public class UserServiceTest {
         final User user = createUser();
         final String newPassword = "validPass123";
         final Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", singletonList("application/x-www-form-urlencoded"));
+        headers.put(HttpHeaders.CONTENT_TYPE, singletonList(MediaType.APPLICATION_FORM_URLENCODED));
 
-        final ContainerResponse response = launcher.service("POST",
+        final ContainerResponse response = launcher.service(HttpMethod.POST,
                                                             SERVICE_PATH + "/password",
                                                             BASE_URI,
                                                             headers,
@@ -299,9 +303,9 @@ public class UserServiceTest {
         final User user = createUser();
         final String newPassword = "password";
         final Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", singletonList("application/x-www-form-urlencoded"));
+        headers.put(HttpHeaders.CONTENT_TYPE, singletonList(MediaType.APPLICATION_FORM_URLENCODED));
 
-        final ContainerResponse response = launcher.service("POST",
+        final ContainerResponse response = launcher.service(HttpMethod.POST,
                                                             SERVICE_PATH + "/password",
                                                             BASE_URI,
                                                             headers,
@@ -318,9 +322,9 @@ public class UserServiceTest {
         final User user = createUser();
         final String newPassword = "12345678";
         final Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", singletonList("application/x-www-form-urlencoded"));
+        headers.put(HttpHeaders.CONTENT_TYPE, singletonList(MediaType.APPLICATION_FORM_URLENCODED));
 
-        final ContainerResponse response = launcher.service("POST",
+        final ContainerResponse response = launcher.service(HttpMethod.POST,
                                                             SERVICE_PATH + "/password",
                                                             BASE_URI,
                                                             headers,
@@ -337,9 +341,9 @@ public class UserServiceTest {
         final User user = createUser();
         final String newPassword = "abc123";
         final Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Content-Type", singletonList("application/x-www-form-urlencoded"));
+        headers.put(HttpHeaders.CONTENT_TYPE, singletonList(MediaType.APPLICATION_FORM_URLENCODED));
 
-        final ContainerResponse response = launcher.service("POST",
+        final ContainerResponse response = launcher.service(HttpMethod.POST,
                                                             SERVICE_PATH + "/password",
                                                             BASE_URI,
                                                             headers,
@@ -355,7 +359,7 @@ public class UserServiceTest {
     public void shouldBeAbleToRemoveUser() throws Exception {
         final User testUser = createUser();
 
-        final ContainerResponse response = makeRequest("DELETE", SERVICE_PATH + "/" + testUser.getId(), null);
+        final ContainerResponse response = makeRequest(HttpMethod.DELETE, SERVICE_PATH + "/" + testUser.getId(), null);
 
         assertEquals(response.getStatus(), NO_CONTENT.getStatusCode());
         verify(userDao).remove(testUser.getId());
@@ -369,7 +373,7 @@ public class UserServiceTest {
     public void checkUserWithDefaultScope() throws Exception {
         when(securityContext.isUserInRole("user")).thenReturn(true);
 
-        final ContainerResponse response = makeRequest("GET", SERVICE_PATH + "/inrole?role=user", null);
+        final ContainerResponse response = makeRequest(HttpMethod.GET, SERVICE_PATH + "/inrole?role=user", null);
 
         assertEquals(response.getStatus(), OK.getStatusCode());
         final UserInRoleDescriptor userInRoleDescriptor = (UserInRoleDescriptor)response.getEntity();
@@ -388,7 +392,7 @@ public class UserServiceTest {
     public void checkUserWithSystemScope() throws Exception {
         when(securityContext.isUserInRole("user")).thenReturn(true);
 
-        final ContainerResponse response = makeRequest("GET", SERVICE_PATH + "/inrole?role=user&scope=system", null);
+        final ContainerResponse response = makeRequest(HttpMethod.GET, SERVICE_PATH + "/inrole?role=user&scope=system", null);
 
         assertEquals(response.getStatus(), OK.getStatusCode());
         final UserInRoleDescriptor userInRoleDescriptor = (UserInRoleDescriptor)response.getEntity();
@@ -409,7 +413,7 @@ public class UserServiceTest {
     public void checkTempUserWithSystemScope() throws Exception {
         when(securityContext.isUserInRole("temp_user")).thenReturn(true);
 
-        final ContainerResponse response = makeRequest("GET", SERVICE_PATH + "/inrole?role=temp_user&scope=system", null);
+        final ContainerResponse response = makeRequest(HttpMethod.GET, SERVICE_PATH + "/inrole?role=temp_user&scope=system", null);
 
         assertEquals(response.getStatus(), OK.getStatusCode());
         final UserInRoleDescriptor userInRoleDescriptor = (UserInRoleDescriptor)response.getEntity();
@@ -429,7 +433,7 @@ public class UserServiceTest {
     public void checkUserIsAdminWithDefaultScope() throws Exception {
         when(securityContext.isUserInRole("system/admin")).thenReturn(true);
 
-        final ContainerResponse response = makeRequest("GET", SERVICE_PATH + "/inrole?role=admin", null);
+        final ContainerResponse response = makeRequest(HttpMethod.GET, SERVICE_PATH + "/inrole?role=admin", null);
 
         assertEquals(response.getStatus(), OK.getStatusCode());
         final UserInRoleDescriptor userInRoleDescriptor = (UserInRoleDescriptor)response.getEntity();
@@ -449,7 +453,7 @@ public class UserServiceTest {
     public void checkUserIsNotAdmin() throws Exception {
         when(securityContext.isUserInRole("system/admin")).thenReturn(false);
 
-        final ContainerResponse response = makeRequest("GET", SERVICE_PATH + "/inrole?role=admin", null);
+        final ContainerResponse response = makeRequest(HttpMethod.GET, SERVICE_PATH + "/inrole?role=admin", null);
 
         assertEquals(response.getStatus(), OK.getStatusCode());
         final UserInRoleDescriptor userInRoleDescriptor = (UserInRoleDescriptor)response.getEntity();
@@ -470,7 +474,7 @@ public class UserServiceTest {
     public void checkUserIsManagerWithProvidedScope() throws Exception {
         when(securityContext.isUserInRole("system/manager")).thenReturn(true);
 
-        final ContainerResponse response = makeRequest("GET", SERVICE_PATH + "/inrole?role=manager&scope=system", null);
+        final ContainerResponse response = makeRequest(HttpMethod.GET, SERVICE_PATH + "/inrole?role=manager&scope=system", null);
 
         assertEquals(response.getStatus(), OK.getStatusCode());
         final UserInRoleDescriptor userInRoleDescriptor = (UserInRoleDescriptor)response.getEntity();
@@ -494,7 +498,7 @@ public class UserServiceTest {
         byte[] data = null;
         if (entity != null) {
             headers = new HashMap<>();
-            headers.put("Content-Type", singletonList("application/json"));
+            headers.put(HttpHeaders.CONTENT_TYPE, singletonList(MediaType.APPLICATION_JSON));
             data = JsonHelper.toJson(entity).getBytes();
         }
         return launcher.service(method, path, BASE_URI, headers, data, null, environmentContext);

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/ContentStreamWriter.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/ContentStreamWriter.java
@@ -64,7 +64,7 @@ public final class ContentStreamWriter implements MessageBodyWriter<ContentStrea
         if (mimeType != null) {
             httpHeaders.putSingle(HttpHeaders.CONTENT_TYPE, mimeType);
         }
-        httpHeaders.putSingle("Content-Disposition", "attachment; filename=\"" + t.getFileName() + '"');
+        httpHeaders.putSingle(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + t.getFileName() + '"');
         Date lastModificationDate = t.getLastModificationDate();
         if (lastModificationDate != null) {
             httpHeaders.putSingle(HttpHeaders.LAST_MODIFIED, t.getLastModificationDate());

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/VirtualFileSystem.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/VirtualFileSystem.java
@@ -25,7 +25,7 @@ import org.eclipse.che.api.vfs.shared.dto.Lock;
 import org.eclipse.che.api.vfs.shared.dto.Property;
 import org.eclipse.che.api.vfs.shared.dto.ReplacementSet;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo;
-
+import org.eclipse.che.commons.lang.ws.rs.ExtMediaType;
 import org.apache.commons.fileupload.FileItem;
 
 import javax.ws.rs.Consumes;
@@ -36,6 +36,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+
 import java.io.InputStream;
 import java.util.Iterator;
 import java.util.List;
@@ -229,7 +230,7 @@ public interface VirtualFileSystem {
      *          "path":"/folder01/DOCUMENT01.txt",
      *          "versionId":"current",
      *          "creationDate":1292574268440,
-     *          "contentType":"text/plain",
+     *          "contentType":MediaType.TEXT_PLAIN,
      *          "length":100,
      *          "lastModificationDate":1292574268440
      *          "locked":false,
@@ -385,7 +386,7 @@ public interface VirtualFileSystem {
      *   "path":"/folder01/DOCUMENT01.txt",
      *   "versionId":"current",
      *   "creationDate":1292574268440,
-     *   "contentType":"text/plain",
+     *   "contentType":MediaType.TEXT_PLAIN,
      *   "length":100,
      *   "lastModificationDate":1292574268440
      *   "locked":false,
@@ -492,7 +493,7 @@ public interface VirtualFileSystem {
      *          "path":"/folder01/DOCUMENT01.txt",
      *          "versionId":"1",
      *          "creationDate":1292574263440,
-     *          "contentType":"text/plain",
+     *          "contentType":MediaType.TEXT_PLAIN,
      *          "length":56,
      *          "lastModificationDate":1292574263440
      *          "locked":false,
@@ -504,7 +505,7 @@ public interface VirtualFileSystem {
      *          "path":"/folder01/DOCUMENT01.txt",
      *          "versionId":"2",
      *          "creationDate":1292574265640,
-     *          "contentType":"text/plain",
+     *          "contentType":MediaType.TEXT_PLAIN,
      *          "length":83,
      *          "lastModificationDate":1292574265640
      *          "locked":false,
@@ -516,7 +517,7 @@ public interface VirtualFileSystem {
      *          "path":"/folder01/DOCUMENT01.txt",
      *          "versionId":"current",
      *          "creationDate":1292574267340,
-     *          "contentType":"text/plain",
+     *          "contentType":MediaType.TEXT_PLAIN,
      *          "length":100,
      *          "lastModificationDate":1292574268440
      *          "locked":false,
@@ -879,7 +880,7 @@ public interface VirtualFileSystem {
      */
     @GET
     @Path("export")
-    @Produces({"application/zip"})
+    @Produces({ExtMediaType.APPLICATION_ZIP})
     ContentStream exportZip(String folderId) throws NotFoundException, ForbiddenException, ServerException;
 
     /**
@@ -925,8 +926,8 @@ public interface VirtualFileSystem {
      */
     @POST
     @Path("export")
-    @Produces({"application/zip"})
-    @Consumes({"text/plain"})
+    @Produces({ExtMediaType.APPLICATION_ZIP})
+    @Consumes({MediaType.TEXT_PLAIN})
     Response exportZip(String folderId, InputStream in) throws NotFoundException, ForbiddenException, ServerException;
 
     /**
@@ -972,8 +973,8 @@ public interface VirtualFileSystem {
      */
     @POST
     @Path("export")
-    @Produces({"multipart/form-data"})
-    @Consumes({"text/plain"})
+    @Produces({MediaType.MULTIPART_FORM_DATA})
+    @Consumes({MediaType.TEXT_PLAIN})
     Response exportZipMultipart(String folderId, InputStream in) throws NotFoundException, ForbiddenException, ServerException;
 
     /**
@@ -1003,7 +1004,7 @@ public interface VirtualFileSystem {
      */
     @POST
     @Path("import")
-    @Consumes({"application/zip"})
+    @Consumes({ExtMediaType.APPLICATION_ZIP})
     void importZip(String parentId, InputStream in, Boolean overwrite, Boolean skipFirstLevel)
             throws NotFoundException, ForbiddenException, ConflictException, ServerException;
 
@@ -1078,7 +1079,7 @@ public interface VirtualFileSystem {
      */
     @GET
     @Path("downloadzip")
-    @Produces({"application/zip"})
+    @Produces({ExtMediaType.APPLICATION_ZIP})
     Response downloadZip(String folderId) throws NotFoundException, ForbiddenException, ServerException;
 
     /**

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/VirtualFileSystemImpl.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/VirtualFileSystemImpl.java
@@ -33,13 +33,12 @@ import org.eclipse.che.api.vfs.shared.dto.Variable;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.ACLCapability;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
-
 import org.eclipse.che.commons.lang.Deserializer;
 import org.eclipse.che.commons.lang.IoUtil;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.commons.lang.Pair;
+import org.eclipse.che.commons.lang.ws.rs.ExtMediaType;
 import org.eclipse.che.dto.server.DtoFactory;
-
 import org.apache.commons.fileupload.FileItem;
 import org.everrest.core.impl.provider.multipart.OutputItem;
 
@@ -54,6 +53,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -161,7 +161,7 @@ public abstract class VirtualFileSystemImpl implements VirtualFileSystem {
     @Override
     public File createFile(@PathParam("parentId") String parentId,
                            @QueryParam("name") String name,
-                           @HeaderParam("Content-Type") MediaType mediaType,
+                           @HeaderParam(HttpHeaders.CONTENT_TYPE) MediaType mediaType,
                            InputStream content) throws NotFoundException, ForbiddenException, ConflictException, ServerException {
         final VirtualFile parent = mountPoint.getVirtualFileById(parentId);
         // Have issue with client side. Always have Content-type header is set even if client doesn't set it.
@@ -606,7 +606,7 @@ public abstract class VirtualFileSystemImpl implements VirtualFileSystem {
     @Override
     public void updateContent(
             @PathParam("id") String id,
-            @DefaultValue(MediaType.APPLICATION_OCTET_STREAM) @HeaderParam("Content-Type") MediaType mediaType,
+            @DefaultValue(MediaType.APPLICATION_OCTET_STREAM) @HeaderParam(HttpHeaders.CONTENT_TYPE) MediaType mediaType,
             InputStream newContent,
             @QueryParam("lockToken") String lockToken) throws NotFoundException, ForbiddenException, ServerException {
         // Have issue with client side. Always have Content-type header is set even if client doesn't set it.
@@ -662,7 +662,7 @@ public abstract class VirtualFileSystemImpl implements VirtualFileSystem {
         }
         final List<OutputItem> multipart = new LinkedList<>();
         // String name, Object entity, MediaType mediaType, String fileName
-        final OutputItem updates = OutputItem.create("updates", zip.getStream(), MediaType.valueOf("application/zip"), zip.getFileName());
+        final OutputItem updates = OutputItem.create("updates", zip.getStream(), ExtMediaType.APPLICATION_ZIP_TYPE, zip.getFileName());
         updates.getHeaders().putSingle(HttpHeaders.CONTENT_LENGTH, Long.toString(zip.getLength()));
         multipart.add(updates);
 
@@ -690,7 +690,7 @@ public abstract class VirtualFileSystemImpl implements VirtualFileSystem {
                 .ok(zip.getStream(), zip.getMimeType())
                 .lastModified(zip.getLastModificationDate())
                 .header(HttpHeaders.CONTENT_LENGTH, Long.toString(zip.getLength()))
-                .header("Content-Disposition", "attachment; filename=\"" + zip.getFileName() + '"');
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + zip.getFileName() + '"');
         if (!deleted.isEmpty()) {
             final StringBuilder buff = new StringBuilder();
             for (String str : deleted) {
@@ -829,7 +829,7 @@ public abstract class VirtualFileSystemImpl implements VirtualFileSystem {
                 .ok(content.getStream(), content.getMimeType())
                 .lastModified(content.getLastModificationDate())
                 .header(HttpHeaders.CONTENT_LENGTH, Long.toString(content.getLength()))
-                .header("Content-Disposition", "attachment; filename=\"" + content.getFileName() + '"')
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + content.getFileName() + '"')
                 .build();
     }
 
@@ -909,7 +909,7 @@ public abstract class VirtualFileSystemImpl implements VirtualFileSystem {
                 .ok(zip.getStream(), zip.getMimeType()) //
                 .lastModified(zip.getLastModificationDate()) //
                 .header(HttpHeaders.CONTENT_LENGTH, Long.toString(zip.getLength())) //
-                .header("Content-Disposition", "attachment; filename=\"" + zip.getFileName() + '"') //
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + zip.getFileName() + '"') //
                 .build();
     }
 

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/impl/memory/MemoryVirtualFile.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/impl/memory/MemoryVirtualFile.java
@@ -40,10 +40,11 @@ import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.Property;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
-
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.commons.lang.Pair;
+import org.eclipse.che.commons.lang.ws.rs.ExtMediaType;
 import org.eclipse.che.dto.server.DtoFactory;
+
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import com.google.common.io.ByteSource;
@@ -1037,7 +1038,7 @@ public class MemoryVirtualFile implements VirtualFile {
             throw new ServerException(e.getMessage(), e);
         }
         final byte[] zipContent = out.toByteArray();
-        return new ContentStream(getName() + ".zip", new ByteArrayInputStream(zipContent), "application/zip", zipContent.length,
+        return new ContentStream(getName() + ".zip", new ByteArrayInputStream(zipContent), ExtMediaType.APPLICATION_ZIP, zipContent.length,
                                  new Date());
     }
 

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/util/LinksHelper.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/util/LinksHelper.java
@@ -12,10 +12,12 @@ package org.eclipse.che.api.vfs.server.util;
 
 import org.eclipse.che.api.vfs.server.VirtualFileSystemFactory;
 import org.eclipse.che.api.vfs.shared.dto.Link;
+import org.eclipse.che.commons.lang.ws.rs.ExtMediaType;
 import org.eclipse.che.dto.server.DtoFactory;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
+
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -169,13 +171,13 @@ public class LinksHelper {
                   createLink(createURI(baseUriBuilder.clone(), wsName, "uploadfile", id), Link.REL_UPLOAD_FILE, MediaType.TEXT_HTML));
 
         links.put(Link.REL_EXPORT, //
-                  createLink(createURI(baseUriBuilder.clone(), wsName, "export", id), Link.REL_EXPORT, "application/zip"));
+                  createLink(createURI(baseUriBuilder.clone(), wsName, "export", id), Link.REL_EXPORT, ExtMediaType.APPLICATION_ZIP));
 
         links.put(Link.REL_IMPORT, //
-                  createLink(createURI(baseUriBuilder.clone(), wsName, "import", id), Link.REL_IMPORT, "application/zip"));
+                  createLink(createURI(baseUriBuilder.clone(), wsName, "import", id), Link.REL_IMPORT, ExtMediaType.APPLICATION_ZIP));
 
         links.put(Link.REL_DOWNLOAD_ZIP, //
-                  createLink(createURI(baseUriBuilder.clone(), wsName, "downloadzip", id), Link.REL_DOWNLOAD_ZIP, "application/zip"));
+                  createLink(createURI(baseUriBuilder.clone(), wsName, "downloadzip", id), Link.REL_DOWNLOAD_ZIP, ExtMediaType.APPLICATION_ZIP));
 
         links.put(Link.REL_UPLOAD_ZIP, //
                   createLink(createURI(baseUriBuilder.clone(), wsName, "uploadzip", id), Link.REL_UPLOAD_ZIP, MediaType.TEXT_HTML));

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/ChildrenTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/ChildrenTest.java
@@ -17,6 +17,7 @@ import org.eclipse.che.api.vfs.shared.dto.ItemList;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.Property;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -31,6 +32,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.MediaType;
+
 /** @author andrew00x */
 public class ChildrenTest extends MemoryFileSystemTest {
     private String folderId;
@@ -43,7 +47,7 @@ public class ChildrenTest extends MemoryFileSystemTest {
 
         VirtualFile folder = parentFolder.createFolder("ChildrenTest_FOLDER");
 
-        VirtualFile file = folder.createFile("ChildrenTest_FILE01", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        VirtualFile file = folder.createFile("ChildrenTest_FILE01", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         file.updateProperties(Arrays.asList(createProperty("PropertyA", "A"), createProperty("PropertyB", "B")), null);
 
         VirtualFile folder1 = folder.createFolder("ChildrenTest_FOLDER01");
@@ -58,7 +62,7 @@ public class ChildrenTest extends MemoryFileSystemTest {
     public void testGetChildren() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "children/" + folderId;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(200, response.getStatus());
         //log.info(new String(writer.getBody()));
         @SuppressWarnings("unchecked")
@@ -82,7 +86,7 @@ public class ChildrenTest extends MemoryFileSystemTest {
 
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "children/" + folderId;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -97,7 +101,7 @@ public class ChildrenTest extends MemoryFileSystemTest {
 
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "children/" + mountPoint.getRoot().getId();
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(200, response.getStatus());
         ItemList children = (ItemList)response.getEntity();
         assertEquals(0, children.getItems().size());
@@ -115,7 +119,7 @@ public class ChildrenTest extends MemoryFileSystemTest {
         // Have permission for read folder but have not permission to read one of its child.
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "children/" + folderId;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(200, response.getStatus());
         //log.info(new String(writer.getBody()));
         @SuppressWarnings("unchecked")
@@ -134,7 +138,7 @@ public class ChildrenTest extends MemoryFileSystemTest {
     public void testGetChildrenPagingSkipCount() throws Exception {
         // Get all children.
         String path = SERVICE_URI + "children/" + folderId;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         ItemList children = (ItemList)response.getEntity();
         List<Object> all = new ArrayList<>(3);
@@ -148,14 +152,14 @@ public class ChildrenTest extends MemoryFileSystemTest {
 
         // Skip first item in result.
         path = SERVICE_URI + "children/" + folderId + "?" + "skipCount=" + 1;
-        checkPage(path, "GET", Item.class.getMethod("getName"), all);
+        checkPage(path, HttpMethod.GET, Item.class.getMethod("getName"), all);
     }
 
     @SuppressWarnings("unchecked")
     public void testGetChildrenPagingMaxItems() throws Exception {
         // Get all children.
         String path = SERVICE_URI + "children/" + folderId;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         ItemList children = (ItemList)response.getEntity();
         List<Object> all = new ArrayList<>(3);
@@ -166,7 +170,7 @@ public class ChildrenTest extends MemoryFileSystemTest {
         // Exclude last item from result.
         path = SERVICE_URI + "children/" + folderId + "?" + "maxItems=" + 2;
         all.remove(2);
-        checkPage(path, "GET", Item.class.getMethod("getName"), all);
+        checkPage(path, HttpMethod.GET, Item.class.getMethod("getName"), all);
     }
 
     @SuppressWarnings("unchecked")
@@ -174,7 +178,7 @@ public class ChildrenTest extends MemoryFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         // Get children without filter.
         String path = SERVICE_URI + "children/" + folderId;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         //log.info(new String(writer.getBody()));
         assertEquals(200, response.getStatus());
         ItemList children = (ItemList)response.getEntity();
@@ -192,7 +196,7 @@ public class ChildrenTest extends MemoryFileSystemTest {
         // Get children and apply filter for properties.
         String propertyFilter = "PropertyA";
         String path = SERVICE_URI + "children/" + folderId + "?" + "propertyFilter=" + propertyFilter;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         //log.info(new String(writer.getBody()));
         assertEquals(200, response.getStatus());
         ItemList children = (ItemList)response.getEntity();
@@ -208,7 +212,7 @@ public class ChildrenTest extends MemoryFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         // Get children and apply filter for properties.
         String path = SERVICE_URI + "children/" + folderId + "?" + "itemType=folder";
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         //log.info(new String(writer.getBody()));
         assertEquals(200, response.getStatus());
         ItemList children = (ItemList)response.getEntity();

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/CloneTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/CloneTest.java
@@ -19,6 +19,8 @@ import org.eclipse.che.api.vfs.shared.dto.Item;
 
 import java.io.ByteArrayInputStream;
 
+import javax.ws.rs.core.MediaType;
+
 /** @author Vitaliy Guliy */
 public class CloneTest extends MemoryFileSystemTest {
 
@@ -46,7 +48,7 @@ public class CloneTest extends MemoryFileSystemTest {
     public void testCloneFile() throws Exception {
         // create file in 'my-ws'
         VirtualFile rootFolder = srcMountPoint.getRoot();
-        VirtualFile sourceFile = rootFolder.createFile("file-to-clone", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        VirtualFile sourceFile = rootFolder.createFile("file-to-clone", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
 
         // clone it to 'next-ws'
         VirtualFileSystem sourceVFS = fileSystemProvider.newInstance(null);
@@ -78,14 +80,14 @@ public class CloneTest extends MemoryFileSystemTest {
 
         VirtualFile folder1 = rootFolder.createFolder("folder1");
             VirtualFile folder2 = folder1.createFolder("folder2");
-                VirtualFile file1 = folder2.createFile("file1", "text/plain", new ByteArrayInputStream("file1 text".getBytes()));
+                VirtualFile file1 = folder2.createFile("file1", MediaType.TEXT_PLAIN, new ByteArrayInputStream("file1 text".getBytes()));
             VirtualFile folder3 = folder1.createFolder("folder3");
                 VirtualFile folder4 = folder3.createFolder("folder4");
-                VirtualFile file2 = folder3.createFile("file2", "text/plain", new ByteArrayInputStream("file2 text".getBytes()));
-                VirtualFile file3 = folder3.createFile("file3", "text/plain", new ByteArrayInputStream("file3 text".getBytes()));
+                VirtualFile file2 = folder3.createFile("file2", MediaType.TEXT_PLAIN, new ByteArrayInputStream("file2 text".getBytes()));
+                VirtualFile file3 = folder3.createFile("file3", MediaType.TEXT_PLAIN, new ByteArrayInputStream("file3 text".getBytes()));
             VirtualFile folder5 = folder1.createFolder("folder5");
-            VirtualFile file4 = folder1.createFile("file4", "text/plain", new ByteArrayInputStream("file4 text".getBytes()));
-            VirtualFile file5 = folder1.createFile("file5", "text/plain", new ByteArrayInputStream("file5 text".getBytes()));
+            VirtualFile file4 = folder1.createFile("file4", MediaType.TEXT_PLAIN, new ByteArrayInputStream("file4 text".getBytes()));
+            VirtualFile file5 = folder1.createFile("file5", MediaType.TEXT_PLAIN, new ByteArrayInputStream("file5 text".getBytes()));
 
         // clone it to 'next-ws'
         VirtualFileSystem sourceVFS = fileSystemProvider.newInstance(null);
@@ -127,14 +129,14 @@ public class CloneTest extends MemoryFileSystemTest {
 
         VirtualFile folder1 = rootFolder.createFolder("folder1");
         VirtualFile folder2 = folder1.createFolder("folder2");
-        VirtualFile file1 = folder2.createFile("file1", "text/plain", new ByteArrayInputStream("file1 text".getBytes()));
+        VirtualFile file1 = folder2.createFile("file1", MediaType.TEXT_PLAIN, new ByteArrayInputStream("file1 text".getBytes()));
         VirtualFile folder3 = folder1.createFolder("folder3");
         VirtualFile folder4 = folder3.createFolder("folder4");
-        VirtualFile file2 = folder3.createFile("file2", "text/plain", new ByteArrayInputStream("file2 text".getBytes()));
-        VirtualFile file3 = folder3.createFile("file3", "text/plain", new ByteArrayInputStream("file3 text".getBytes()));
+        VirtualFile file2 = folder3.createFile("file2", MediaType.TEXT_PLAIN, new ByteArrayInputStream("file2 text".getBytes()));
+        VirtualFile file3 = folder3.createFile("file3", MediaType.TEXT_PLAIN, new ByteArrayInputStream("file3 text".getBytes()));
         VirtualFile folder5 = folder1.createFolder("folder5");
-        VirtualFile file4 = folder1.createFile("file4", "text/plain", new ByteArrayInputStream("file4 text".getBytes()));
-        VirtualFile file5 = folder1.createFile("file5", "text/plain", new ByteArrayInputStream("file5 text".getBytes()));
+        VirtualFile file4 = folder1.createFile("file4", MediaType.TEXT_PLAIN, new ByteArrayInputStream("file4 text".getBytes()));
+        VirtualFile file5 = folder1.createFile("file5", MediaType.TEXT_PLAIN, new ByteArrayInputStream("file5 text".getBytes()));
 
         VirtualFile destination = mountPoint.getRoot().createFolder("a/b");
         // clone it to 'next-ws'

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/CopyTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/CopyTest.java
@@ -15,6 +15,7 @@ import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.shared.dto.Item;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -24,6 +25,9 @@ import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.MediaType;
 
 /** @author andrew00x */
 public class CopyTest extends MemoryFileSystemTest {
@@ -39,7 +43,7 @@ public class CopyTest extends MemoryFileSystemTest {
 
         folderForCopy = parentFolder.createFolder("CopyTest_FOLDER");
         // add child in folder
-        fileForCopy = folderForCopy.createFile("CopyTest_FILE", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        fileForCopy = folderForCopy.createFile("CopyTest_FILE", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
 
         copyTestDestinationFolder = mountPoint.getRoot().createFolder("CopyTest_DESTINATION");
     }
@@ -47,7 +51,7 @@ public class CopyTest extends MemoryFileSystemTest {
     public void testCopyFile() throws Exception {
         final String originPath = fileForCopy.getPath();
         String path = SERVICE_URI + "copy/" + fileForCopy.getId() + '?' + "parentId=" + copyTestDestinationFolder.getId();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         String expectedPath = copyTestDestinationFolder.getPath() + '/' + fileForCopy.getName();
         try {
@@ -69,9 +73,9 @@ public class CopyTest extends MemoryFileSystemTest {
 
     public void testCopyFileAlreadyExist() throws Exception {
         final String originPath = fileForCopy.getPath();
-        copyTestDestinationFolder.createFile("CopyTest_FILE", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        copyTestDestinationFolder.createFile("CopyTest_FILE", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         String path = SERVICE_URI + "copy/" + fileForCopy.getId() + '?' + "parentId=" + copyTestDestinationFolder.getId();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(409, response.getStatus());
         try {
             mountPoint.getVirtualFile(originPath);
@@ -83,9 +87,9 @@ public class CopyTest extends MemoryFileSystemTest {
     public void testCopyFileWrongParent() throws Exception {
         final String originPath = fileForCopy.getPath();
         VirtualFile destination =
-                mountPoint.getRoot().createFile("destination", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+                mountPoint.getRoot().createFile("destination", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         String path = SERVICE_URI + "copy/" + fileForCopy.getId() + '?' + "parentId=" + destination.getId();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(403, response.getStatus());
         try {
             mountPoint.getVirtualFile(originPath);
@@ -105,7 +109,7 @@ public class CopyTest extends MemoryFileSystemTest {
 
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "copy/" + fileForCopy.getId() + '?' + "parentId=" + copyTestDestinationFolder.getId();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
         try {
@@ -122,7 +126,7 @@ public class CopyTest extends MemoryFileSystemTest {
 
     public void testCopyFolder() throws Exception {
         String path = SERVICE_URI + "copy/" + folderForCopy.getId() + '?' + "parentId=" + copyTestDestinationFolder.getId();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         String expectedPath = copyTestDestinationFolder.getPath() + "/" + folderForCopy.getName();
         final String originPath = folderForCopy.getPath();
@@ -155,14 +159,14 @@ public class CopyTest extends MemoryFileSystemTest {
     }
 
     public void testCopyFolderNoPermissionForChild() throws Exception {
-        VirtualFile myFile = folderForCopy.createFile("file", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        VirtualFile myFile = folderForCopy.createFile("file", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         Principal adminPrincipal = createPrincipal("admin", Principal.Type.USER);
         Map<Principal, Set<String>> permissions = new HashMap<>(1);
         permissions.put(adminPrincipal, Sets.newHashSet(BasicPermissions.ALL.value()));
         myFile.updateACL(createAcl(permissions), true, null);
 
         String path = SERVICE_URI + "copy/" + folderForCopy.getId() + '?' + "parentId=" + copyTestDestinationFolder.getId();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         String expectedPath = copyTestDestinationFolder.getPath() + "/" + folderForCopy.getName();
         // one file must not be copied since permission restriction
@@ -173,7 +177,7 @@ public class CopyTest extends MemoryFileSystemTest {
         final String originPath = folderForCopy.getPath();
         copyTestDestinationFolder.createFolder("CopyTest_FOLDER");
         String path = SERVICE_URI + "copy/" + folderForCopy.getId() + "?" + "parentId=" + copyTestDestinationFolder.getId();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(409, response.getStatus());
         try {
             mountPoint.getVirtualFile(originPath);

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/CreateTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/CreateTest.java
@@ -16,12 +16,16 @@ import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.shared.dto.Item;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
 import org.everrest.core.tools.ByteArrayContainerResponseWriter;
 
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -49,10 +53,10 @@ public class CreateTest extends MemoryFileSystemTest {
         String path = SERVICE_URI + "file/" + createTestFolderId + '?' + "name=" + name; //
         Map<String, List<String>> headers = new HashMap<>();
         List<String> contentType = new ArrayList<>();
-        contentType.add("text/plain");
-        headers.put("Content-Type", contentType);
+        contentType.add(MediaType.TEXT_PLAIN);
+        headers.put(HttpHeaders.CONTENT_TYPE, contentType);
 
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, headers, content.getBytes(), null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, headers, content.getBytes(), null);
         assertEquals(200, response.getStatus());
         String expectedPath = createTestFolderPath + "/" + name;
         try {
@@ -66,7 +70,7 @@ public class CreateTest extends MemoryFileSystemTest {
             fail("Created file not accessible by id. ");
         }
         VirtualFile file = mountPoint.getVirtualFile(expectedPath);
-        checkFileContext(content, "text/plain", file);
+        checkFileContext(content, MediaType.TEXT_PLAIN, file);
     }
 
     public void testCreateFileInRoot() throws Exception {
@@ -75,10 +79,10 @@ public class CreateTest extends MemoryFileSystemTest {
         String path = SERVICE_URI + "file/" + mountPoint.getRoot().getId() + '?' + "name=" + name;
         Map<String, List<String>> headers = new HashMap<>();
         List<String> contentType = new ArrayList<>();
-        contentType.add("text/plain");
-        headers.put("Content-Type", contentType);
+        contentType.add(MediaType.TEXT_PLAIN);
+        headers.put(HttpHeaders.CONTENT_TYPE, contentType);
 
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, headers, content.getBytes(), null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, headers, content.getBytes(), null);
         assertEquals(200, response.getStatus());
         String expectedPath = "/" + name;
         try {
@@ -92,13 +96,13 @@ public class CreateTest extends MemoryFileSystemTest {
             fail("Created file not accessible by id. ");
         }
         VirtualFile file = mountPoint.getVirtualFile(expectedPath);
-        checkFileContext(content, "text/plain", file);
+        checkFileContext(content, MediaType.TEXT_PLAIN, file);
     }
 
     public void testCreateFileNoContent() throws Exception {
         String name = "testCreateFileNoContent";
         String path = SERVICE_URI + "file/" + createTestFolderId + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
 
         assertEquals(200, response.getStatus());
         String expectedPath = createTestFolderPath + "/" + name;
@@ -123,7 +127,7 @@ public class CreateTest extends MemoryFileSystemTest {
         String content = "test create file without media type";
         String path = SERVICE_URI + "file/" + createTestFolderId + '?' + "name=" + name;
 
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, content.getBytes(), writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, content.getBytes(), writer, null);
         assertEquals(200, response.getStatus());
         String expectedPath = createTestFolderPath + "/" + name;
         try {
@@ -143,7 +147,7 @@ public class CreateTest extends MemoryFileSystemTest {
     public void testCreateFileNoName() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "file/" + createTestFolderId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, DEFAULT_CONTENT.getBytes(), writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, DEFAULT_CONTENT.getBytes(), writer, null);
         assertEquals(500, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -159,7 +163,7 @@ public class CreateTest extends MemoryFileSystemTest {
         String name = "testCreateFileNoPermissions";
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "file/" + createTestFolderId + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, DEFAULT_CONTENT.getBytes(), writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, DEFAULT_CONTENT.getBytes(), writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -169,7 +173,7 @@ public class CreateTest extends MemoryFileSystemTest {
         String name = "testCreateFileWrongParent";
         String path = SERVICE_URI + "file/" + createTestFolderId + "_WRONG_ID" + '?' + "name=" + name;
         ContainerResponse response =
-                launcher.service("POST", path, BASE_URI, null, DEFAULT_CONTENT.getBytes(), writer, null);
+                launcher.service(HttpMethod.POST, path, BASE_URI, null, DEFAULT_CONTENT.getBytes(), writer, null);
         assertEquals(404, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -177,7 +181,7 @@ public class CreateTest extends MemoryFileSystemTest {
     public void testCreateFolder() throws Exception {
         String name = "testCreateFolder";
         String path = SERVICE_URI + "folder/" + createTestFolderId + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         String expectedPath = createTestFolderPath + "/" + name;
         try {
@@ -195,7 +199,7 @@ public class CreateTest extends MemoryFileSystemTest {
     public void testCreateFolderInRoot() throws Exception {
         String name = "testCreateFolderInRoot";
         String path = SERVICE_URI + "folder/" + mountPoint.getRoot().getId() + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         String expectedPath = "/" + name;
         try {
@@ -213,7 +217,7 @@ public class CreateTest extends MemoryFileSystemTest {
     public void testCreateFolderNoName() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "folder/" + createTestFolderId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(500, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -227,7 +231,7 @@ public class CreateTest extends MemoryFileSystemTest {
         String name = "testCreateFolderNoPermissions";
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "folder/" + createTestFolderId + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -236,7 +240,7 @@ public class CreateTest extends MemoryFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String name = "testCreateFolderWrongParent";
         String path = SERVICE_URI + "folder/" + createTestFolderId + "_WRONG_ID" + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(404, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -244,7 +248,7 @@ public class CreateTest extends MemoryFileSystemTest {
     public void testCreateFolderHierarchy() throws Exception {
         String name = "testCreateFolderHierarchy/1/2/3/4/5";
         String path = SERVICE_URI + "folder/" + createTestFolderId + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null, null);
         assertEquals(200, response.getStatus());
         String expectedPath = createTestFolderPath + "/" + name;
         try {
@@ -263,7 +267,7 @@ public class CreateTest extends MemoryFileSystemTest {
         // create some items in path
         String name = "testCreateFolderHierarchy/1/2/3";
         String path = SERVICE_URI + "folder/" + createTestFolderId + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null, null);
         assertEquals(200, response.getStatus());
         String expectedPath = createTestFolderPath + "/" + name;
         try {
@@ -279,7 +283,7 @@ public class CreateTest extends MemoryFileSystemTest {
         // create the rest of path
         name += "/4/5";
         path = SERVICE_URI + "folder/" + createTestFolderId + '?' + "name=" + name;
-        response = launcher.service("POST", path, BASE_URI, null, null, null, null);
+        response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null, null);
         assertEquals(200, response.getStatus());
         expectedPath = createTestFolderPath + "/" + name;
         try {

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/DeleteTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/DeleteTest.java
@@ -14,6 +14,7 @@ import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -23,6 +24,9 @@ import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.MediaType;
 
 /** @author andrew00x */
 public class DeleteTest extends MemoryFileSystemTest {
@@ -42,20 +46,20 @@ public class DeleteTest extends MemoryFileSystemTest {
 
         VirtualFile folder = deleteTestFolder.createFolder("DeleteTest_FOLDER");
         // add child in folder
-        VirtualFile childFile = folder.createFile("file", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        VirtualFile childFile = folder.createFile("file", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         folderId = folder.getId();
         folderChildId = childFile.getId();
         folderPath = folder.getPath();
         folderChildPath = childFile.getPath();
 
-        file = deleteTestFolder.createFile("DeleteTest_FILE", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        file = deleteTestFolder.createFile("DeleteTest_FILE", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         fileId = file.getId();
         filePath = file.getPath();
     }
 
     public void testDeleteFile() throws Exception {
         String path = SERVICE_URI + "delete/" + fileId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(204, response.getStatus());
         try {
             mountPoint.getVirtualFileById(fileId);
@@ -73,7 +77,7 @@ public class DeleteTest extends MemoryFileSystemTest {
     public void testDeleteFileLocked() throws Exception {
         String lockToken = file.lock(0);
         String path = SERVICE_URI + "delete/" + fileId + '?' + "lockToken=" + lockToken;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(204, response.getStatus());
         try {
             mountPoint.getVirtualFileById(fileId);
@@ -91,7 +95,7 @@ public class DeleteTest extends MemoryFileSystemTest {
         file.lock(0);
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "delete/" + fileId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         try {
@@ -111,7 +115,7 @@ public class DeleteTest extends MemoryFileSystemTest {
 
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "delete/" + fileId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         try {
@@ -124,7 +128,7 @@ public class DeleteTest extends MemoryFileSystemTest {
     public void testDeleteFileWrongId() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "delete/" + fileId + "_WRONG_ID";
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(404, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -132,14 +136,14 @@ public class DeleteTest extends MemoryFileSystemTest {
     public void testDeleteRootFolder() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "delete/" + mountPoint.getRoot().getId();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
 
     public void testDeleteFolder() throws Exception {
         String path = SERVICE_URI + "delete/" + folderId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(204, response.getStatus());
         try {
             mountPoint.getVirtualFileById(folderId);
@@ -172,7 +176,7 @@ public class DeleteTest extends MemoryFileSystemTest {
         mountPoint.getVirtualFileById(folderChildId).updateACL(createAcl(permissions), true, null);
 
         String path = SERVICE_URI + "delete/" + folderId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(403, response.getStatus());
         try {
             mountPoint.getVirtualFileById(folderId);
@@ -184,7 +188,7 @@ public class DeleteTest extends MemoryFileSystemTest {
     public void testDeleteFolderLockedChild() throws Exception {
         mountPoint.getVirtualFileById(folderChildId).lock(0);
         String path = SERVICE_URI + "delete/" + folderId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(403, response.getStatus());
         try {
             mountPoint.getVirtualFileById(folderId);

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/EventsTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/EventsTest.java
@@ -20,7 +20,6 @@ import org.eclipse.che.api.vfs.server.observation.UpdateACLEvent;
 import org.eclipse.che.api.vfs.server.observation.UpdateContentEvent;
 import org.eclipse.che.api.vfs.server.observation.UpdatePropertiesEvent;
 import org.eclipse.che.api.vfs.server.observation.VirtualFileEvent;
-
 import org.everrest.core.impl.ContainerResponse;
 
 import java.io.ByteArrayInputStream;
@@ -28,6 +27,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 
 /** @author andrew00x */
 public class EventsTest extends MemoryFileSystemTest {
@@ -51,7 +54,7 @@ public class EventsTest extends MemoryFileSystemTest {
         testFolderPath = testEventsFolder.getPath();
         destinationFolderID = destinationFolder.getId();
         destinationFolderPath = destinationFolder.getPath();
-        VirtualFile testFile = testEventsFolder.createFile("file", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        VirtualFile testFile = testEventsFolder.createFile("file", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         testFileId = testFile.getId();
         testFilePath = testFile.getPath();
         events = new ArrayList<>();
@@ -106,8 +109,8 @@ public class EventsTest extends MemoryFileSystemTest {
         Map<String, List<String>> headers = new HashMap<>();
         List<String> contentType = new ArrayList<>();
         contentType.add("text/plain;charset=utf8");
-        headers.put("Content-Type", contentType);
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, headers, content.getBytes(), null);
+        headers.put(HttpHeaders.CONTENT_TYPE, contentType);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, headers, content.getBytes(), null);
         assertEquals(200, response.getStatus());
         assertEquals(1, events.size());
         assertEquals(VirtualFileEvent.ChangeType.CREATED, events.get(0).getType());
@@ -119,7 +122,7 @@ public class EventsTest extends MemoryFileSystemTest {
     public void testCreateFolder() throws Exception {
         String name = "testCreateFolder";
         String path = SERVICE_URI + "folder/" + testFolderId + '?' + "name=" + name;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         assertEquals(1, events.size());
         assertEquals(VirtualFileEvent.ChangeType.CREATED, events.get(0).getType());
@@ -130,7 +133,7 @@ public class EventsTest extends MemoryFileSystemTest {
 
     public void testCopy() throws Exception {
         String path = SERVICE_URI + "copy/" + testFileId + '?' + "parentId=" + destinationFolderID;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         assertEquals(1, events.size());
         assertEquals(VirtualFileEvent.ChangeType.CREATED, events.get(0).getType());
@@ -141,7 +144,7 @@ public class EventsTest extends MemoryFileSystemTest {
 
     public void testMove() throws Exception {
         String path = SERVICE_URI + "move/" + testFileId + '?' + "parentId=" + destinationFolderID;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         assertEquals(1, events.size());
         assertEquals(VirtualFileEvent.ChangeType.MOVED, events.get(0).getType());
@@ -155,10 +158,10 @@ public class EventsTest extends MemoryFileSystemTest {
         String path = SERVICE_URI + "content/" + testFileId;
         Map<String, List<String>> headers = new HashMap<>();
         List<String> contentType = new ArrayList<>();
-        contentType.add("application/xml");
-        headers.put("Content-Type", contentType);
+        contentType.add(MediaType.APPLICATION_XML);
+        headers.put(HttpHeaders.CONTENT_TYPE, contentType);
         String content = "<?xml version='1.0'><root/>";
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, headers, content.getBytes(), null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, headers, content.getBytes(), null);
         assertEquals(204, response.getStatus());
         assertEquals(1, events.size());
         assertEquals(VirtualFileEvent.ChangeType.CONTENT_UPDATED, events.get(0).getType());
@@ -171,10 +174,10 @@ public class EventsTest extends MemoryFileSystemTest {
         String path = SERVICE_URI + "item/" + testFileId;
         Map<String, List<String>> headers = new HashMap<>();
         List<String> contentType = new ArrayList<>();
-        contentType.add("application/json");
-        headers.put("Content-Type", contentType);
+        contentType.add(MediaType.APPLICATION_JSON);
+        headers.put(HttpHeaders.CONTENT_TYPE, contentType);
         String properties = "[{\"name\":\"MyProperty\", \"value\":[\"MyValue\"]}]";
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, headers, properties.getBytes(), null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, headers, properties.getBytes(), null);
         assertEquals(200, response.getStatus());
         assertEquals(1, events.size());
         assertEquals(VirtualFileEvent.ChangeType.PROPERTIES_UPDATED, events.get(0).getType());
@@ -185,7 +188,7 @@ public class EventsTest extends MemoryFileSystemTest {
 
     public void testDelete() throws Exception {
         String path = SERVICE_URI + "delete/" + testFileId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(204, response.getStatus());
         assertEquals(1, events.size());
         assertEquals(VirtualFileEvent.ChangeType.DELETED, events.get(0).getType());
@@ -196,7 +199,7 @@ public class EventsTest extends MemoryFileSystemTest {
 
     public void testRename() throws Exception {
         String path = SERVICE_URI + "rename/" + testFileId + '?' + "newname=" + "_FILE_NEW_NAME_";
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         assertEquals(1, events.size());
         assertEquals(VirtualFileEvent.ChangeType.RENAMED, events.get(0).getType());

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/ExportTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/ExportTest.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.api.vfs.server.impl.memory;
 
 import org.eclipse.che.api.vfs.server.VirtualFile;
-
+import org.eclipse.che.commons.lang.ws.rs.ExtMediaType;
 import org.everrest.core.impl.ContainerResponse;
 import org.everrest.core.tools.ByteArrayContainerResponseWriter;
 
@@ -20,6 +20,10 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 
 /** @author andrew00x */
 public class ExportTest extends MemoryFileSystemTest {
@@ -54,17 +58,17 @@ public class ExportTest extends MemoryFileSystemTest {
         VirtualFile folder2 = exportTestFolder.createFolder("folder2");
         VirtualFile folder3 = exportTestFolder.createFolder("folder3");
 
-        VirtualFile file1 = folder1.createFile("file1.txt", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT_BYTES));
-        VirtualFile file2 = folder2.createFile("file2.txt", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT_BYTES));
-        VirtualFile file3 = folder3.createFile("file3.txt", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT_BYTES));
+        VirtualFile file1 = folder1.createFile("file1.txt", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT_BYTES));
+        VirtualFile file2 = folder2.createFile("file2.txt", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT_BYTES));
+        VirtualFile file3 = folder3.createFile("file3.txt", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT_BYTES));
 
         VirtualFile folder12 = folder1.createFolder("folder12");
         VirtualFile folder22 = folder2.createFolder("folder22");
         VirtualFile folder32 = folder3.createFolder("folder32");
 
-        VirtualFile file12 = folder12.createFile("file12.txt", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT_BYTES));
-        VirtualFile file22 = folder22.createFile("file22.txt", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT_BYTES));
-        VirtualFile file32 = folder32.createFile("file32.txt", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT_BYTES));
+        VirtualFile file12 = folder12.createFile("file12.txt", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT_BYTES));
+        VirtualFile file22 = folder22.createFile("file22.txt", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT_BYTES));
+        VirtualFile file32 = folder32.createFile("file32.txt", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT_BYTES));
 
         expectedExportFolderZipItems.add("folder1/");
         expectedExportFolderZipItems.add("folder2/");
@@ -99,18 +103,18 @@ public class ExportTest extends MemoryFileSystemTest {
     public void testExportRootFolder() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "export/" + mountPoint.getRoot().getId();
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(200, response.getStatus());
-        assertEquals("application/zip", writer.getHeaders().getFirst("Content-Type"));
+        assertEquals(ExtMediaType.APPLICATION_ZIP, writer.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
         checkZipItems(expectedExportTestRootZipItems, new ZipInputStream(new ByteArrayInputStream(writer.getBody())));
     }
 
     public void testExportFile() throws Exception {
         VirtualFile file = mountPoint.getVirtualFileById(exportFolderId)
-                                     .createFile("export_test_file.txt", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT_BYTES));
+                                     .createFile("export_test_file.txt", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT_BYTES));
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "export/" + file.getId();
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
     }
 

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/GetACLTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/GetACLTest.java
@@ -14,10 +14,10 @@ import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.shared.dto.AccessControlEntry;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
-
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.user.User;
 import org.eclipse.che.commons.user.UserImpl;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -30,6 +30,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.MediaType;
+
 /** @author andrew00x */
 public class GetACLTest extends MemoryFileSystemTest {
     private VirtualFile file;
@@ -41,7 +44,7 @@ public class GetACLTest extends MemoryFileSystemTest {
         String name = getClass().getName();
         VirtualFile getAclTestFolder = mountPoint.getRoot().createFolder(name);
 
-        file = getAclTestFolder.createFile(name, "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        file = getAclTestFolder.createFile(name, MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
 
         Principal adminPrincipal = createPrincipal("admin", Principal.Type.USER);
         Principal userPrincipal = createPrincipal("john", Principal.Type.USER);
@@ -55,7 +58,7 @@ public class GetACLTest extends MemoryFileSystemTest {
 
     public void testGetACL() throws Exception {
         String path = SERVICE_URI + "acl/" + fileId;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         @SuppressWarnings("unchecked")
         List<AccessControlEntry> acl = (List<AccessControlEntry>)response.getEntity();
@@ -80,7 +83,7 @@ public class GetACLTest extends MemoryFileSystemTest {
         EnvironmentContext.getCurrent().setUser(previousUser); // restore
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "acl/" + fileId;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/GetAvailableFileSystemsTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/GetAvailableFileSystemsTest.java
@@ -14,7 +14,6 @@ import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.ACLCapability;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.QueryCapability;
-
 import org.everrest.core.impl.ContainerResponse;
 import org.everrest.core.tools.ByteArrayContainerResponseWriter;
 
@@ -22,12 +21,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import javax.ws.rs.HttpMethod;
+
 /** @author andrew00x */
 public class GetAvailableFileSystemsTest extends MemoryFileSystemTest {
     public void testAvailableFS() throws Exception {
         String path = BASE_URI + "/vfs/my-ws";
         ByteArrayContainerResponseWriter wr = new ByteArrayContainerResponseWriter();
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, wr, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, wr, null);
         //log.info(new String(wr.getBody()));
         assertEquals("Error: " + response.getEntity(), 200, response.getStatus());
         @SuppressWarnings("unchecked")

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/GetContentTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/GetContentTest.java
@@ -13,12 +13,16 @@ package org.eclipse.che.api.vfs.server.impl.memory;
 import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
 import org.everrest.core.tools.ByteArrayContainerResponseWriter;
 
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
 import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 import java.util.Map;
@@ -39,7 +43,7 @@ public class GetContentTest extends MemoryFileSystemTest {
         VirtualFile getContentTestFolder = mountPoint.getRoot().createFolder(name);
 
         VirtualFile file =
-                getContentTestFolder.createFile("GetContentTest_FILE", "text/plain", new ByteArrayInputStream(content.getBytes()));
+                getContentTestFolder.createFile("GetContentTest_FILE", MediaType.TEXT_PLAIN, new ByteArrayInputStream(content.getBytes()));
         fileId = file.getId();
         fileName = file.getName();
         filePath = file.getPath();
@@ -51,29 +55,29 @@ public class GetContentTest extends MemoryFileSystemTest {
     public void testGetContent() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "content/" + fileId;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(200, response.getStatus());
         //log.info(new String(writer.getBody()));
         assertEquals(content, new String(writer.getBody()));
-        assertEquals("text/plain", writer.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+        assertEquals(MediaType.TEXT_PLAIN, writer.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
     }
 
     public void testDownloadFile() throws Exception {
-        // Expect the same as 'get content' plus header "Content-Disposition".
+        // Expect the same as 'get content' plus header HttpHeaders.CONTENT_DISPOSITION.
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "downloadfile/" + fileId;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(200, response.getStatus());
         //log.info(new String(writer.getBody()));
         assertEquals(content, new String(writer.getBody()));
-        assertEquals("text/plain", writer.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
-        assertEquals("attachment; filename=\"" + fileName + "\"", writer.getHeaders().getFirst("Content-Disposition"));
+        assertEquals(MediaType.TEXT_PLAIN, writer.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+        assertEquals("attachment; filename=\"" + fileName + "\"", writer.getHeaders().getFirst(HttpHeaders.CONTENT_DISPOSITION));
     }
 
     public void testGetContentFolder() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "content/" + folderId;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -86,7 +90,7 @@ public class GetContentTest extends MemoryFileSystemTest {
 
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "content/" + fileId;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -94,20 +98,20 @@ public class GetContentTest extends MemoryFileSystemTest {
     public void testGetContentByPath() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "contentbypath" + filePath;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(200, response.getStatus());
         //log.info(new String(writer.getBody()));
         assertEquals(content, new String(writer.getBody()));
-        assertEquals("text/plain", writer.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+        assertEquals(MediaType.TEXT_PLAIN, writer.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
     }
 
     public void testGetContentByPathWithVersionID() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "contentbypath" + filePath + '?' + "versionId=" + "0";
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(200, response.getStatus());
         //log.info(new String(writer.getBody()));
         assertEquals(content, new String(writer.getBody()));
-        assertEquals("text/plain", writer.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
+        assertEquals(MediaType.TEXT_PLAIN, writer.getHeaders().getFirst(HttpHeaders.CONTENT_TYPE));
     }
 }

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/GetItemTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/GetItemTest.java
@@ -16,6 +16,7 @@ import org.eclipse.che.api.vfs.shared.dto.Item;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.Property;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -27,6 +28,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.MediaType;
 
 /** @author <a href="mailto:andrey.parfonov@exoplatform.com">Andrey Parfonov</a> */
 public class GetItemTest extends MemoryFileSystemTest {
@@ -45,7 +49,7 @@ public class GetItemTest extends MemoryFileSystemTest {
         folderPath = folder.getPath();
 
         VirtualFile file =
-                parentFolder.createFile("GetObjectTest_FILE", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+                parentFolder.createFile("GetObjectTest_FILE", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         file.updateProperties(Arrays.asList(
                 createProperty("MyProperty01", "hello world"),
                 createProperty("MyProperty02", "to be or not to be"),
@@ -59,7 +63,7 @@ public class GetItemTest extends MemoryFileSystemTest {
     public void testGetFile() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "item/" + fileId;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(200, response.getStatus());
         //log.info(new String(writer.getBody()));
         Item item = (Item)response.getEntity();
@@ -72,7 +76,7 @@ public class GetItemTest extends MemoryFileSystemTest {
     public void testGetFileByPath() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "itembypath" + filePath;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(200, response.getStatus());
         Item item = (Item)response.getEntity();
@@ -88,7 +92,7 @@ public class GetItemTest extends MemoryFileSystemTest {
         // No filter - all properties
         String path = SERVICE_URI + "item/" + fileId;
 
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         //log.info(new String(writer.getBody()));
         assertEquals(200, response.getStatus());
         List<Property> properties = ((Item)response.getEntity()).getProperties();
@@ -106,7 +110,7 @@ public class GetItemTest extends MemoryFileSystemTest {
         // With filter
         path = SERVICE_URI + "item/" + fileId + '?' + "propertyFilter=" + "MyProperty02";
 
-        response = launcher.service("GET", path, BASE_URI, null, null, null);
+        response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         m.clear();
         properties = ((Item)response.getEntity()).getProperties();
@@ -120,7 +124,7 @@ public class GetItemTest extends MemoryFileSystemTest {
     public void testGetFileNotFound() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "item/" + fileId + "_WRONG_ID_";
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(404, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -132,7 +136,7 @@ public class GetItemTest extends MemoryFileSystemTest {
         mountPoint.getVirtualFileById(fileId).updateACL(createAcl(permissions), true, null);
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "item/" + fileId;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -144,7 +148,7 @@ public class GetItemTest extends MemoryFileSystemTest {
         mountPoint.getVirtualFileById(fileId).updateACL(createAcl(permissions), true, null);
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "itembypath" + filePath;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -152,7 +156,7 @@ public class GetItemTest extends MemoryFileSystemTest {
     public void testGetFolder() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "item/" + folderId;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         //log.info(new String(writer.getBody()));
         assertEquals(200, response.getStatus());
         Item item = (Item)response.getEntity();
@@ -165,7 +169,7 @@ public class GetItemTest extends MemoryFileSystemTest {
     public void testGetFolderByPath() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "itembypath" + folderPath;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         //log.info(new String(writer.getBody()));
         assertEquals(200, response.getStatus());
         Item item = (Item)response.getEntity();
@@ -178,7 +182,7 @@ public class GetItemTest extends MemoryFileSystemTest {
     public void testGetFolderByPathWithVersionID() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "itembypath" + folderPath + '?' + "versionId=" + "0";
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
     }

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/GetVFSInfoTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/GetVFSInfoTest.java
@@ -14,7 +14,6 @@ import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.ACLCapability;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.QueryCapability;
-
 import org.everrest.core.impl.ContainerResponse;
 import org.everrest.core.tools.ByteArrayContainerResponseWriter;
 
@@ -22,11 +21,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import javax.ws.rs.HttpMethod;
+
 /** @author andrew00x */
 public class GetVFSInfoTest extends MemoryFileSystemTest {
     public void testVFSInfo() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
-        ContainerResponse response = launcher.service("GET", SERVICE_URI, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, SERVICE_URI, BASE_URI, null, null, writer, null);
         assertNotNull(response.getEntity());
         assertEquals(response.getEntity().toString(), 200, response.getStatus());
         //log.info(new String(writer.getBody()));

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/ImportTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/ImportTest.java
@@ -14,7 +14,6 @@ import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.server.observation.CreateEvent;
 import org.eclipse.che.api.vfs.server.observation.VirtualFileEvent;
-
 import org.everrest.core.impl.ContainerResponse;
 
 import java.io.ByteArrayOutputStream;
@@ -23,6 +22,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.MediaType;
 
 /** @author andrew00x */
 public class ImportTest extends MemoryFileSystemTest {
@@ -72,7 +74,7 @@ public class ImportTest extends MemoryFileSystemTest {
 
     public void testImportFolder() throws Exception {
         String path = SERVICE_URI + "import/" + importTestRootId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, zipFolder, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, zipFolder, null);
         assertEquals(204, response.getStatus());
         VirtualFile parent = mountPoint.getVirtualFileById(importTestRootId);
         VirtualFile folder1 = parent.getChild("folder1");
@@ -83,13 +85,13 @@ public class ImportTest extends MemoryFileSystemTest {
         assertNotNull(folder3);
         VirtualFile file1 = folder1.getChild("file1.txt");
         assertNotNull(file1);
-        checkFileContext(DEFAULT_CONTENT, "text/plain", file1);
+        checkFileContext(DEFAULT_CONTENT, MediaType.TEXT_PLAIN, file1);
         VirtualFile file2 = folder2.getChild("file2.txt");
         assertNotNull(file2);
-        checkFileContext(DEFAULT_CONTENT, "text/plain", file2);
+        checkFileContext(DEFAULT_CONTENT, MediaType.TEXT_PLAIN, file2);
         VirtualFile file3 = folder3.getChild("file3.txt");
         assertNotNull(file3);
-        checkFileContext(DEFAULT_CONTENT, "text/plain", file3);
+        checkFileContext(DEFAULT_CONTENT, MediaType.TEXT_PLAIN, file3);
 
 
         assertEquals(6, events.size());

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/LockTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/LockTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.vfs.server.impl.memory;
 import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -22,6 +23,9 @@ import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.MediaType;
 
 /** @author andrew00x */
 public class LockTest extends MemoryFileSystemTest {
@@ -37,14 +41,14 @@ public class LockTest extends MemoryFileSystemTest {
         VirtualFile folder = lockTestFolder.createFolder("LockTest_FOLDER");
         folderId = folder.getId();
 
-        VirtualFile file = lockTestFolder.createFile("LockTest_FILE", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        VirtualFile file = lockTestFolder.createFile("LockTest_FILE", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         fileId = file.getId();
     }
 
     public void testLockFile() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "lock/" + fileId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(200, response.getStatus());
         log.info(new String(writer.getBody()));
         VirtualFile file = mountPoint.getVirtualFileById(fileId);
@@ -57,7 +61,7 @@ public class LockTest extends MemoryFileSystemTest {
         file.lock(0);
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "lock/" + fileId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(409, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -73,7 +77,7 @@ public class LockTest extends MemoryFileSystemTest {
 
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "lock/" + fileId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         file = mountPoint.getVirtualFileById(fileId);
@@ -83,7 +87,7 @@ public class LockTest extends MemoryFileSystemTest {
     public void testLockFolder() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "lock/" + folderId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
     }
 

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/MemoryFileSystemTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/MemoryFileSystemTest.java
@@ -27,12 +27,11 @@ import org.eclipse.che.api.vfs.shared.dto.Link;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.Property;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo;
-
 import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.lang.ws.rs.ExtMediaType;
 import org.eclipse.che.commons.user.User;
 import org.eclipse.che.commons.user.UserImpl;
 import org.eclipse.che.dto.server.DtoFactory;
-
 import org.everrest.core.ResourceBinder;
 import org.everrest.core.impl.ApplicationContextImpl;
 import org.everrest.core.impl.ApplicationProviderBinder;
@@ -47,8 +46,10 @@ import org.everrest.core.tools.ResourceLauncher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriBuilder;
+
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -143,7 +144,7 @@ public abstract class MemoryFileSystemTest extends TestCase {
 
     protected Item getItem(String id) throws Exception {
         String path = SERVICE_URI + "item/" + id;
-        ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, null, null);
         if (response.getStatus() == 200) {
             return (Item)response.getEntity();
         }
@@ -354,21 +355,21 @@ public abstract class MemoryFileSystemTest extends TestCase {
 
             link = links.get(Link.REL_EXPORT);
             assertNotNull("'" + Link.REL_EXPORT + "' link not found. ", link);
-            assertEquals("application/zip", link.getType());
+            assertEquals(ExtMediaType.APPLICATION_ZIP, link.getType());
             assertEquals(Link.REL_EXPORT, link.getRel());
             assertEquals(UriBuilder.fromPath(SERVICE_URI).path("export").path(item.getId()).build().toString(),
                          link.getHref());
 
             link = links.get(Link.REL_IMPORT);
             assertNotNull("'" + Link.REL_IMPORT + "' link not found. ", link);
-            assertEquals("application/zip", link.getType());
+            assertEquals(ExtMediaType.APPLICATION_ZIP, link.getType());
             assertEquals(Link.REL_IMPORT, link.getRel());
             assertEquals(UriBuilder.fromPath(SERVICE_URI).path("import").path(item.getId()).build().toString(),
                          link.getHref());
 
             link = links.get(Link.REL_DOWNLOAD_ZIP);
             assertNotNull("'" + Link.REL_DOWNLOAD_ZIP + "' link not found. ", link);
-            assertEquals("application/zip", link.getType());
+            assertEquals(ExtMediaType.APPLICATION_ZIP, link.getType());
             assertEquals(Link.REL_DOWNLOAD_ZIP, link.getRel());
             assertEquals(UriBuilder.fromPath(SERVICE_URI).path("downloadzip").path(item.getId()).build().toString(),
                          link.getHref());

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/MoveTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/MoveTest.java
@@ -14,6 +14,7 @@ import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -23,6 +24,9 @@ import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.MediaType;
 
 /** @author andrew00x */
 public class MoveTest extends MemoryFileSystemTest {
@@ -39,15 +43,15 @@ public class MoveTest extends MemoryFileSystemTest {
         moveTestDestinationFolder = mountPoint.getRoot().createFolder(name + "_MoveTest_DESTINATION");
 
         folderForMove = moveTestFolder.createFolder("MoveTest_FOLDER");
-        folderForMove.createFile("file", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        folderForMove.createFile("file", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
 
-        fileForMove = moveTestFolder.createFile("MoveTest_FILE", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        fileForMove = moveTestFolder.createFile("MoveTest_FILE", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
     }
 
     public void testMoveFile() throws Exception {
         String path = SERVICE_URI + "move/" + fileForMove.getId() + '?' + "parentId=" + moveTestDestinationFolder.getId();
         String originPath = fileForMove.getPath();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         String expectedPath = moveTestDestinationFolder.getPath() + '/' + fileForMove.getName();
         try {
@@ -63,10 +67,10 @@ public class MoveTest extends MemoryFileSystemTest {
     }
 
     public void testMoveFileAlreadyExist() throws Exception {
-        moveTestDestinationFolder.createFile(fileForMove.getName(), "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        moveTestDestinationFolder.createFile(fileForMove.getName(), MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         String originPath = fileForMove.getPath();
         String path = SERVICE_URI + "move/" + fileForMove.getId() + '?' + "parentId=" + moveTestDestinationFolder.getId();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(409, response.getStatus());
         try {
             mountPoint.getVirtualFile(originPath);
@@ -78,9 +82,9 @@ public class MoveTest extends MemoryFileSystemTest {
     public void testCopyFileWrongParent() throws Exception {
         final String originPath = fileForMove.getPath();
         VirtualFile destination =
-                mountPoint.getRoot().createFile("destination", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+                mountPoint.getRoot().createFile("destination", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         String path = SERVICE_URI + "move/" + fileForMove.getId() + '?' + "parentId=" + destination.getId();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(403, response.getStatus());
         try {
             mountPoint.getVirtualFile(originPath);
@@ -94,7 +98,7 @@ public class MoveTest extends MemoryFileSystemTest {
         String path = SERVICE_URI + "move/" + fileForMove.getId() + '?' + "parentId=" + moveTestDestinationFolder.getId() +
                       '&' + "lockToken=" + lockToken;
         String originPath = fileForMove.getPath();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         String expectedPath = moveTestDestinationFolder.getPath() + '/' + fileForMove.getName();
         try {
@@ -114,7 +118,7 @@ public class MoveTest extends MemoryFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "move/" + fileForMove.getId() + '?' + "parentId=" + moveTestDestinationFolder.getId();
         String originPath = fileForMove.getPath();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
         String expectedPath = moveTestDestinationFolder.getPath() + '/' + fileForMove.getName();
@@ -141,7 +145,7 @@ public class MoveTest extends MemoryFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "move/" + fileForMove.getId() + '?' + "parentId=" + moveTestDestinationFolder.getId();
         String originPath = fileForMove.getPath();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
         String expectedPath = moveTestDestinationFolder.getPath() + '/' + fileForMove.getName();
@@ -168,7 +172,7 @@ public class MoveTest extends MemoryFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "move/" + fileForMove.getId() + '?' + "parentId=" + moveTestDestinationFolder.getId();
         String originPath = fileForMove.getPath();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         log.info(new String(writer.getBody()));
         assertEquals(403, response.getStatus());
         String expectedPath = moveTestDestinationFolder.getPath() + '/' + fileForMove.getName();
@@ -187,7 +191,7 @@ public class MoveTest extends MemoryFileSystemTest {
     public void testMoveFolder() throws Exception {
         String path = SERVICE_URI + "move/" + folderForMove.getId() + '?' + "parentId=" + moveTestDestinationFolder.getId();
         String originPath = folderForMove.getPath();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         String expectedPath = moveTestDestinationFolder.getPath() + '/' + folderForMove.getName();
         try {
@@ -211,7 +215,7 @@ public class MoveTest extends MemoryFileSystemTest {
         folderForMove.getChild("file").lock(0);
         String path = SERVICE_URI + "move/" + folderForMove.getId() + '?' + "parentId=" + moveTestDestinationFolder.getId();
         String originPath = folderForMove.getPath();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(403, response.getStatus());
         String expectedPath = moveTestDestinationFolder.getPath() + '/' + folderForMove.getName();
         try {
@@ -237,7 +241,7 @@ public class MoveTest extends MemoryFileSystemTest {
 
         String path = SERVICE_URI + "move/" + folderForMove.getId() + '?' + "parentId=" + moveTestDestinationFolder.getId();
         String originPath = folderForMove.getPath();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(403, response.getStatus());
         String expectedPath = moveTestDestinationFolder.getPath() + '/' + folderForMove.getName();
         try {
@@ -255,7 +259,7 @@ public class MoveTest extends MemoryFileSystemTest {
     public void testMoveFolderAlreadyExist() throws Exception {
         moveTestDestinationFolder.createFolder(folderForMove.getName());
         String path = SERVICE_URI + "move/" + folderForMove.getId() + '?' + "parentId=" + moveTestDestinationFolder.getId();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(409, response.getStatus());
     }
 }

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/RenameTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/RenameTest.java
@@ -14,6 +14,7 @@ import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -23,6 +24,9 @@ import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.MediaType;
 
 /** @author andrew00x */
 public class RenameTest extends MemoryFileSystemTest {
@@ -41,7 +45,7 @@ public class RenameTest extends MemoryFileSystemTest {
         folder = renameTestFolder.createFolder("RenameFileTest_FOLDER");
         folderId = folder.getId();
 
-        file = renameTestFolder.createFile("file", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        file = renameTestFolder.createFile("file", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         fileId = file.getId();
     }
 
@@ -49,7 +53,7 @@ public class RenameTest extends MemoryFileSystemTest {
         String path = SERVICE_URI + "rename/" + fileId + '?' + "newname=" + "_FILE_NEW_NAME_" + '&' + "mediaType=" +
                       "text/*;charset=ISO-8859-1";
         String originPath = file.getPath();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         String expectedPath = renameTestFolder.getPath() + '/' + "_FILE_NEW_NAME_";
         try {
@@ -67,10 +71,10 @@ public class RenameTest extends MemoryFileSystemTest {
     }
 
     public void testRenameFileAlreadyExists() throws Exception {
-        renameTestFolder.createFile("_FILE_NEW_NAME_", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        renameTestFolder.createFile("_FILE_NEW_NAME_", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         String path = SERVICE_URI + "rename/" + fileId + '?' + "newname=" + "_FILE_NEW_NAME_" + '&' + "mediaType=" +
                       "text/*;charset=ISO-8859-1";
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(409, response.getStatus());
     }
 
@@ -79,7 +83,7 @@ public class RenameTest extends MemoryFileSystemTest {
         String path = SERVICE_URI + "rename/" + fileId + '?' + "newname=" + "_FILE_NEW_NAME_" + '&' + "mediaType=" +
                       "text/*;charset=ISO-8859-1" + '&' + "lockToken=" + lockToken;
         String originPath = file.getPath();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         String expectedPath = renameTestFolder.getPath() + '/' + "_FILE_NEW_NAME_";
         try {
@@ -100,7 +104,7 @@ public class RenameTest extends MemoryFileSystemTest {
         String path = SERVICE_URI + "rename/" + fileId + '?' + "newname=" + "_FILE_NEW_NAME_" + '&' + "mediaType=" +
                       "text/*;charset=ISO-8859-1";
         String originPath = file.getPath();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         String expectedPath = renameTestFolder.getPath() + '/' + "_FILE_NEW_NAME_";
@@ -127,7 +131,7 @@ public class RenameTest extends MemoryFileSystemTest {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "rename/" + fileId + '?' + "newname=" + "_FILE_NEW_NAME_";
         String originPath = file.getPath();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
         String expectedPath = renameTestFolder.getPath() + '/' + "_FILE_NEW_NAME_";
@@ -146,7 +150,7 @@ public class RenameTest extends MemoryFileSystemTest {
     public void testRenameFolder() throws Exception {
         String path = SERVICE_URI + "rename/" + folderId + '?' + "newname=" + "_FOLDER_NEW_NAME_";
         String originPath = folder.getPath();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(200, response.getStatus());
         String expectedPath = renameTestFolder.getPath() + '/' + "_FOLDER_NEW_NAME_";
         try {
@@ -162,10 +166,10 @@ public class RenameTest extends MemoryFileSystemTest {
     }
 
     public void testRenameFolderWithLockedFile() throws Exception {
-        folder.createFile("file", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes())).lock(0);
+        folder.createFile("file", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes())).lock(0);
         String path = SERVICE_URI + "rename/" + folderId + '?' + "newname=" + "_FOLDER_NEW_NAME_";
         String originPath = folder.getPath();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(403, response.getStatus());
         String expectedPath = renameTestFolder.getPath() + '/' + "_FOLDER_NEW_NAME_";
         try {
@@ -181,7 +185,7 @@ public class RenameTest extends MemoryFileSystemTest {
     }
 
     public void testRenameFolderNoPermissionForChild() throws Exception {
-        VirtualFile myFile = folder.createFile("file", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        VirtualFile myFile = folder.createFile("file", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         Principal adminPrincipal = createPrincipal("admin", Principal.Type.USER);
         Principal userPrincipal = createPrincipal("john", Principal.Type.USER);
         Map<Principal, Set<String>> permissions = new HashMap<>(2);
@@ -191,7 +195,7 @@ public class RenameTest extends MemoryFileSystemTest {
 
         String path = SERVICE_URI + "rename/" + folderId + '?' + "newname=" + "_FOLDER_NEW_NAME_";
         String originPath = folder.getPath();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(403, response.getStatus());
         String expectedPath = renameTestFolder.getPath() + '/' + "_FOLDER_NEW_NAME_";
         try {

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/ReplaceTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/ReplaceTest.java
@@ -14,10 +14,8 @@ package org.eclipse.che.api.vfs.server.impl.memory;
 import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.shared.dto.ReplacementSet;
 import org.eclipse.che.api.vfs.shared.dto.Variable;
-
 import org.eclipse.che.commons.lang.IoUtil;
 import org.eclipse.che.dto.server.DtoFactory;
-
 import org.everrest.core.impl.ContainerResponse;
 
 import java.io.ByteArrayInputStream;
@@ -26,6 +24,10 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 
 public class ReplaceTest extends MemoryFileSystemTest {
     private VirtualFile replaceTestFolder;
@@ -48,7 +50,7 @@ public class ReplaceTest extends MemoryFileSystemTest {
     public void testSimpleReplaceVar() throws Exception {
         final String fileName = "test_file.txt";
         VirtualFile file = replaceTestFolder
-                .createFile(fileName, "text/plain",
+                .createFile(fileName, MediaType.TEXT_PLAIN,
                             new ByteArrayInputStream(String.format(template, find1, find2).getBytes()));
         List<Variable> variables = new ArrayList<>(2);
         variables.add(DtoFactory.getInstance().createDto(Variable.class).withFind(find1).withReplace(replace1));
@@ -59,10 +61,10 @@ public class ReplaceTest extends MemoryFileSystemTest {
         ReplacementSet replacementSet =
                 DtoFactory.getInstance().createDto(ReplacementSet.class).withEntries(variables).withFiles(expression);
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         String path = SERVICE_URI + "replace/" + replaceTestFolder.getName();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, h,
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, h,
                                                       String.format("[%s]",
                                                                     DtoFactory.getInstance().toJson(replacementSet))
                                                             .getBytes(), null, null);
@@ -77,11 +79,11 @@ public class ReplaceTest extends MemoryFileSystemTest {
         final String fileName3 = "test_file.class";
 
         VirtualFile file1 = replaceTestFolder
-                .createFile(fileName1, "text/plain", new ByteArrayInputStream(String.format(template, find1, find2).getBytes()));
+                .createFile(fileName1, MediaType.TEXT_PLAIN, new ByteArrayInputStream(String.format(template, find1, find2).getBytes()));
         VirtualFile file2 = replaceTestFolder
-                .createFile(fileName2, "text/plain", new ByteArrayInputStream(String.format(template, find1, find2).getBytes()));
+                .createFile(fileName2, MediaType.TEXT_PLAIN, new ByteArrayInputStream(String.format(template, find1, find2).getBytes()));
         VirtualFile file3 = replaceTestFolder
-                .createFile(fileName3, "text/plain", new ByteArrayInputStream(String.format(template, find1, find2).getBytes()));
+                .createFile(fileName3, MediaType.TEXT_PLAIN, new ByteArrayInputStream(String.format(template, find1, find2).getBytes()));
 
         List<Variable> variables = new ArrayList<>(2);
         variables.add(DtoFactory.getInstance().createDto(Variable.class).withFind(find1).withReplace(replace1));
@@ -91,10 +93,10 @@ public class ReplaceTest extends MemoryFileSystemTest {
 
         ReplacementSet replacementSet = DtoFactory.getInstance().createDto(ReplacementSet.class).withEntries(variables).withFiles(expression);
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         String path = SERVICE_URI + "replace/" + replaceTestFolder.getName();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, h,
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, h,
                                                       String.format("[%s]", DtoFactory.getInstance().toJson(replacementSet)).getBytes() , null, null);
         assertEquals(204, response.getStatus());
         assertEquals(String.format(templateReplaced, replace1, replace2), IoUtil.readAndCloseQuietly(mountPoint.getVirtualFileById(file2.getId()).getContent().getStream()));
@@ -107,7 +109,7 @@ public class ReplaceTest extends MemoryFileSystemTest {
         final String template_local = "some super content\n with ${%s} and another variable %s";
         final String fileName = "test_file.txt";
         VirtualFile file = replaceTestFolder
-                .createFile(fileName, "text/plain",
+                .createFile(fileName, MediaType.TEXT_PLAIN,
                             new ByteArrayInputStream(String.format(template_local, find1, find2).getBytes()));
         List<Variable> variables = new ArrayList<>(2);
         variables.add(DtoFactory.getInstance().createDto(Variable.class).withFind(find1).withReplace(replace1));
@@ -119,10 +121,10 @@ public class ReplaceTest extends MemoryFileSystemTest {
         ReplacementSet replacementSet =
                 DtoFactory.getInstance().createDto(ReplacementSet.class).withEntries(variables).withFiles(expression);
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         String path = SERVICE_URI + "replace/" + replaceTestFolder.getName();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, h,
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, h,
                                                       String.format("[%s]",
                                                                     DtoFactory.getInstance().toJson(replacementSet))
                                                             .getBytes(), null, null);
@@ -137,13 +139,13 @@ public class ReplaceTest extends MemoryFileSystemTest {
         final String fileName3 = "test_file.class";
 
         VirtualFile file1 = replaceTestFolder
-                .createFile(fileName1, "text/plain",
+                .createFile(fileName1, MediaType.TEXT_PLAIN,
                             new ByteArrayInputStream(String.format(template, find1, find2).getBytes()));
         VirtualFile file2 = replaceTestFolder
-                .createFile(fileName2, "text/plain",
+                .createFile(fileName2, MediaType.TEXT_PLAIN,
                             new ByteArrayInputStream(String.format(template, find1, find2).getBytes()));
         VirtualFile file3 = replaceTestFolder
-                .createFile(fileName3, "text/plain",
+                .createFile(fileName3, MediaType.TEXT_PLAIN,
                             new ByteArrayInputStream(String.format(template, find1, find2).getBytes()));
 
         List<Variable> variables = new ArrayList<>(2);
@@ -155,10 +157,10 @@ public class ReplaceTest extends MemoryFileSystemTest {
         ReplacementSet replacementSet =
                 DtoFactory.getInstance().createDto(ReplacementSet.class).withEntries(variables).withFiles(expression);
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         String path = SERVICE_URI + "replace/" + replaceTestFolder.getName();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, h,
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, h,
                                                       String.format("[%s]",
                                                                     DtoFactory.getInstance().toJson(replacementSet))
                                                             .getBytes(), null, null);
@@ -176,10 +178,10 @@ public class ReplaceTest extends MemoryFileSystemTest {
         final String fileName2 = "test_Mile.bat";
 
         VirtualFile file1 = replaceTestFolder
-                .createFile(fileName1, "text/plain",
+                .createFile(fileName1, MediaType.TEXT_PLAIN,
                             new ByteArrayInputStream(String.format(template, find1, find2).getBytes()));
         VirtualFile file2 = replaceTestFolder
-                .createFile(fileName2, "text/plain",
+                .createFile(fileName2, MediaType.TEXT_PLAIN,
                             new ByteArrayInputStream(String.format(template, find1, find2).getBytes()));
 
         List<Variable> variables = new ArrayList<>(2);
@@ -191,10 +193,10 @@ public class ReplaceTest extends MemoryFileSystemTest {
         ReplacementSet replacementSet =
                 DtoFactory.getInstance().createDto(ReplacementSet.class).withEntries(variables).withFiles(expression);
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         String path = SERVICE_URI + "replace/" + replaceTestFolder.getName();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, h,
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, h,
                                                       String.format("[%s]",
                                                                     DtoFactory.getInstance().toJson(replacementSet))
                                                             .getBytes(), null, null);
@@ -210,7 +212,7 @@ public class ReplaceTest extends MemoryFileSystemTest {
         final String fileName = "test_file.txt";
         VirtualFile src = replaceTestFolder.createFolder("src/main/java");
         VirtualFile file = src
-                .createFile(fileName, "text/plain",
+                .createFile(fileName, MediaType.TEXT_PLAIN,
                             new ByteArrayInputStream(String.format(template, find1, find2).getBytes()));
         List<Variable> variables = new ArrayList<>(2);
         variables.add(DtoFactory.getInstance().createDto(Variable.class).withFind(find1).withReplace(replace1));
@@ -221,10 +223,10 @@ public class ReplaceTest extends MemoryFileSystemTest {
         ReplacementSet replacementSet =
                 DtoFactory.getInstance().createDto(ReplacementSet.class).withEntries(variables).withFiles(expression);
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
 
         String path = SERVICE_URI + "replace/" + replaceTestFolder.getName();
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, h,
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, h,
                                                       String.format("[%s]",
                                                                     DtoFactory.getInstance().toJson(replacementSet))
                                                             .getBytes(), null, null);

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/ResourceLoaderTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/ResourceLoaderTest.java
@@ -17,6 +17,8 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 
+import javax.ws.rs.core.MediaType;
+
 /** @author andrew00x */
 public class ResourceLoaderTest extends MemoryFileSystemTest {
     private String folderId;
@@ -33,11 +35,11 @@ public class ResourceLoaderTest extends MemoryFileSystemTest {
         VirtualFile resourceLoaderTestFolder = mountPoint.getRoot().createFolder(name);
 
         VirtualFile folder = resourceLoaderTestFolder.createFolder("GetResourceTest_FOLDER");
-        folder.createFile("file1", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+        folder.createFile("file1", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         folderId = folder.getId();
         folderPath = folder.getPath();
 
-        VirtualFile file = resourceLoaderTestFolder.createFile("GetResourceTest_FILE", "text/plain",
+        VirtualFile file = resourceLoaderTestFolder.createFile("GetResourceTest_FILE", MediaType.TEXT_PLAIN,
                                                                 new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         fileId = file.getId();
         filePath = file.getPath();

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/UnlockTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/UnlockTest.java
@@ -11,11 +11,13 @@
 package org.eclipse.che.api.vfs.server.impl.memory;
 
 import org.eclipse.che.api.vfs.server.VirtualFile;
-
 import org.everrest.core.impl.ContainerResponse;
 import org.everrest.core.tools.ByteArrayContainerResponseWriter;
 
 import java.io.ByteArrayInputStream;
+
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.MediaType;
 
 /** @author andrew00x */
 public class UnlockTest extends MemoryFileSystemTest {
@@ -29,19 +31,19 @@ public class UnlockTest extends MemoryFileSystemTest {
         String name = getClass().getName();
         VirtualFile unlockTestFolder = mountPoint.getRoot().createFolder(name);
 
-        VirtualFile lockedFile = unlockTestFolder.createFile("UnlockTest_LOCKED", "text/plain",
+        VirtualFile lockedFile = unlockTestFolder.createFile("UnlockTest_LOCKED", MediaType.TEXT_PLAIN,
                                                              new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         fileLockToken = lockedFile.lock(0);
         lockedFileId = lockedFile.getId();
 
-        VirtualFile notLockedFile = unlockTestFolder.createFile("UnlockTest_NOTLOCKED", "text/plain",
+        VirtualFile notLockedFile = unlockTestFolder.createFile("UnlockTest_NOTLOCKED", MediaType.TEXT_PLAIN,
                                                                 new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         notLockedFileId = notLockedFile.getId();
     }
 
     public void testUnlockFile() throws Exception {
         String path = SERVICE_URI + "unlock/" + lockedFileId + '?' + "lockToken=" + fileLockToken;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, null);
         assertEquals(204, response.getStatus());
         VirtualFile file = mountPoint.getVirtualFileById(lockedFileId);
         assertFalse("Lock must be removed. ", file.isLocked());
@@ -50,7 +52,7 @@ public class UnlockTest extends MemoryFileSystemTest {
     public void testUnlockFileNoLockToken() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "unlock/" + lockedFileId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -58,7 +60,7 @@ public class UnlockTest extends MemoryFileSystemTest {
     public void testUnlockFileWrongLockToken() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "unlock/" + lockedFileId + '?' + "lockToken=" + fileLockToken + "_WRONG";
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -67,7 +69,7 @@ public class UnlockTest extends MemoryFileSystemTest {
     public void testUnlockFileNotLocked() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "unlock/" + notLockedFileId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(409, response.getStatus());
         log.info(new String(writer.getBody()));
     }

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/UpdateACLTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/UpdateACLTest.java
@@ -14,6 +14,7 @@ import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.shared.dto.AccessControlEntry;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -26,6 +27,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
 /** @author andrew00x */
 public class UpdateACLTest extends MemoryFileSystemTest {
     private String objectId;
@@ -36,7 +41,7 @@ public class UpdateACLTest extends MemoryFileSystemTest {
         String name = getClass().getName();
         VirtualFile updateAclTestFolder = mountPoint.getRoot().createFolder(name);
 
-        VirtualFile file = updateAclTestFolder.createFile("UpdateACLTest_FILE", "text/plain",
+        VirtualFile file = updateAclTestFolder.createFile("UpdateACLTest_FILE", MediaType.TEXT_PLAIN,
                                                           new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         objectId = file.getId();
     }
@@ -46,8 +51,8 @@ public class UpdateACLTest extends MemoryFileSystemTest {
         String body = "[{\"principal\":{\"name\":\"admin\",\"type\":\"USER\"},\"permissions\":[\"all\"]}," + //
                       "{\"principal\":{\"name\":\"john\",\"type\":\"USER\"},\"permissions\":[\"read\"]}]";
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, h, body.getBytes(), null);
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, h, body.getBytes(), null);
         assertEquals(204, response.getStatus());
         List<AccessControlEntry> acl = mountPoint.getVirtualFileById(objectId).getACL();
         Map<String, List<String>> m = toMap(acl);
@@ -66,8 +71,8 @@ public class UpdateACLTest extends MemoryFileSystemTest {
         String body = "[{\"principal\":{\"name\":\"admin\",\"type\":\"USER\"},\"permissions\":[\"all\"]}," + //
                       "{\"principal\":{\"name\":\"john\",\"type\":\"USER\"},\"permissions\":[\"read\"]}]";
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, h, body.getBytes(), writer, null);
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, h, body.getBytes(), writer, null);
         assertEquals(204, response.getStatus());
 
         List<AccessControlEntry> acl = mountPoint.getVirtualFileById(objectId).getACL();
@@ -87,8 +92,8 @@ public class UpdateACLTest extends MemoryFileSystemTest {
         String body = "[{\"principal\":{\"name\":\"admin\",\"type\":\"USER\"},\"permissions\":[\"all\"]}," + //
                       "{\"principal\":{\"name\":\"john\",\"type\":\"USER\"},\"permissions\":[\"read\"]}]";
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, h, body.getBytes(), null);
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, h, body.getBytes(), null);
         assertEquals(204, response.getStatus());
 
         List<AccessControlEntry> acl = mountPoint.getVirtualFileById(objectId).getACL();
@@ -105,8 +110,8 @@ public class UpdateACLTest extends MemoryFileSystemTest {
         String body = "[{\"principal\":{\"name\":\"admin\",\"type\":\"USER\"},\"permissions\":[\"all\"]}," + //
                       "{\"principal\":{\"name\":\"john\",\"type\":\"USER\"},\"permissions\":[\"read\"]}]";
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, h, body.getBytes(), writer, null);
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, h, body.getBytes(), writer, null);
         assertEquals(204, response.getStatus());
 
         List<AccessControlEntry> acl = mountPoint.getVirtualFileById(objectId).getACL();
@@ -122,8 +127,8 @@ public class UpdateACLTest extends MemoryFileSystemTest {
         String body = "[{\"principal\":{\"name\":\"admin\",\"type\":\"USER\"},\"permissions\":[\"all\"]}," + //
                       "{\"principal\":{\"name\":\"john\",\"type\":\"USER\"},\"permissions\":[\"read\"]}]";
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, h, body.getBytes(), writer, null);
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, h, body.getBytes(), writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -141,8 +146,8 @@ public class UpdateACLTest extends MemoryFileSystemTest {
         String body = "[{\"principal\":{\"name\":\"admin\",\"type\":\"USER\"},\"permissions\":[\"all\"]}," + //
                       "{\"principal\":{\"name\":\"john\",\"type\":\"USER\"},\"permissions\":[\"read\"]}]";
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, h, body.getBytes(), writer, null);
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, h, body.getBytes(), writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/UpdateContentTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/UpdateContentTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.vfs.server.impl.memory;
 import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -25,6 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
 /** @author andrew00x */
 public class UpdateContentTest extends MemoryFileSystemTest {
     private String fileId;
@@ -36,7 +41,7 @@ public class UpdateContentTest extends MemoryFileSystemTest {
         super.setUp();
         String name = getClass().getName();
         VirtualFile updateContentTestFolder = mountPoint.getRoot().createFolder(name);
-        VirtualFile file = updateContentTestFolder.createFile("UpdateContentTest_FILE", "text/plain",
+        VirtualFile file = updateContentTestFolder.createFile("UpdateContentTest_FILE", MediaType.TEXT_PLAIN,
                                                               new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         fileId = file.getId();
         VirtualFile folder = updateContentTestFolder.createFolder("UpdateContentTest_FOLDER");
@@ -48,20 +53,20 @@ public class UpdateContentTest extends MemoryFileSystemTest {
 
         Map<String, List<String>> headers = new HashMap<>();
         List<String> contentType = new ArrayList<>();
-        contentType.add("text/plain");
-        headers.put("Content-Type", contentType);
+        contentType.add(MediaType.TEXT_PLAIN);
+        headers.put(HttpHeaders.CONTENT_TYPE, contentType);
 
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, headers, content.getBytes(), null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, headers, content.getBytes(), null);
         assertEquals(204, response.getStatus());
 
         VirtualFile file = mountPoint.getVirtualFileById(fileId);
-        checkFileContext(content, "text/plain", file);
+        checkFileContext(content, MediaType.TEXT_PLAIN, file);
     }
 
     public void testUpdateContentFolder() throws Exception {
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "content/" + folderId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, content.getBytes(), writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, content.getBytes(), writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -77,7 +82,7 @@ public class UpdateContentTest extends MemoryFileSystemTest {
 
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "content/" + fileId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }
@@ -90,14 +95,14 @@ public class UpdateContentTest extends MemoryFileSystemTest {
 
         Map<String, List<String>> headers = new HashMap<>();
         List<String> contentType = new ArrayList<>();
-        contentType.add("text/plain");
-        headers.put("Content-Type", contentType);
+        contentType.add(MediaType.TEXT_PLAIN);
+        headers.put(HttpHeaders.CONTENT_TYPE, contentType);
 
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, headers, content.getBytes(), null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, headers, content.getBytes(), null);
         assertEquals(204, response.getStatus());
 
         file = mountPoint.getVirtualFileById(fileId);
-        checkFileContext(content, "text/plain", file);
+        checkFileContext(content, MediaType.TEXT_PLAIN, file);
     }
 
     public void testUpdateContentLockedNoLockToken() throws Exception {
@@ -105,7 +110,7 @@ public class UpdateContentTest extends MemoryFileSystemTest {
         file.lock(0);
         ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
         String path = SERVICE_URI + "content/" + fileId;
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, null, null, writer, null);
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, null, null, writer, null);
         assertEquals(403, response.getStatus());
         log.info(new String(writer.getBody()));
     }

--- a/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/UpdateTest.java
+++ b/platform-api/che-core-api-vfs/src/test/java/org/eclipse/che/api/vfs/server/impl/memory/UpdateTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.vfs.server.impl.memory;
 import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
+
 import com.google.common.collect.Sets;
 
 import org.everrest.core.impl.ContainerResponse;
@@ -24,6 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
 /** @author andrew00x */
 public class UpdateTest extends MemoryFileSystemTest {
     private String fileId;
@@ -34,7 +39,7 @@ public class UpdateTest extends MemoryFileSystemTest {
         String name = getClass().getName();
         VirtualFile updateTestFolder = mountPoint.getRoot().createFolder(name);
         VirtualFile file =
-                updateTestFolder.createFile("UpdateTest_FILE", "text/plain", new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
+                updateTestFolder.createFile("UpdateTest_FILE", MediaType.TEXT_PLAIN, new ByteArrayInputStream(DEFAULT_CONTENT.getBytes()));
         fileId = file.getId();
     }
 
@@ -51,8 +56,8 @@ public class UpdateTest extends MemoryFileSystemTest {
         String properties = "[{\"name\":\"MyProperty\", \"value\":[\"MyValue\"]}]";
         String path = SERVICE_URI + "item/" + fileId + "?lockToken=" + lockToken;
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, h, properties.getBytes(), null);
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, h, properties.getBytes(), null);
         assertEquals(200, response.getStatus());
         file = mountPoint.getVirtualFileById(fileId);
         assertEquals("MyValue", file.getPropertyValue("MyProperty"));
@@ -64,8 +69,8 @@ public class UpdateTest extends MemoryFileSystemTest {
         String properties = "[{\"name\":\"MyProperty\", \"value\":[\"MyValue\"]}]";
         String path = SERVICE_URI + "item/" + fileId;
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, h, properties.getBytes(), null);
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, h, properties.getBytes(), null);
         assertEquals(403, response.getStatus());
         file = mountPoint.getVirtualFileById(fileId);
         assertEquals(null, file.getPropertyValue("MyProperty"));
@@ -82,8 +87,8 @@ public class UpdateTest extends MemoryFileSystemTest {
         String properties = "[{\"name\":\"MyProperty\", \"value\":[\"MyValue\"]}]";
         String path = SERVICE_URI + "item/" + fileId;
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, h, properties.getBytes(), null);
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, h, properties.getBytes(), null);
         assertEquals(403, response.getStatus());
         file = mountPoint.getVirtualFileById(fileId);
         assertEquals(null, file.getPropertyValue("MyProperty"));
@@ -92,8 +97,8 @@ public class UpdateTest extends MemoryFileSystemTest {
     public void doUpdate(String id, String rawData) throws Exception {
         String path = SERVICE_URI + "item/" + id;
         Map<String, List<String>> h = new HashMap<>(1);
-        h.put("Content-Type", Arrays.asList("application/json"));
-        ContainerResponse response = launcher.service("POST", path, BASE_URI, h, rawData.getBytes(), null);
+        h.put(HttpHeaders.CONTENT_TYPE, Arrays.asList(MediaType.APPLICATION_JSON));
+        ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, h, rawData.getBytes(), null);
         assertEquals(200, response.getStatus());
     }
 }

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -56,6 +56,7 @@ import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -65,6 +66,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriBuilder;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -871,7 +873,7 @@ public class WorkspaceService extends Service {
         if (context.isUserInRole("account/owner") ||
             context.isUserInRole("workspace/admin") ||
             context.isUserInRole("workspace/developer")) {
-            links.add(LinksHelper.createLink("GET",
+            links.add(LinksHelper.createLink(HttpMethod.GET,
                                              serviceUriBuilder.clone()
                                                               .path(getClass(), "getMembers")
                                                               .build(workspace.getId())
@@ -881,7 +883,7 @@ public class WorkspaceService extends Service {
                                              Constants.LINK_REL_GET_WORKSPACE_MEMBERS));
         }
         if (context.isUserInRole("account/owner") || context.isUserInRole("workspace/admin")) {
-            links.add(LinksHelper.createLink("DELETE",
+            links.add(LinksHelper.createLink(HttpMethod.DELETE,
                                              serviceUriBuilder.clone()
                                                               .path(getClass(), "removeMember")
                                                               .build(workspace.getId(), member.getUserId())
@@ -890,7 +892,7 @@ public class WorkspaceService extends Service {
                                              null,
                                              Constants.LINK_REL_REMOVE_WORKSPACE_MEMBER));
         }
-        links.add(LinksHelper.createLink("GET",
+        links.add(LinksHelper.createLink(HttpMethod.GET,
                                          baseUriBuilder.clone()
                                                        .path(UserService.class)
                                                        .path(UserService.class, "getById")
@@ -899,7 +901,7 @@ public class WorkspaceService extends Service {
                                          null,
                                          APPLICATION_JSON,
                                          LINK_REL_GET_USER_BY_ID));
-        final Link wsLink = LinksHelper.createLink("GET",
+        final Link wsLink = LinksHelper.createLink(HttpMethod.GET,
                                                    serviceUriBuilder.clone()
                                                                     .path(getClass(), "getById")
                                                                     .build(workspace.getId())
@@ -907,7 +909,7 @@ public class WorkspaceService extends Service {
                                                    null,
                                                    APPLICATION_JSON,
                                                    Constants.LINK_REL_GET_WORKSPACE_BY_ID);
-        final Link projectsLink = LinksHelper.createLink("GET",
+        final Link projectsLink = LinksHelper.createLink(HttpMethod.GET,
                                                          baseUriBuilder.clone()
                                                                        .path(ProjectService.class)
                                                                        .path(ProjectService.class, "getProjects")
@@ -941,7 +943,7 @@ public class WorkspaceService extends Service {
         final List<Link> links = new LinkedList<>();
         final UriBuilder uriBuilder = getServiceContext().getServiceUriBuilder();
         if (context.isUserInRole("user")) {
-            links.add(LinksHelper.createLink("GET",
+            links.add(LinksHelper.createLink(HttpMethod.GET,
                                              getServiceContext().getBaseUriBuilder().clone()
                                                                 .path(ProjectService.class)
                                                                 .path(ProjectService.class, "getProjects")
@@ -950,7 +952,7 @@ public class WorkspaceService extends Service {
                                              null,
                                              APPLICATION_JSON,
                                              org.eclipse.che.api.project.server.Constants.LINK_REL_GET_PROJECTS));
-            links.add(LinksHelper.createLink("GET",
+            links.add(LinksHelper.createLink(HttpMethod.GET,
                                              uriBuilder.clone()
                                                        .path(getClass(), "getMembershipsOfCurrentUser")
                                                        .build()
@@ -958,7 +960,7 @@ public class WorkspaceService extends Service {
                                              null,
                                              APPLICATION_JSON,
                                              Constants.LINK_REL_GET_CURRENT_USER_WORKSPACES));
-            links.add(LinksHelper.createLink("GET",
+            links.add(LinksHelper.createLink(HttpMethod.GET,
                                              uriBuilder.clone()
                                                        .path(getClass(), "getMembershipOfCurrentUser")
                                                        .build(workspaceDescriptor.getId())
@@ -969,7 +971,7 @@ public class WorkspaceService extends Service {
         }
         if (context.isUserInRole("workspace/admin") || context.isUserInRole("workspace/developer") ||
             context.isUserInRole("system/admin") || context.isUserInRole("system/manager") || context.isUserInRole("account/owner")) {
-            links.add(LinksHelper.createLink("GET",
+            links.add(LinksHelper.createLink(HttpMethod.GET,
                                              uriBuilder.clone().
                                                      path(getClass(), "getByName")
                                                        .queryParam("name", workspaceDescriptor.getName())
@@ -978,7 +980,7 @@ public class WorkspaceService extends Service {
                                              null,
                                              APPLICATION_JSON,
                                              Constants.LINK_REL_GET_WORKSPACE_BY_NAME));
-            links.add(LinksHelper.createLink("GET",
+            links.add(LinksHelper.createLink(HttpMethod.GET,
                                              uriBuilder.clone()
                                                        .path(getClass(), "getById")
                                                        .build(workspaceDescriptor.getId())
@@ -986,7 +988,7 @@ public class WorkspaceService extends Service {
                                              null,
                                              APPLICATION_JSON,
                                              Constants.LINK_REL_GET_WORKSPACE_BY_ID));
-            links.add(LinksHelper.createLink("GET",
+            links.add(LinksHelper.createLink(HttpMethod.GET,
                                              uriBuilder.clone()
                                                        .path(getClass(), "getMembers")
                                                        .build(workspaceDescriptor.getId())
@@ -996,7 +998,7 @@ public class WorkspaceService extends Service {
                                              Constants.LINK_REL_GET_WORKSPACE_MEMBERS));
         }
         if (context.isUserInRole("account/owner") || context.isUserInRole("workspace/admin") || context.isUserInRole("system/admin")) {
-            links.add(LinksHelper.createLink("DELETE",
+            links.add(LinksHelper.createLink(HttpMethod.DELETE,
                                              uriBuilder.clone()
                                                        .path(getClass(), "remove")
                                                        .build(workspaceDescriptor.getId())

--- a/platform-api/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/platform-api/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -51,7 +51,11 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
+
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -746,14 +750,14 @@ public class WorkspaceServiceTest {
 
     @SuppressWarnings("unchecked")
     private <T> T doDelete(String path, Status expectedResponseStatus) throws Exception {
-        final ContainerResponse response = launcher.service("DELETE", path, BASE_URI, null, null, null, environmentContext);
+        final ContainerResponse response = launcher.service(HttpMethod.DELETE, path, BASE_URI, null, null, null, environmentContext);
         assertEquals(response.getStatus(), expectedResponseStatus.getStatusCode());
         return (T)response.getEntity();
     }
 
     @SuppressWarnings("unchecked")
     private <T> T doGet(String path) throws Exception {
-        final ContainerResponse response = launcher.service("GET", path, BASE_URI, null, null, null, environmentContext);
+        final ContainerResponse response = launcher.service(HttpMethod.GET, path, BASE_URI, null, null, null, environmentContext);
         assertEquals(response.getStatus(), OK.getStatusCode());
         return (T)response.getEntity();
     }
@@ -762,8 +766,8 @@ public class WorkspaceServiceTest {
     private <T> T doPost(String path, Object entity, Status expectedResponseStatus) throws Exception {
         final byte[] data = JsonHelper.toJson(entity).getBytes();
         final Map<String, List<String>> headers = new HashMap<>(4);
-        headers.put("Content-Type", singletonList("application/json"));
-        final ContainerResponse response = launcher.service("POST", path, BASE_URI, headers, data, null, environmentContext);
+        headers.put(HttpHeaders.CONTENT_TYPE, singletonList(MediaType.APPLICATION_JSON));
+        final ContainerResponse response = launcher.service(HttpMethod.POST, path, BASE_URI, headers, data, null, environmentContext);
         assertEquals(response.getStatus(), expectedResponseStatus.getStatusCode());
         return (T)response.getEntity();
     }


### PR DESCRIPTION
Content-Type, application/<type>, test/plain, Content-Disposition, Method

Added ExtMediaType to commons-lang for extended MediaType constants
Added "zip" and "tar" constants to builder

Signed-off-by: Tareq Sharafy <tareq.sharafy@sap.com>