### PR TITLE
[#206 - issue] Private constructors changed in ParameterizedTypeImpl.java

### DIFF
--- a/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/reflect/ParameterizedTypeImpl.java
+++ b/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/reflect/ParameterizedTypeImpl.java
@@ -21,14 +21,10 @@ import java.util.Arrays;
  */
 public final class ParameterizedTypeImpl implements ParameterizedType {
 
-    public static ParameterizedType newParameterizedType(Class<?> rawType, Type... typeArguments) {
-        return new ParameterizedTypeImpl(rawType, typeArguments);
-    }
-
     private final Type[]   typeArguments;
     private final Class<?> rawType;
 
-    private ParameterizedTypeImpl(Class<?> rawType, Type[] typeArguments) {
+    public ParameterizedTypeImpl(Class<?> rawType, Type... typeArguments) {
         this.rawType = rawType;
         this.typeArguments = new Type[typeArguments.length];
         System.arraycopy(typeArguments, 0, this.typeArguments, 0, this.typeArguments.length);

--- a/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/reflect/ParameterizedTypeImpl.java
+++ b/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/reflect/ParameterizedTypeImpl.java
@@ -29,29 +29,18 @@ public final class ParameterizedTypeImpl implements ParameterizedType {
         return new ParameterizedTypeImpl(rawType, typeArgument);
     }
 
-    private final Type     ownerType;
     private final Type[]   typeArguments;
     private final Class<?> rawType;
 
-    private ParameterizedTypeImpl(Type ownerType, Class<?> rawType, Type typeArgument) {
-        this.ownerType = ownerType; // always null for now
+    private ParameterizedTypeImpl(Class<?> rawType, Type typeArgument) {
         this.rawType = rawType;
         this.typeArguments = new Type[]{typeArgument};
     }
 
-    private ParameterizedTypeImpl(Class<?> rawType, Type typeArgument) {
-        this(null, rawType, typeArgument);
-    }
-
-    private ParameterizedTypeImpl(Type ownerType, Class<?> rawType, Type[] typeArguments) {
-        this.ownerType = ownerType; // always null for now
+    private ParameterizedTypeImpl(Class<?> rawType, Type[] typeArguments) {
         this.rawType = rawType;
         this.typeArguments = new Type[typeArguments.length];
         System.arraycopy(typeArguments, 0, this.typeArguments, 0, this.typeArguments.length);
-    }
-
-    private ParameterizedTypeImpl(Class<?> rawType, Type[] typeArguments) {
-        this(null, rawType, typeArguments);
     }
 
     @Override
@@ -66,17 +55,13 @@ public final class ParameterizedTypeImpl implements ParameterizedType {
 
     @Override
     public Type getOwnerType() {
-        return ownerType;
+        return null;
     }
 
 
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
-        if (ownerType != null) {
-            builder.append(ownerType instanceof Class ? ((Class<?>)ownerType).getName() : ownerType.toString());
-            builder.append('.');
-        }
         builder.append(rawType.getName());
         builder.append('<');
         for (int i = 0, length = typeArguments.length; i < length; i++) {
@@ -92,9 +77,6 @@ public final class ParameterizedTypeImpl implements ParameterizedType {
     @Override
     public int hashCode() {
         int hashCode = 7;
-        if (ownerType != null) {
-            hashCode = 31 * hashCode + ownerType.hashCode();
-        }
         hashCode = 31 * hashCode + rawType.hashCode();
         hashCode = 31 * hashCode + Arrays.hashCode(typeArguments);
         return hashCode;
@@ -109,8 +91,7 @@ public final class ParameterizedTypeImpl implements ParameterizedType {
             return false;
         }
         ParameterizedType other = (ParameterizedType)o;
-        return (ownerType == null ? other.getOwnerType() == null : ownerType.equals(other.getOwnerType())) &&
-               rawType.equals(other.getRawType()) && Arrays.equals(typeArguments, other.getActualTypeArguments());
+        return rawType.equals(other.getRawType()) && Arrays.equals(typeArguments, other.getActualTypeArguments());
 
     }
 }

--- a/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/reflect/ParameterizedTypeImpl.java
+++ b/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/reflect/ParameterizedTypeImpl.java
@@ -25,17 +25,8 @@ public final class ParameterizedTypeImpl implements ParameterizedType {
         return new ParameterizedTypeImpl(rawType, typeArguments);
     }
 
-    public static ParameterizedType newParameterizedType(Class<?> rawType, Type typeArgument) {
-        return new ParameterizedTypeImpl(rawType, typeArgument);
-    }
-
     private final Type[]   typeArguments;
     private final Class<?> rawType;
-
-    private ParameterizedTypeImpl(Class<?> rawType, Type typeArgument) {
-        this.rawType = rawType;
-        this.typeArguments = new Type[]{typeArgument};
-    }
 
     private ParameterizedTypeImpl(Class<?> rawType, Type[] typeArguments) {
         this.rawType = rawType;

--- a/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/DtoFactory.java
+++ b/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/DtoFactory.java
@@ -48,14 +48,14 @@ public final class DtoFactory {
             new LoadingValueSLRUCache<Type, ParameterizedType>(16, 16) {
                 @Override
                 protected ParameterizedType loadValue(Type type) {
-                    return ParameterizedTypeImpl.newParameterizedType(List.class, type);
+                    return new ParameterizedTypeImpl(List.class, type);
                 }
             });
     private static final Cache<Type, ParameterizedType> mapTypeCache  = new SynchronizedCache<>(
             new LoadingValueSLRUCache<Type, ParameterizedType>(16, 16) {
                 @Override
                 protected ParameterizedType loadValue(Type type) {
-                    return ParameterizedTypeImpl.newParameterizedType(Map.class, String.class, type);
+                    return new ParameterizedTypeImpl(Map.class, String.class, type);
                 }
             });
 


### PR DESCRIPTION
According to issue #206, we can remove code overhead by making these changes.

But, it is still a question - Will this class provide the ```ownerType``` variable's instantiation through static generation methods. If so, than all these changes are inappropriate, and the different approach should be used (there should be static generation methods with three parameters):
```
public static ParameterizedType newParameterizedType(Type ownerType, 
   Class<?> rawType, Type typeArgument) {
   return new ParameterizedTypeImpl(ownerType, rawType, typeArgument);
} 
```
and
```
public static ParameterizedType newParameterizedType(Type ownerType, 
   Class<?> rawType, Type... typeArgument) {
   return new ParameterizedTypeImpl(ownerType, rawType, typeArgument);
} 
```
And class will need its ```private final Type ownerType``` variable back, and two constructors(everyone with three parameters)