### PR TITLE
Move complex logic from ProjectServce to ProjectManager

### DIFF
--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/DefaultProjectManager.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/DefaultProjectManager.java
@@ -19,6 +19,8 @@ import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.project.server.handlers.CreateModuleHandler;
 import org.eclipse.che.api.project.server.handlers.CreateProjectHandler;
 import org.eclipse.che.api.project.server.handlers.ProjectHandlerRegistry;
+import org.eclipse.che.api.project.server.handlers.ProjectTypeChangedHandler;
+import org.eclipse.che.api.project.server.notification.ProjectItemModifiedEvent;
 import org.eclipse.che.api.project.server.type.Attribute;
 import org.eclipse.che.api.project.server.type.AttributeValue;
 import org.eclipse.che.api.project.server.type.BaseProjectType;
@@ -30,6 +32,7 @@ import org.eclipse.che.api.project.shared.dto.SourceEstimation;
 import org.eclipse.che.api.vfs.server.Path;
 import org.eclipse.che.api.vfs.server.VirtualFileSystemRegistry;
 import org.eclipse.che.api.vfs.server.observation.VirtualFileEvent;
+import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.commons.lang.cache.Cache;
 import org.eclipse.che.commons.lang.cache.SLRUCache;
@@ -38,14 +41,22 @@ import org.eclipse.che.dto.server.DtoFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.wordnik.swagger.annotations.ApiParam;
+
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -231,6 +242,67 @@ public final class DefaultProjectManager implements ProjectManager {
             project.setVisibility(visibility);
         }
 
+        return project;
+    }
+
+    /**
+     * Update the given project
+     * @param workspace The workspace that contains the project to update.
+     * @param path The path to the project.
+     * @param newConfig The new configuration of the project
+     * @param newVisibility Then new visibility of the project. If not, visibility is not changed.
+     * @return The updated project.
+     */
+    @Override
+    public Project updateProject(String workspace, String path, ProjectConfig newConfig, String newVisibility)
+            throws ForbiddenException, ServerException, NotFoundException, ConflictException, IOException {
+        Project project = getProject(workspace, path);
+        String oldProjectType = null;
+        List<String> oldMixinTypes = new ArrayList<>();
+        // If a project does not exist in the target path, create a new one
+        if (project == null) {
+            FolderEntry projectsRoot = getProjectsRoot(workspace);
+            VirtualFileEntry child = projectsRoot.getChild(path);
+            if (child != null && child.isFolder() && child.getParent().isRoot()) {
+                project = new Project((FolderEntry) child, this);
+            } else {
+                throw new NotFoundException(
+                        String.format("Project '%s' doesn't exist in workspace '%s'.", path, workspace));
+            }
+        } else {
+            try {
+                ProjectConfig config = project.getConfig();
+                oldProjectType = config.getTypeId();
+                oldMixinTypes = config.getMixinTypes();
+            } catch (ProjectTypeConstraintException | ValueStorageException e) {
+                // here we allow changing bad project type on registered
+                LOG.warn(e.getMessage());
+            }
+        }
+        // Update the visibility if asked to do so
+        if (newVisibility != null && !newVisibility.isEmpty()) {
+            project.setVisibility(newVisibility);
+        }
+        project.updateConfig(newConfig);
+        // handle project type changes
+        // post actions on changing project type
+        // base or mixin
+        if (!newConfig.getTypeId().equals(oldProjectType)) {
+            ProjectTypeChangedHandler projectTypeChangedHandler = handlers
+                    .getProjectTypeChangedHandler(newConfig.getTypeId());
+            if (projectTypeChangedHandler != null) {
+                projectTypeChangedHandler.onProjectTypeChanged(project.getBaseFolder());
+            }
+        }
+        List<String> mixinTypes = firstNonNull(newConfig.getMixinTypes(), Collections.<String> emptyList());
+        for (String mixin : mixinTypes) {
+            if (!oldMixinTypes.contains(mixin)) {
+                ProjectTypeChangedHandler projectTypeChangedHandler = handlers.getProjectTypeChangedHandler(mixin);
+                if (projectTypeChangedHandler != null) {
+                    projectTypeChangedHandler.onProjectTypeChanged(project.getBaseFolder());
+                }
+            }
+        }
         return project;
     }
 
@@ -611,5 +683,84 @@ public final class DefaultProjectManager implements ProjectManager {
         return project;
     }
 
