### PR TITLE
IDEX-3326: Fix wrong behaviour of WorkspaceManager start method 

### DIFF
--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -244,7 +244,7 @@ public class WorkspaceService extends Service {
     public UsersWorkspaceDto startById(@PathParam("id") String workspaceId,
                                        @QueryParam("environment") String envName,
                                        @QueryParam("accountId") String accountId)
-            throws ServerException, BadRequestException, NotFoundException, ForbiddenException {
+            throws ServerException, BadRequestException, NotFoundException, ForbiddenException, ConflictException {
         ensureUserIsWorkspaceOwner(workspaceId);
 
         final Map<String, String> params = Maps.newHashMapWithExpectedSize(2);
@@ -262,7 +262,7 @@ public class WorkspaceService extends Service {
     public UsersWorkspaceDto startByName(@QueryParam("name") String name,
                                          @QueryParam("environment") String envName,
                                          @QueryParam("accountId") String accountId)
-            throws ServerException, BadRequestException, NotFoundException, ForbiddenException {
+            throws ServerException, BadRequestException, NotFoundException, ForbiddenException, ConflictException {
         final UsersWorkspace workspace = workspaceManager.getWorkspace(name, getCurrentUserId());
         ensureUserIsWorkspaceOwner(workspace);
 

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/EnvironmentImpl.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/EnvironmentImpl.java
@@ -36,6 +36,7 @@ public class EnvironmentImpl implements Environment {
 
     public EnvironmentImpl(String name, Recipe recipe, List<? extends MachineConfig> machineConfigs) {
         this.name = name;
+        // TODO here should be the copy of the recipe
         this.recipe = recipe;
         if (machineConfigs != null) {
             this.machineConfigs = machineConfigs.stream()

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ProjectConfigImpl.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ProjectConfigImpl.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static java.util.stream.Collectors.toMap;
+
 //TODO move?
 
 /**
@@ -45,15 +47,15 @@ public class ProjectConfigImpl implements ProjectConfig {
         path = projectCfg.getPath();
         description = projectCfg.getDescription();
         type = projectCfg.getType();
-        mixinTypes = projectCfg.getMixinTypes();
-        attributes = projectCfg.getAttributes();
+        mixinTypes = new ArrayList<>(projectCfg.getMixinTypes());
+        attributes = projectCfg.getAttributes()
+                               .entrySet()
+                               .stream()
+                               .collect(toMap(Map.Entry::getKey, e -> new ArrayList<>(e.getValue())));
         if (projectCfg.getSource() != null) {
-            storage = new SourceStorageImpl(projectCfg.getSource()
-                                                      .getType(),
-                                            projectCfg.getSource()
-                                                      .getLocation(),
-                                            projectCfg.getSource()
-                                                      .getParameters());
+            storage = new SourceStorageImpl(projectCfg.getSource().getType(),
+                                            projectCfg.getSource().getLocation(),
+                                            projectCfg.getSource().getParameters());
         }
     }
 

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/RuntimeWorkspaceImpl.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/RuntimeWorkspaceImpl.java
@@ -89,6 +89,23 @@ public class RuntimeWorkspaceImpl extends UsersWorkspaceImpl implements RuntimeW
              usersWorkspace.getStatus());
     }
 
+    public RuntimeWorkspaceImpl(RuntimeWorkspace runtimeWorkspace) {
+        this(runtimeWorkspace.getId(),
+             runtimeWorkspace.getName(),
+             runtimeWorkspace.getOwner(),
+             runtimeWorkspace.getAttributes(),
+             runtimeWorkspace.getCommands(),
+             runtimeWorkspace.getProjects(),
+             runtimeWorkspace.getEnvironments(),
+             runtimeWorkspace.getDefaultEnvName(),
+             runtimeWorkspace.getDescription(),
+             runtimeWorkspace.getDevMachine(),
+             runtimeWorkspace.getMachines(),
+             runtimeWorkspace.getRootFolder(),
+             runtimeWorkspace.getActiveEnvName(),
+             runtimeWorkspace.getStatus());
+    }
+
     @Override
     public MachineImpl getDevMachine() {
         return devMachine;
@@ -122,6 +139,10 @@ public class RuntimeWorkspaceImpl extends UsersWorkspaceImpl implements RuntimeW
 
     public void setActiveEnvName(String activeEnvName) {
         this.activeEnvName = activeEnvName;
+    }
+    
+    public Environment getActiveEnvironment() {
+        return getEnvironments().get(activeEnvName);
     }
 
     @Override

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/SourceStorageImpl.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/SourceStorageImpl.java
@@ -32,7 +32,9 @@ public class SourceStorageImpl implements SourceStorage {
     public SourceStorageImpl(String type, String location, Map<String, String> parameters) {
         this.type = type;
         this.location = location;
-        this.parameters = parameters;
+        if (parameters != null) {
+            this.parameters = new HashMap<>(parameters);
+        }
     }
 
     @Override

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/UsersWorkspaceImpl.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/UsersWorkspaceImpl.java
@@ -80,7 +80,9 @@ public class UsersWorkspaceImpl implements UsersWorkspace {
                                     .map(ProjectConfigImpl::new)
                                     .collect(toList());
         }
-        this.attributes = attributes;
+        if (attributes != null) {
+            this.attributes = new HashMap<>(attributes);
+        }
         setDefaultEnvName(defaultEnvironment);
     }
 

--- a/platform-api/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/RuntimeWorkspaceRegistryTest.java
+++ b/platform-api/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/RuntimeWorkspaceRegistryTest.java
@@ -11,12 +11,37 @@
 package org.eclipse.che.api.workspace.server;
 
 import org.eclipse.che.api.machine.server.MachineManager;
+
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.model.machine.MachineConfig;
+import org.eclipse.che.api.core.model.machine.Recipe;
+import org.eclipse.che.api.machine.server.model.impl.LimitsImpl;
+import org.eclipse.che.api.machine.server.model.impl.MachineImpl;
+import org.eclipse.che.api.machine.server.model.impl.MachineStateImpl;
+import org.eclipse.che.api.workspace.server.model.impl.EnvironmentStateImpl;
+import org.eclipse.che.api.workspace.server.model.impl.RuntimeWorkspaceImpl;
+import org.eclipse.che.commons.lang.NameGenerator;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
 
-//TODO
+import java.util.Collections;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
+import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPING;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+
+//TODO Cover all methods and cases with tests
 
 /**
  * Tests for {@link RuntimeWorkspaceRegistry}.
@@ -32,7 +57,84 @@ public class RuntimeWorkspaceRegistryTest {
     RuntimeWorkspaceRegistry registry;
 
     @BeforeMethod
-    public void setUpRegistry() {
+    public void setUp() throws Exception {
+        when(machineManager.createMachineSync(any(), any(), any())).thenAnswer(invocation -> {
+            MachineConfig cfg = (MachineConfig)invocation.getArguments()[0];
+            return MachineImpl.builder()
+                              .setId(NameGenerator.generate("machine", 10))
+                              .setType(cfg.getType())
+                              .setName(cfg.getName())
+                              .setDev(cfg.isDev())
+                              .setSource(cfg.getSource())
+                              .setLimits(new LimitsImpl(cfg.getLimits()))
+                              .build();
+        });
         registry = new RuntimeWorkspaceRegistry(machineManager);
+    }
+
+    @Test(expectedExceptions = ConflictException.class,
+          expectedExceptionsMessageRegExp = "Could not start workspace '.*' because its status is '.*'")
+    public void shouldNotStartRunningWorkspaces() throws Exception {
+        final RuntimeWorkspaceImpl workspace = createWorkspace();
+
+        registry.start(workspace, null);
+        registry.start(workspace, null);
+    }
+
+    @Test
+    public void shouldStartWorkspace() throws Exception {
+        final RuntimeWorkspaceImpl workspace = createWorkspace();
+
+        final RuntimeWorkspaceImpl running = registry.start(workspace, null);
+
+        assertEquals(running.getStatus(), RUNNING);
+        assertNotNull(running.getDevMachine());
+        assertFalse(running.getMachines().isEmpty());
+    }
+
+    @Test
+    public void shouldUpdateRunningWorkspace() throws Exception {
+        final RuntimeWorkspaceImpl workspace = createWorkspace();
+        registry.start(workspace, null);
+
+        final RuntimeWorkspaceImpl running = registry.get(workspace.getId());
+        running.setStatus(STOPPING);
+        final MachineImpl newDev = mock(MachineImpl.class);
+        running.getMachines().add(newDev);
+        running.setDevMachine(newDev);
+        registry.update(running);
+
+        final RuntimeWorkspaceImpl updated = registry.get(workspace.getId());
+        assertEquals(updated.getStatus(), STOPPING);
+        assertEquals(updated.getMachines().size(), running.getMachines().size());
+        assertEquals(updated.getDevMachine().getId(), newDev.getId());
+    }
+
+    @Test(expectedExceptions = NotFoundException.class)
+    public void shouldNotUpdateWorkspaceWhichIsNotRunning() throws Exception {
+        final RuntimeWorkspaceImpl workspace = createWorkspace();
+
+        registry.update(workspace);
+    }
+
+    private static RuntimeWorkspaceImpl createWorkspace() {
+        // prepare default environment
+        final EnvironmentStateImpl envState = mock(EnvironmentStateImpl.class, RETURNS_MOCKS);
+
+        final Recipe recipe = mock(Recipe.class);
+        when(recipe.getType()).thenReturn("docker");
+        when(envState.getRecipe()).thenReturn(recipe);
+
+        final MachineStateImpl cfg = mock(MachineStateImpl.class);
+        when(cfg.isDev()).thenReturn(true);
+        when(envState.getMachineConfigs()).thenReturn((singletonList(cfg)));
+
+        // prepare workspace
+        final RuntimeWorkspaceImpl workspace = mock(RuntimeWorkspaceImpl.class, RETURNS_MOCKS);
+        when(workspace.getEnvironments()).thenReturn(Collections.singletonMap("", envState));
+        when(workspace.getDevMachine()).thenReturn(mock(MachineImpl.class, RETURNS_MOCKS));
+        when(workspace.getId()).thenReturn(NameGenerator.generate("workspace", 10));
+
+        return workspace;
     }
 }

--- a/platform-api/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/platform-api/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -11,13 +11,16 @@
 package org.eclipse.che.api.workspace.server;
 
 
-import jdk.nashorn.internal.ir.annotations.Ignore;
-
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.model.workspace.RuntimeWorkspace;
 import org.eclipse.che.api.core.model.workspace.UsersWorkspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.machine.server.MachineManager;
 import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
 import org.eclipse.che.api.machine.shared.dto.MachineSourceDto;
+import org.eclipse.che.api.workspace.server.model.impl.RuntimeWorkspaceImpl;
 import org.eclipse.che.api.workspace.server.model.impl.UsersWorkspaceImpl;
 import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
 import org.eclipse.che.api.workspace.shared.dto.EnvironmentDto;
@@ -34,17 +37,23 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
-import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
+import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STARTING;
+import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPED;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 
 //TODO cover WorkspaceManager with tests when API is established
 
@@ -60,6 +69,8 @@ public class WorkspaceManagerTest {
     EventService             eventService;
     @Mock
     WorkspaceDao             workspaceDao;
+    @Mock
+    MachineManager           client;
     @Mock
     WorkspaceHooks           workspaceHooks;
     @Mock
@@ -85,36 +96,32 @@ public class WorkspaceManagerTest {
     }
 
     @Test
-    @Ignore
-    //TODO fix test
     public void shouldBeAbleToCreateWorkspace() throws Exception {
-//        final WorkspaceConfig cfg = createConfig();
-//
-//        final UsersWorkspaceImpl workspace = manager.createWorkspace(cfg, "user123", "account");
-//
-//        assertNotNull(workspace);
-//        assertFalse(isNullOrEmpty(workspace.getId()));
-//        assertEquals(workspace.getOwner(), "user123");
-//        assertEquals(workspace.getName(), cfg.getName());
-//        assertEquals(workspace.getStatus(), STOPPED);
-//        verify(workspaceHooks).beforeCreate(workspace, "account");
-//        verify(workspaceHooks).afterCreate(workspace, "account");
-//        verify(workspaceDao).create(workspace);
+        final WorkspaceConfig cfg = createConfig();
+
+        final UsersWorkspaceImpl workspace = manager.createWorkspace(cfg, "user123", "account");
+
+        assertNotNull(workspace);
+        assertFalse(isNullOrEmpty(workspace.getId()));
+        assertEquals(workspace.getOwner(), "user123");
+        assertEquals(workspace.getName(), cfg.getName());
+        assertEquals(workspace.getStatus(), STOPPED);
+        verify(workspaceHooks).beforeCreate(workspace, "account");
+        verify(workspaceHooks).afterCreate(workspace, "account");
+        verify(workspaceDao).create(workspace);
     }
 
     @Test
-    @Ignore
-    //TODO fix test
     public void shouldBeAbleToUpdateWorkspace() throws Exception {
-//        final UsersWorkspaceImpl workspace = manager.createWorkspace(createConfig(), "user123", "account");
-//        when(workspaceDao.get(workspace.getId())).thenReturn(workspace);
-//        when(registry.get(any())).thenThrow(new NotFoundException(""));
-//        final WorkspaceConfig update = createConfig();
-//
-//        UsersWorkspace updated = manager.updateWorkspace(workspace.getId(), update);
-//
-//        verify(workspaceDao).update(any(UsersWorkspaceImpl.class));
-//        assertNotNull(updated.getStatus());
+        final UsersWorkspaceImpl workspace = manager.createWorkspace(createConfig(), "user123", "account");
+        when(workspaceDao.get(workspace.getId())).thenReturn(workspace);
+        when(registry.get(any())).thenThrow(new NotFoundException(""));
+        final WorkspaceConfig update = createConfig();
+
+        UsersWorkspace updated = manager.updateWorkspace(workspace.getId(), update);
+
+        verify(workspaceDao).update(any(UsersWorkspaceImpl.class));
+        assertNotNull(updated.getStatus());
     }
 
     @Test
@@ -126,30 +133,40 @@ public class WorkspaceManagerTest {
     }
 
     @Test
-    @Ignore
-    //TODO fix test
     public void shouldBeAbleToStartWorkspace() throws Exception {
-//        final UsersWorkspaceImpl workspace = manager.createWorkspace(createConfig(), "user123", "account");
-//        when(workspaceDao.get(workspace.getId())).thenReturn(workspace);
-//        doNothing().when(manager).startWorkspaceAsync(workspace, null);
-//
-//        final UsersWorkspace workspace2 = manager.startWorkspaceById(workspace.getId(), null, null);
-//
-//        assertEquals(workspace2.getStatus(), STARTING);
-//        verify(manager).startWorkspaceAsync(workspace, null);
-//        verify(workspaceHooks).beforeStart(workspace, null);
+        final UsersWorkspaceImpl workspace = manager.createWorkspace(createConfig(), "user123", "account");
+        when(workspaceDao.get(workspace.getId())).thenReturn(workspace);
+        doReturn(workspace).when(manager).startWorkspaceAsync(workspace, null);
+        when(registry.get(any())).thenThrow(new NotFoundException(""));
+
+        final UsersWorkspace workspace2 = manager.startWorkspaceById(workspace.getId(), null, null);
+
+        assertEquals(workspace2.getStatus(), STARTING);
+        verify(manager).startWorkspaceAsync(workspace, null);
+        verify(workspaceHooks).beforeStart(workspace, null);
     }
 
-    @Test(enabled = false)
+    @Test(expectedExceptions = ConflictException.class,
+          expectedExceptionsMessageRegExp = "Could not start workspace '.*' because its status is '.*'")
+    public void shouldNotBeAbleToStartWorkspaceIfItIsRunning() throws Exception {
+        final UsersWorkspaceImpl workspace = manager.createWorkspace(createConfig(), "user123", "account");
+        when(workspaceDao.get(workspace.getId())).thenReturn(workspace);
+        when(registry.get(workspace.getId())).thenReturn(mock(RuntimeWorkspaceImpl.class));
+
+        manager.startWorkspaceById(workspace.getId(), null, null);
+    }
+
+    @Test
     public void shouldBeAbleToStartTemporaryWorkspace() throws Exception {
         final WorkspaceConfig config = createConfig();
         final UsersWorkspace workspace = manager.createWorkspace(config, "user123", "account");
         doReturn(workspace).when(manager).fromConfig(config);
+        final RuntimeWorkspaceImpl runtime = mock(RuntimeWorkspaceImpl.class);
+        when(registry.start(any(), anyString())).thenReturn(runtime);
 
-        final UsersWorkspaceImpl workspace2 = manager.startTemporaryWorkspace(config, "account");
+        final RuntimeWorkspaceImpl workspace2 = manager.startTemporaryWorkspace(config, "account");
 
-        assertEquals(workspace2.getStatus(), RUNNING);
-        verify(manager).startWorkspaceSync(workspace2, null);
+        assertEquals(runtime, workspace2);
         verify(workspaceHooks).beforeStart(workspace, "account");
     }
 


### PR DESCRIPTION
WorkspaceManager was returning RuntimeWorkspace instance with __STARTING__ status each time when workspace start was performed. Now it checks if workspace is stopped before it starts as well as `RuntimeWorkspaceRegistry` does. It this PR i also added new `update` method to the registry + fixed methods behaviour when registry is stopping workspaces.

It is not consistent with 4.0 because it requires merge conflict fixes, but i will do it ASAP.
@skabashnyuk, @garagatyi, @akorneta, @sleshchenko can you please review this changes.