### PR TITLE
Support NULL 'any' properties in DTO cloning

### DIFF
--- a/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImplServerTemplate.java
+++ b/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImplServerTemplate.java
@@ -615,7 +615,12 @@ public class DtoImplServerTemplate extends DtoImpl {
         return builder;
     }
     private static StringBuilder appendNaiveCopyJsonExpression(String inValue, StringBuilder builder) {
-        return builder.append("new JsonParser().parse((").append(inValue).append(").toString())");
+        builder.append("((");
+        builder.append(inValue);
+        builder.append(") != null ? new JsonParser().parse((");
+        builder.append(inValue);
+        builder.append(").toString()) : null)");
+        return builder;
     }
 
     private void emitPreamble(Class<?> dtoInterface, StringBuilder builder) {

--- a/platform-api/che-core-api-dto/src/test/java/org/eclipse/che/dto/ServerDtoTest.java
+++ b/platform-api/che-core-api-dto/src/test/java/org/eclipse/che/dto/ServerDtoTest.java
@@ -23,6 +23,7 @@ import org.eclipse.che.dto.server.DtoFactory;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
@@ -140,6 +141,18 @@ public class ServerDtoTest {
         DtoWithAny dto = dtoFactory.createDtoFromJson(json.toString(), DtoWithAny.class);
 
         Assert.assertEquals(dto.getStuff(), createTestValueForAny());
+    }
+
+    @Test
+    public void testCloneWithNullAny() throws Exception {
+        DtoWithAny dto1 = dtoFactory.createDto(DtoWithAny.class);
+        DtoWithAny dto2 = dtoFactory.clone(dto1);
+        Assert.assertEquals(dto1, dto2);
+        JsonElement json = new JsonParser().parse(dtoFactory.toJson(dto1));
+        JsonObject expJson = new JsonObject();
+        expJson.addProperty("id", 0);
+        expJson.add("stuff", JsonNull.INSTANCE);
+        assertEquals(expJson, json);
     }
 
     /** Intentionally call several times to ensure non-reference equality */


### PR DESCRIPTION
previously this failed with NPE

Change-Id: Id0de7b3a51bb3b98252388185878913fa40897c4
Signed-off-by: Tareq Sharafy <tareq.sharafy@sap.com>