+    @Override
+    public VirtualFileEntry rename(String workspace, String path, String newName, String newMediaType)
+            throws ForbiddenException, ServerException, ConflictException, NotFoundException {
+        final FolderEntry root = getProjectsRoot(workspace);
+        final VirtualFileEntry entry = root.getChild(path);
+        if (entry == null) {
+            return null;
+        }
+        if (entry.isFile() && newMediaType != null) {
+            // Use the same rules as in method createFile to make client side simpler.
+            ((FileEntry) entry).rename(newName, newMediaType);
+        } else {
+            entry.rename(newName);
+            String projectName = projectPath(path);
+            /* We should not edit Modules if resource to rename is project */
+            if (!projectName.equals(path) && entry.isFolder() && ((FolderEntry) entry).isProjectFolder()) {
+                Project project = getProject(workspace, projectName);
+
+                /*
+                 * We need module path without projectName, f.e projectName/module1/oldModuleName ->
+                 * module1/oldModuleName
+                 */
+                String oldModulePath = path.replaceFirst(projectName + "/", "");
+                /* Calculates new module path, f.e module1/oldModuleName -> module1/newModuleName */
+                String newModulePath = oldModulePath.substring(0, oldModulePath.lastIndexOf("/") + 1) + newName;
+
+                project.getModules().update(oldModulePath, newModulePath);
+            }
+        }
+        return entry;
+    }
+
+    @Override
+    public boolean delete(String workspace, String path, String modulePath)
+            throws ServerException, ForbiddenException, NotFoundException, ConflictException {
+        final FolderEntry root = getProjectsRoot(workspace);
+        final VirtualFileEntry entry = root.getChild(path);
+        if (entry == null) {
+            return false;
+        }
+        if (entry.isFolder() && ((FolderEntry) entry).isProjectFolder()) {
+            // In case of folder extract some information about project for logger before delete project.
+            Project project = new Project((FolderEntry) entry, this);
+            // remove module only
+            if (modulePath != null) {
+                return project.getModules().remove(modulePath);
+            }
+            final String name = project.getName();
+            String projectType = null;
+            try {
+                projectType = project.getConfig().getTypeId();
+            } catch (ServerException | ValueStorageException | ProjectTypeConstraintException e) {
+                // Let delete even project in invalid state.
+                entry.remove();
+                LOG.info("EVENT#project-destroyed# PROJECT#{}# TYPE#{}# WS#{}# USER#{}#", name, "unknown",
+                        EnvironmentContext.getCurrent().getWorkspaceName(),
+                        EnvironmentContext.getCurrent().getUser().getName());
+                LOG.warn(String.format("Removing not valid project ws : %s, project path: %s ", workspace, path)
+                        + e.getMessage(), e);
+            }
+            entry.remove();
+            LOG.info("EVENT#project-destroyed# PROJECT#{}# TYPE#{}# WS#{}# USER#{}#", name, projectType,
+                    EnvironmentContext.getCurrent().getWorkspaceName(),
+                    EnvironmentContext.getCurrent().getUser().getName());
+        } else {
+            eventService.publish(new ProjectItemModifiedEvent(ProjectItemModifiedEvent.EventType.DELETED, workspace,
+                    projectPath(entry.getPath()), entry.getPath(), entry.isFolder()));
+            entry.remove();
+        }
+        return true;
+    }
+
+    private static String projectPath(String path) {
+        int end = path.indexOf("/");
+        if (end == -1) {
+            return path;
+        }
+        return path.substring(0, end);
+    }
 
 }

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/Project.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/Project.java
@@ -391,14 +391,15 @@ public class Project {
 
         private final String MODULES_PATH = ".codenvy/modules";
 
-        public void remove(String path) throws ForbiddenException, ServerException, ConflictException {
+        public boolean remove(String path) throws ForbiddenException, ServerException, ConflictException {
 
             Set<String> all = read();
             if (all.contains(path)) {
                 all.remove(path);
                 write(all);
+                return true;
             }
-
+            return false;
         }
 
         public void add(String path) throws ForbiddenException, ServerException, ConflictException {

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectManager.java
@@ -22,6 +22,7 @@ import org.eclipse.che.api.project.shared.dto.SourceEstimation;
 import org.eclipse.che.api.vfs.server.VirtualFileSystemRegistry;
 import com.google.inject.ImplementedBy;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -78,6 +79,17 @@ public interface ProjectManager {
     Project createProject(String workspace, String name, ProjectConfig projectConfig, Map<String, String> options,
                           String visibility)
             throws ConflictException, ForbiddenException, ServerException, ProjectTypeConstraintException, NotFoundException;
+
+    /**
+     * Update the given project
+     * @param workspace The workspace that contains the project to update.
+     * @param path The path to the project.
+     * @param newConfig The new configuration of the project
+     * @param newVisibility Then new visibility of the project. If not, visibility is not changed.
+     * @return The updated project.
+     */
+    Project updateProject(String workspace, String path, ProjectConfig newConfig, String newVisibility)
+            throws ForbiddenException, ServerException, NotFoundException, ConflictException, IOException;
 
     /**
      * Gets root folder od project tree.
@@ -149,4 +161,26 @@ public interface ProjectManager {
 
     Project convertFolderToProject(String workspace, String path, ProjectConfig projectConfig, String visibility)
             throws ConflictException, ForbiddenException, ServerException, NotFoundException;
+
+    /**
+     * Rename the given item.
+     * @param workspace The workspace that contains the item.
+     * @param path The current path to the path being renamed
+     * @param newName The name name of the item.
+     * @param newMediaType A new media type to set
+     * @return The renamed virtual file entry, or null if no entry with the given path was found.
+     */
+    VirtualFileEntry rename(String workspace, String path, String newName, String newMediaType)
+            throws ForbiddenException, ServerException, ConflictException, NotFoundException;
+
+    /**
+     * Delete the given item from the workspace.
+     * @param workspace The workspace to delete from.
+     * @param path Path to the item (file / folder / project) to delete.
+     * @param modulePath In case a module is being deleted, the module's path relative to the provided path.
+     * @return True if the path was found and deleted, false if the path was not found.
+     */
+    boolean delete(String workspace, String path, String modulePath)
+            throws ServerException, ForbiddenException, NotFoundException, ConflictException;
+
 }

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
@@ -406,54 +406,9 @@ public class ProjectService extends Service {
                                            @PathParam("path") String path,
                                            ProjectUpdate update)
             throws NotFoundException, ConflictException, ForbiddenException, ServerException, IOException {
-        Project project = projectManager.getProject(workspace, path);
-        String oldProjectType = null;
-        List<String> oldMixinTypes = new ArrayList<>();
-        if (project == null) {
-            FolderEntry projectsRoot = projectManager.getProjectsRoot(workspace);
-            VirtualFileEntry child = projectsRoot.getChild(path);
-            if (child != null && child.isFolder() && child.getParent().isRoot()) {
-                project = new Project((FolderEntry)child, projectManager);
-            } else {
-                throw new NotFoundException(String.format("Project '%s' doesn't exist in workspace '%s'.", path, workspace));
-            }
-        } else {
-            try {
-                ProjectConfig config = project.getConfig();
-                oldProjectType = config.getTypeId();
-                oldMixinTypes = config.getMixinTypes();
-            } catch (ProjectTypeConstraintException | ValueStorageException e) {
-                //here we allow changing bad project type on registered
-                LOG.warn(e.getMessage());
-            }
-        }
-
-        String visibility = update.getVisibility();
-        if (visibility != null && !visibility.isEmpty()) {
-            project.setVisibility(visibility);
-        }
-        project.updateConfig(DtoConverter.fromDto2(update, projectManager.getProjectTypeRegistry()));
-
-        //handle project type changes
-        //post actions on changing project type
-        //base or mixin
-        if (!update.getType().equals(oldProjectType)) {
-            ProjectTypeChangedHandler projectTypeChangedHandler = projectHandlerRegistry.getProjectTypeChangedHandler(update.getType());
-            if (projectTypeChangedHandler != null) {
-                projectTypeChangedHandler.onProjectTypeChanged(project.getBaseFolder());
-            }
-        }
-
-        List<String> mixinTypes = firstNonNull(update.getMixinTypes(), Collections.<String>emptyList());
-        for (String mixin : mixinTypes) {
-            if (!oldMixinTypes.contains(mixin)) {
-                ProjectTypeChangedHandler projectTypeChangedHandler = projectHandlerRegistry.getProjectTypeChangedHandler(mixin);
-                if (projectTypeChangedHandler != null) {
-                    projectTypeChangedHandler.onProjectTypeChanged(project.getBaseFolder());
-                }
-            }
-        }
-
+        ProjectConfig newConfig = DtoConverter.fromDto2(update, projectManager.getProjectTypeRegistry());
+        String newVisibility = update.getVisibility();
+        Project project = projectManager.updateProject(workspace, path, newConfig, newVisibility);
         return DtoConverter.toDescriptorDto2(project,
                                              getServiceContext().getServiceUriBuilder(),
                                              getServiceContext().getBaseUriBuilder(),
@@ -685,37 +640,8 @@ public class ProjectService extends Service {
                        @PathParam("path") String path,
                        @QueryParam("module") String modulePath)
             throws NotFoundException, ForbiddenException, ConflictException, ServerException {
-
-        final VirtualFileEntry entry = getVirtualFileEntry(workspace, path);
-        if (entry.isFolder() && ((FolderEntry)entry).isProjectFolder()) {
-            // In case of folder extract some information about project for logger before delete project.
-            Project project = new Project((FolderEntry)entry, projectManager);
-            // remove module only
-            if (modulePath != null) {
-                project.getModules().remove(modulePath);
-                return;
-            }
-
-            final String name = project.getName();
-            String projectType = null;
-            try {
-                projectType = project.getConfig().getTypeId();
-            } catch (ServerException | ValueStorageException | ProjectTypeConstraintException e) {
-                // Let delete even project in invalid state.
-                entry.remove();
-                LOG.info("EVENT#project-destroyed# PROJECT#{}# TYPE#{}# WS#{}# USER#{}#", name, "unknown",
-                         EnvironmentContext.getCurrent().getWorkspaceName(), EnvironmentContext.getCurrent().getUser().getName());
-                LOG.warn(String.format("Removing not valid project ws : %s, project path: %s ", workspace, path) + e.getMessage(), e);
-            }
-            entry.remove();
-            LOG.info("EVENT#project-destroyed# PROJECT#{}# TYPE#{}# WS#{}# USER#{}#", name, projectType,
-                     EnvironmentContext.getCurrent().getWorkspaceName(), EnvironmentContext.getCurrent().getUser().getName());
-        } else {
-
-            eventService.publish(new ProjectItemModifiedEvent(ProjectItemModifiedEvent.EventType.DELETED,
-                                                              workspace, projectPath(entry.getPath()), entry.getPath(), entry.isFolder()));
-
-            entry.remove();
+        if (!projectManager.delete(workspace, path, modulePath)) {
+            throw new NotFoundException(String.format("Path '%s' doesn't exist.", path));
         }
     }
 
@@ -832,26 +758,9 @@ public class ProjectService extends Service {
                            @ApiParam(value = "New media type")
                            @QueryParam("mediaType") String newMediaType)
             throws NotFoundException, ConflictException, ForbiddenException, ServerException, IOException {
-        final VirtualFileEntry entry = getVirtualFileEntry(workspace, path);
-        if (entry.isFile() && newMediaType != null) {
-            // Use the same rules as in method createFile to make client side simpler.
-            ((FileEntry)entry).rename(newName, newMediaType);
-        } else {
-            entry.rename(newName);
-
-            String projectName = projectPath(path);
-
-            /* We should not edit Modules if resource to rename is project */
-            if (!projectName.equals(path) && entry.isFolder() && ((FolderEntry)entry).isProjectFolder()) {
-                Project project = projectManager.getProject(workspace, projectName);
-
-                /* We need module path without projectName, f.e projectName/module1/oldModuleName -> module1/oldModuleName */
-                String oldModulePath = path.replaceFirst(projectName + "/", "");
-                /* Calculates new module path, f.e module1/oldModuleName -> module1/newModuleName */
-                String newModulePath = oldModulePath.substring(0, oldModulePath.lastIndexOf("/") + 1) + newName;
-
-                project.getModules().update(oldModulePath, newModulePath);
-            }
+        final VirtualFileEntry entry = projectManager.rename(workspace, path, newName, newMediaType);
+        if (entry == null) {
+            throw new NotFoundException(String.format("Path '%s' doesn't exist.", path));
         }
         final URI location = getServiceContext().getServiceUriBuilder()
                                                 .path(getClass(), entry.isFile() ? "getFile" : "getChildren")


### PR DESCRIPTION
This allow reusing the whole logic of updateProject/delete/rename from inside the server, without the need for loop-back calls to ProjectService. This further reduces the mix-up of service layer with server logic.

Change-Id: I7cdf4c71f11dae24316da4f21b346cf2b181d8a0
Signed-off-by: Tareq Sharafy <tareq.sharafy@sap.com>