### PR TITLE
Skip editor close when node removed

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerPresenter.java
@@ -257,7 +257,7 @@ public class ProjectExplorerPresenter extends BasePresenter implements ActionDel
                 }
             });
         } else {
-            view.getNodeByPath(new HasStorablePath.StorablePath(descriptor.getPath()), false).then(new Operation<Node>() {
+            view.getNodeByPath(new HasStorablePath.StorablePath(descriptor.getPath()), false, true).then(new Operation<Node>() {
                 @Override
                 public void apply(final Node node) throws OperationException {
                     openNode(node, descriptor);
@@ -569,11 +569,35 @@ public class ProjectExplorerPresenter extends BasePresenter implements ActionDel
     }
 
     public Promise<Node> getNodeByPath(HasStorablePath path) {
-        return view.getNodeByPath(path, false);
+        return view.getNodeByPath(path, false, true);
     }
 
+    /**
+     * Search node in the project explorer tree by storable path.
+     *
+     * @param path
+     *         path to node
+     * @param forceUpdate
+     *         force children reload
+     * @return promise object with found node or promise error if node wasn't found
+     */
     public Promise<Node> getNodeByPath(HasStorablePath path, boolean forceUpdate) {
-        return view.getNodeByPath(path, forceUpdate);
+        return view.getNodeByPath(path, forceUpdate, true);
+    }
+
+    /**
+     * Search node in the project explorer tree by storable path.
+     *
+     * @param path
+     *         path to node
+     * @param forceUpdate
+     *         force children reload
+     * @param closeMissingFiles
+     *         allow editor to close removed files if they were opened
+     * @return promise object with found node or promise error if node wasn't found
+     */
+    public Promise<Node> getNodeByPath(HasStorablePath path, boolean forceUpdate, boolean closeMissingFiles) {
+        return view.getNodeByPath(path, forceUpdate, closeMissingFiles);
     }
 
     public void select(Node item, boolean keepExisting) {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerView.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerView.java
@@ -74,7 +74,18 @@ public interface ProjectExplorerView extends View<ProjectExplorerView.ActionDele
 
     boolean isShowHiddenFiles();
 
-    Promise<Node> getNodeByPath(HasStorablePath path, boolean forceUpdate);
+    /**
+     * Search node in the project explorer tree by storable path.
+     *
+     * @param path
+     *         path to node
+     * @param forceUpdate
+     *         force children reload
+     * @param closeMissingFiles
+     *         allow editor to close removed files if they were opened
+     * @return promise object with found node or promise error if node wasn't found
+     */
+    Promise<Node> getNodeByPath(HasStorablePath path, boolean forceUpdate, boolean closeMissingFiles);
 
     void select(Node item, boolean keepExisting);
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/ProjectExplorerViewImpl.java
@@ -245,7 +245,7 @@ public class ProjectExplorerViewImpl extends BaseView<ProjectExplorerView.Action
         if (nodes.size() == 1) {
             final String contentRoot = getContentRootOrNull(nodes.get(0));
             if (!Strings.isNullOrEmpty(contentRoot)) {
-                getNodeByPath(new HasStorablePath.StorablePath(contentRoot), false).then(waitRenderAndPerformGoInto());
+                getNodeByPath(new HasStorablePath.StorablePath(contentRoot), false, true).then(waitRenderAndPerformGoInto());
             } else {
                 tree.setExpanded(nodes.get(0), true);
             }
@@ -277,6 +277,10 @@ public class ProjectExplorerViewImpl extends BaseView<ProjectExplorerView.Action
         closeEditorOnNodeRemovedHandler = tree.getNodeStorage().addStoreRemoveHandler(new StoreRemoveEvent.StoreRemoveHandler() {
             @Override
             public void onRemove(StoreRemoveEvent event) {
+                if (searchNodeHandler.isInSearchMode() && !searchNodeHandler.isCloseMissingFiles()) {
+                    return;
+                }
+
                 Node removedNode = event.getNode();
 
                 if (!(removedNode instanceof HasStorablePath)) {
@@ -349,7 +353,7 @@ public class ProjectExplorerViewImpl extends BaseView<ProjectExplorerView.Action
 
     @Override
     public void scrollFromSource(HasStorablePath path) {
-        getNodeByPath(path, false).then(new Operation<Node>() {
+        getNodeByPath(path, false, true).then(new Operation<Node>() {
             @Override
             public void apply(Node node) throws OperationException {
                 tree.scrollIntoView(node);
@@ -678,9 +682,10 @@ public class ProjectExplorerViewImpl extends BaseView<ProjectExplorerView.Action
         }
     }
 
+    /** {@inheritDoc} */
     @Override
-    public Promise<Node> getNodeByPath(HasStorablePath path, boolean forceUpdate) {
-        return searchNodeHandler.getNodeByPath(path, forceUpdate);
+    public Promise<Node> getNodeByPath(HasStorablePath path, boolean forceUpdate, boolean closeMissingFiles) {
+        return searchNodeHandler.getNodeByPath(path, forceUpdate, closeMissingFiles);
     }
 
     @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/SearchNodeHandler.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/SearchNodeHandler.java
@@ -48,6 +48,7 @@ public class SearchNodeHandler implements ExpandNodeHandler, BeforeExpandNodeHan
     private AsyncCallback<Node> callback;
 
     private boolean forceUpdate = false;
+    private boolean closeMissingFiles = true;
 
     public SearchNodeHandler(Tree tree) {
         this.tree = tree;
@@ -58,8 +59,20 @@ public class SearchNodeHandler implements ExpandNodeHandler, BeforeExpandNodeHan
         tree.getNodeLoader().addPostLoadHandler(this);
     }
 
-    public Promise<Node> getNodeByPath(final HasStorablePath path, boolean forceUpdate) {
+    /**
+     * Search node in the project explorer tree by storable path.
+     *
+     * @param path
+     *         path to node
+     * @param forceUpdate
+     *         force children reload
+     * @param closeMissingFiles
+     *         allow editor to close removed files if they were opened
+     * @return promise object with found node or promise error if node wasn't found
+     */
+    public Promise<Node> getNodeByPath(final HasStorablePath path, boolean forceUpdate, boolean closeMissingFiles) {
         this.forceUpdate = forceUpdate;
+        this.closeMissingFiles = closeMissingFiles;
         return AsyncPromiseHelper.createFromAsyncRequest(new AsyncPromiseHelper.RequestCall<Node>() {
             @Override
             public void makeCall(AsyncCallback<Node> callback) {
@@ -220,6 +233,16 @@ public class SearchNodeHandler implements ExpandNodeHandler, BeforeExpandNodeHan
 
     public boolean isInSearchMode() {
         return inSearchMode;
+    }
+
+    /**
+     * Indicates that during node search removed nodes need to be checked
+     * if they were opened in editor parts and need to be closed.
+     *
+     * @return true if opened nodes in editor part should be closed
+     */
+    public boolean isCloseMissingFiles() {
+        return closeMissingFiles;
     }
 
     private Node getRootNode(HasStorablePath path) {


### PR DESCRIPTION
Add ability to configure editor behaviour
in case when we try to update project tree.
By default editor tries to close opened file
if it was removed after reloading. Now it
become possible to configure this behaviour.
This fix needed for java rename refactoring
feature.

@vparfonov 