### PR TITLE
Polishing of EditorAgentImpl class

### DIFF
--- a/commons/che-core-commons-xml/src/main/java/org/eclipse/che/commons/xml/ElementMapper.java
+++ b/commons/che-core-commons-xml/src/main/java/org/eclipse/che/commons/xml/ElementMapper.java
@@ -13,7 +13,7 @@ package org.eclipse.che.commons.xml;
 /**
  * @author Eugene Voevodin
  */
-public interface ElementMapper<T> {
+public interface ElementMapper<> {
 
     T map(Element element);
 }

--- a/commons/che-core-commons-xml/src/main/java/org/eclipse/che/commons/xml/ElementMapper.java
+++ b/commons/che-core-commons-xml/src/main/java/org/eclipse/che/commons/xml/ElementMapper.java
@@ -13,7 +13,7 @@ package org.eclipse.che.commons.xml;
 /**
  * @author Eugene Voevodin
  */
-public interface ElementMapper<> {
+public interface ElementMapper<T> {
 
     T map(Element element);
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/editor/EditorAgentImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/editor/EditorAgentImpl.java
@@ -187,8 +187,9 @@ public class EditorAgentImpl implements EditorAgent {
     }
 
     private void doOpen(final VirtualFile file, final OpenEditorCallback callback) {
-        if (openedEditors.containsKey(file.getPath())) {
-            workspace.setActivePart(openedEditors.get(file.getPath()));
+        String filePath = file.getPath();
+        if (openedEditors.containsKey(filePath)) {
+            workspace.setActivePart(openedEditors.get(filePath));
         } else {
             FileType fileType = fileTypeRegistry.getFileTypeByFile(file);
             EditorProvider editorProvider = editorRegistry.getEditor(fileType);


### PR DESCRIPTION
Reduse qoontity of ```file.getPath()``` operations from two to one in the ```doOpen(final VirtualFile file, final OpenEditorCallback callback)``` method.