### PR TITLE
IDEX-2603 All DTO objects and JsonSerializable will be serialized in the same way.

### DIFF
--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/CodenvyJsonProvider.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/CodenvyJsonProvider.java
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package org.eclipse.che.api.core.rest;
 
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.dto.server.DtoFactory;
+import org.eclipse.che.dto.server.JsonSerializable;
 import org.eclipse.che.dto.shared.DTO;
-
 import org.everrest.core.impl.provider.JsonEntityProvider;
 
-import org.eclipse.che.commons.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -79,10 +79,10 @@ public class CodenvyJsonProvider<T> implements MessageBodyReader<T>, MessageBody
                         MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
         // Add Cache-Control before start write body.
         httpHeaders.putSingle(HttpHeaders.CACHE_CONTROL, "public, no-cache, no-store, no-transform");
-        if (type.isAnnotationPresent(DTO.class)) {
+        if (t instanceof JsonSerializable) {
             Writer w = new OutputStreamWriter(entityStream, Charset.forName("UTF-8"));
             try {
-                w.write(DtoFactory.getInstance().toJson(t));
+                w.write(((JsonSerializable)t).toJson());
             } finally {
                 w.flush();
             }


### PR DESCRIPTION
All DTO objects and JsonSerializable will be serialized in the same way

Some background.
Server side DTO do not have @Dto annotation. This annotation is located in the interface which implements this particular class.
Server DTO classes has annotation @org.eclipse.che.dto.shared.DTOImpl and they are implements JsonSerializable interface.
Behind the scene DtoFactory.getInstance().toJson(t) use JsonSerializable to convert object to json.
To make sure that all objects serialized in the same thay I've reworked  codition.
So from now we check if object implement JsonSerializable interface instead of checking of DTO annotation.

Signed-off-by: Sergii Kabashniuk <skabashnyuk@codenvy.com>