### PR TITLE
Send token in RemoteServiceDescriptor.isAvailable

### DIFF
--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuildQueue.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuildQueue.java
@@ -680,7 +680,7 @@ public class BuildQueue {
             eventService.subscribe(new AnalyticsMessenger());
 
             if (slaves.length > 0) {
-                executor.execute(new Runnable() {
+                executor.execute(ThreadLocalPropagateContext.wrap(new Runnable() {
                     @Override
                     public void run() {
                         final LinkedList<RemoteBuilderServer> servers = new LinkedList<>();
@@ -727,7 +727,7 @@ public class BuildQueue {
                             }
                         }
                     }
-                });
+                }));
             }
         } else {
             throw new IllegalStateException("Already started");

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/RemoteServiceDescriptor.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/RemoteServiceDescriptor.java
@@ -10,6 +10,12 @@
  *******************************************************************************/
 package org.eclipse.che.api.core.rest;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.NotFoundException;
@@ -20,15 +26,6 @@ import org.eclipse.che.api.core.rest.shared.dto.ServiceDescriptor;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.ws.rs.HttpMethod;
 
 /**
  * Provides basic functionality to access remote {@link Service Service}. Basically provides next information about {@code Service}:
@@ -114,23 +111,12 @@ public class RemoteServiceDescriptor {
 
     /** Checks service availability. */
     public boolean isAvailable() {
-        LOG.debug("Testing availability {}", baseUrlURL);
-        HttpURLConnection conn = null;
+        LOG.debug("Testing availability {}", baseUrl);
         try {
-            conn = (HttpURLConnection)baseUrlURL.openConnection();
-            conn.setConnectTimeout(3 * 1000);
-            conn.setReadTimeout(10 * 1000);
-            conn.setRequestMethod(HttpMethod.OPTIONS);
-            int responseCode = conn.getResponseCode();
-            LOG.debug("OPTIONS {} response {}", baseUrlURL, responseCode);
-            return 200 == responseCode;
-        } catch (IOException e) {
+            return (HttpJsonHelper.options(getServiceDescriptorClass(), baseUrl) != null);
+        } catch (Exception e) {
             LOG.warn(e.getLocalizedMessage());
             return false;
-        } finally {
-            if (conn != null) {
-                conn.disconnect();
-            }
         }
     }
 }

--- a/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RunQueue.java
+++ b/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RunQueue.java
@@ -337,13 +337,13 @@ public class RunQueue {
             eventService.subscribe(new AnalyticsMessenger());
 
             if (slaves.length > 0) {
-                executor.execute(new RegisterSlaveRunnerTask(slaves, null));
+                executor.execute(ThreadLocalPropagateContext.wrap(new RegisterSlaveRunnerTask(slaves, null)));
             }
             if (slavesPaid.length > 0) {
-                executor.execute(new RegisterSlaveRunnerTask(slavesPaid, "paid"));
+                executor.execute(ThreadLocalPropagateContext.wrap(new RegisterSlaveRunnerTask(slavesPaid, "paid")));
             }
             if (slavesAlwaysOn.length > 0) {
-                executor.execute(new RegisterSlaveRunnerTask(slavesAlwaysOn, "always_on"));
+                executor.execute(ThreadLocalPropagateContext.wrap(new RegisterSlaveRunnerTask(slavesAlwaysOn, "always_on")));
             }
         } else {
             throw new IllegalStateException("Already started");


### PR DESCRIPTION
- Use HttpJsonHelper for the rest call (this also makes sure the response
  structure is valid)
- Pass current EnvironmentContext to executor.execute when registering
  pre-configured builders and runners