### PR TITLE
IDEX-3267 Return any-any permissions for all VFS entries

### DIFF
--- a/che-core-vfs-impl/pom.xml
+++ b/che-core-vfs-impl/pom.xml
@@ -21,7 +21,7 @@
     </parent>
     <artifactId>che-core-vfs-impl</artifactId>
     <packaging>jar</packaging>
-    <name>Che Core :: Virtual File System</name>
+    <name>Che Core :: Virtual File System (Deprecated)</name>
     <dependencies>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/che-core-vfs-impl/src/main/java/org/eclipse/che/vfs/impl/fs/VirtualFileSystemFSModule.java
+++ b/che-core-vfs-impl/src/main/java/org/eclipse/che/vfs/impl/fs/VirtualFileSystemFSModule.java
@@ -10,14 +10,19 @@
  *******************************************************************************/
 package org.eclipse.che.vfs.impl.fs;
 
-import org.eclipse.che.api.vfs.server.VirtualFile;
-import org.eclipse.che.api.vfs.server.VirtualFileFilter;
-import org.eclipse.che.api.vfs.server.search.SearcherProvider;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 
-/** @author andrew00x */
+import org.eclipse.che.api.vfs.server.VirtualFile;
+import org.eclipse.che.api.vfs.server.VirtualFileFilter;
+import org.eclipse.che.api.vfs.server.search.SearcherProvider;
+
+/**
+ * @deprecated  VFS is deprecated in 4.0
+ * @author andrew00x
+ * */
+@Deprecated
 public class VirtualFileSystemFSModule extends AbstractModule {
     @Override
     protected void configure() {

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/RenameTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/RenameTest.java
@@ -10,24 +10,20 @@
  *******************************************************************************/
 package org.eclipse.che.vfs.impl.fs;
 
-import org.eclipse.che.api.vfs.shared.dto.Principal;
-import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
-import org.eclipse.che.commons.env.EnvironmentContext;
-import org.eclipse.che.commons.user.UserImpl;
-import org.eclipse.che.dto.server.DtoFactory;
-
 import com.google.common.collect.Sets;
 
+import org.eclipse.che.api.vfs.shared.dto.Principal;
+import org.eclipse.che.api.vfs.shared.dto.VirtualFileSystemInfo.BasicPermissions;
+import org.eclipse.che.dto.server.DtoFactory;
 import org.everrest.core.impl.ContainerResponse;
 import org.everrest.core.tools.ByteArrayContainerResponseWriter;
 
+import javax.ws.rs.HttpMethod;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import javax.ws.rs.HttpMethod;
 
 public class RenameTest extends LocalFileSystemTest {
     private final String lockToken = "01234567890abcdef";
@@ -186,18 +182,5 @@ public class RenameTest extends LocalFileSystemTest {
         expectedProperties.put("vfs:mimeType", new String[]{"text/directory+FOO"});
         validateProperties(expectedPath, expectedProperties, false); // media type updated only for current folder
         validateProperties(expectedPath, properties, true);
-    }
-
-    public void testRenameFileCopyPermissions() throws Exception {
-        final String newName = "_FILE_NEW_NAME_";
-        ByteArrayContainerResponseWriter writer = new ByteArrayContainerResponseWriter();
-        String requestPath = SERVICE_URI + "rename/" + protectedFileId + '?' + "newname=" + newName;
-        EnvironmentContext.getCurrent().setUser(new UserImpl("andrew", "andrew", null, Arrays.asList("workspace/developer"), false));
-        ContainerResponse response = launcher.service(HttpMethod.POST, requestPath, BASE_URI, null, null, writer, null);
-        assertEquals(200, response.getStatus());
-        String expectedPath = testRootPath + '/' + newName;
-        assertTrue(exists(expectedPath));
-        Map<Principal, Set<String>> renamedPermissions = readPermissions(expectedPath);
-        assertEquals(permissions, renamedPermissions);
     }
 }


### PR DESCRIPTION
In 4.0 we are not relying on vfs permission so we can simply return any-any permission
for all users. We need to return something because UI is still relying on this information.