### PR TITLE
Use "mixins" instead of "mixinTypes" in ProjectUpdate JSONs

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/presenter/ProjectWizardPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/presenter/ProjectWizardPresenter.java
@@ -170,7 +170,7 @@ public class ProjectWizardPresenter implements Wizard.UpdateDelegate,
                                                                           .withAttributes(new HashMap<>(project.getAttributes()))
                                                                           .withBuilders(project.getBuilders())
                                                                           .withRunners(project.getRunners()));
-        dataObject.getProject().setMixinTypes(project.getMixins());
+        dataObject.getProject().setMixins(project.getMixins());
         showDialog(dataObject);
     }
 
@@ -223,7 +223,7 @@ public class ProjectWizardPresenter implements Wizard.UpdateDelegate,
         newProject.setName(prevDataProject.getName());
         newProject.setDescription(prevDataProject.getDescription());
         newProject.setVisibility(prevDataProject.getVisibility());
-        newProject.setMixinTypes(prevDataProject.getMixinTypes());
+        newProject.setMixins(prevDataProject.getMixins());
         if (wizardMode == UPDATE) {
             newProject.setAttributes(prevDataProject.getAttributes());
         }

--- a/platform-api/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/FactoryService.java
+++ b/platform-api/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/FactoryService.java
@@ -610,7 +610,7 @@ public class FactoryService extends Service {
                                    .withAttributes(projectJson.getAttributes())
                                    .withVisibility(project.getVisibility())
                                    .withDescription(projectJson.getDescription());
-            newProject.setMixinTypes(projectJson.getMixinTypes());
+            newProject.setMixins(projectJson.getMixinTypes());
 
             for (Project module : projectManager.getProjectModules(project)) {
                 ProjectConfig moduleConfig = module.getConfig();

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/DtoConverter.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/DtoConverter.java
@@ -122,7 +122,7 @@ public class DtoConverter {
 
         // mixins
         final List<String> validMixins = new ArrayList<>();
-        for (String typeId : dto.getMixinTypes()) {
+        for (String typeId : dto.getMixins()) {
             ProjectType mixinType = typeRegistry.getProjectType(typeId);
             if (mixinType != null) {  // otherwise just ignore
                 validTypes.add(mixinType);

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/shared/dto/ProjectUpdate.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/shared/dto/ProjectUpdate.java
@@ -101,12 +101,12 @@ public interface ProjectUpdate {
 
     /** Gets project mixin types */
     @ApiModelProperty("Mixing types")
-    List<String> getMixinTypes();
+    List<String> getMixins();
 
     /** Sets permissions of current user on this project. */
-    void setMixinTypes(List<String> mixinTypes);
+    void setMixins(List<String> mixinTypes);
 
-    ProjectUpdate withMixinTypes(List<String> mixinTypes);
+    ProjectUpdate withMixins(List<String> mixinTypes);
 
     String getContentRoot();
 

--- a/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectTest.java
+++ b/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectTest.java
@@ -746,7 +746,7 @@ public class ProjectTest {
 
         final ProjectUpdate projectUpdate = DtoFactory.getInstance().createDto(ProjectUpdate.class)
                 .withType("blank")
-                .withMixinTypes(Arrays.asList("testDtoConverterWithMixin"))
+                .withMixins(Arrays.asList("testDtoConverterWithMixin"))
                 .withAttributes(attributes);
 
         final ProjectConfig projectConfig = DtoConverter.fromDto2(projectUpdate, pm.getProjectTypeRegistry());


### PR DESCRIPTION
this makes the field similar to ProjectDescriptor from the client's POV

currently the project service to uses NewProject and UpdateProejct in the service method that create and update projects, respectively. These DTOs contains the list of mix-in project types in "mixinTypes" field. This is different from ProjectDescriptor DTO which is returned by the service methods that return project metadata, including two service method mentioned earlier, which has a field named "mixins". This leads to confusions and workarounds by the API consumers as they pass project configurations back and forth.

only updateProject() and createProject() service APIs REQUESTS are affected. Existing project JSONs, and accordingly service APIs that return them, are not affected. The responses of updateProject() and createProject() themselves are not affected as well.

Change-Id: I151e6f17499c4003ed7e17c7646f5b5f8f3ee090
Signed-off-by: Tareq Sharafy <tareq.sharafy@sap.com>