### PR TITLE
CLDIDE-2598: Use token in  RemoteTask & SourcesManagerImpl calls

### DIFF
--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/RemoteTask.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/RemoteTask.java
@@ -22,6 +22,7 @@ import org.eclipse.che.api.core.UnauthorizedException;
 import org.eclipse.che.api.core.rest.HttpJsonHelper;
 import org.eclipse.che.api.core.rest.HttpOutputMessage;
 import org.eclipse.che.api.core.rest.shared.dto.Link;
+import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -233,6 +234,10 @@ public class RemoteTask {
         conn.setConnectTimeout(60 * 1000);
         conn.setReadTimeout(60 * 1000);
         conn.setRequestMethod(HttpMethod.GET);
+        final EnvironmentContext context = EnvironmentContext.getCurrent();
+        if (context.getUser() != null && context.getUser().getToken() != null) {
+            conn.setRequestProperty(HttpHeaders.AUTHORIZATION, context.getUser().getToken());
+        }
         try {
             output.setStatus(conn.getResponseCode());
             final String contentType = conn.getContentType();

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/SlaveBuilderService.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/SlaveBuilderService.java
@@ -34,6 +34,7 @@ import org.eclipse.che.commons.lang.TarUtils;
 import org.eclipse.che.commons.lang.ZipUtils;
 import org.eclipse.che.dto.server.DtoFactory;
 
+import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
@@ -77,6 +78,7 @@ public final class SlaveBuilderService extends Service {
     @GET
     @Path("available")
     @Produces(MediaType.APPLICATION_JSON)
+    @RolesAllowed({"user", "tmp_user"})
     public List<BuilderDescriptor> availableBuilders() {
         final Set<Builder> all = builders.getAll();
         final List<BuilderDescriptor> list = new ArrayList<>(all.size());
@@ -94,6 +96,7 @@ public final class SlaveBuilderService extends Service {
     @GET
     @Path("state")
     @Produces(MediaType.APPLICATION_JSON)
+    @RolesAllowed({"user", "tmp_user"})
     public BuilderState getBuilderState(@Required
                                         @Description("Name of the builder")
                                         @QueryParam("builder") String builder) throws Exception {
@@ -109,6 +112,7 @@ public final class SlaveBuilderService extends Service {
     @GET
     @Path("server-state")
     @Produces(MediaType.APPLICATION_JSON)
+    @RolesAllowed({"user", "tmp_user"})
     public ServerState getServerState() {
         return DtoFactory.getInstance().createDto(ServerState.class)
                          .withCpuPercentUsage(SystemInfo.cpu())
@@ -121,6 +125,7 @@ public final class SlaveBuilderService extends Service {
     @Path("build")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @RolesAllowed({"user", "tmp_user"})
     public BuildTaskDescriptor build(@Description("Parameters for build task in JSON format") BuildRequest request) throws Exception {
         final Builder myBuilder = getBuilder(request.getBuilder());
         final BuildTask task = myBuilder.perform(request);
@@ -132,6 +137,7 @@ public final class SlaveBuilderService extends Service {
     @Path("dependencies")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @RolesAllowed({"user", "tmp_user"})
     public BuildTaskDescriptor dependencies(@Description("Parameters for analyze dependencies in JSON format") DependencyRequest request)
             throws Exception {
         final Builder myBuilder = getBuilder(request.getBuilder());
@@ -142,6 +148,7 @@ public final class SlaveBuilderService extends Service {
     @GET
     @Path("status/{builder}/{id}")
     @Produces(MediaType.APPLICATION_JSON)
+    @RolesAllowed({"user", "tmp_user"})
     public BuildTaskDescriptor getStatus(@PathParam("builder") String builder, @PathParam("id") Long id) throws Exception {
         final Builder myBuilder = getBuilder(builder);
         final BuildTask task = myBuilder.getBuildTask(id);
@@ -158,6 +165,7 @@ public final class SlaveBuilderService extends Service {
     @POST
     @Path("cancel/{builder}/{id}")
     @Produces(MediaType.APPLICATION_JSON)
+    @RolesAllowed({"user", "tmp_user"})
     public BuildTaskDescriptor cancel(@PathParam("builder") String builder, @PathParam("id") Long id) throws Exception {
         final Builder myBuilder = getBuilder(builder);
         final BuildTask task = myBuilder.getBuildTask(id);
@@ -168,6 +176,7 @@ public final class SlaveBuilderService extends Service {
     @GET
     @Path("browse/{builder}/{id}")
     @Produces(MediaType.TEXT_HTML)
+    @RolesAllowed({"user", "tmp_user"})
     public Response browseDirectory(@PathParam("builder") String builder,
                                     @PathParam("id") Long id,
                                     @DefaultValue(".") @QueryParam("path") String path) throws Exception {
@@ -261,6 +270,7 @@ public final class SlaveBuilderService extends Service {
     @GET
     @Path("tree/{builder}/{id}")
     @Produces(MediaType.APPLICATION_JSON)
+    @RolesAllowed({"user", "tmp_user"})
     public List<ItemReference> listDirectory(@PathParam("builder") String builder,
                                              @PathParam("id") Long id,
                                              @DefaultValue(".") @QueryParam("path") String path) throws Exception {
@@ -354,6 +364,7 @@ public final class SlaveBuilderService extends Service {
 
     @GET
     @Path("download/{builder}/{id}")
+    @RolesAllowed({"user", "tmp_user"})
     public Response downloadFile(@PathParam("builder") String builder,
                                  @PathParam("id") Long id,
                                  @Required @QueryParam("path") String path) throws Exception {
@@ -374,6 +385,7 @@ public final class SlaveBuilderService extends Service {
 
     @GET
     @Path("download-all/{builder}/{id}")
+    @RolesAllowed({"user", "tmp_user"})
     public Response downloadResultArchive(@PathParam("builder") String builder,
                                           @PathParam("id") Long id,
                                           @DefaultValue(Constants.RESULT_ARCHIVE_TAR) @QueryParam("arch") String arch) throws Exception {
@@ -400,6 +412,7 @@ public final class SlaveBuilderService extends Service {
 
     @GET
     @Path("view/{builder}/{id}")
+    @RolesAllowed({"user", "tmp_user"})
     public Response viewFile(@PathParam("builder") String builder,
                              @PathParam("id") Long id,
                              @Required @QueryParam("path") String path) throws Exception {

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/SourcesManagerImpl.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/SourcesManagerImpl.java
@@ -12,6 +12,7 @@ package org.eclipse.che.api.builder.internal;
 
 import org.eclipse.che.api.builder.dto.BaseBuilderRequest;
 import org.eclipse.che.api.core.util.ValueHolder;
+import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.json.JsonHelper;
 import org.eclipse.che.commons.json.JsonParseException;
 import org.eclipse.che.commons.lang.IoUtil;
@@ -219,6 +220,10 @@ public class SourcesManagerImpl implements SourcesManager {
             conn = (HttpURLConnection)new URL(downloadUrl).openConnection();
             conn.setConnectTimeout(CONNECT_TIMEOUT);
             conn.setReadTimeout(READ_TIMEOUT);
+            final EnvironmentContext context = EnvironmentContext.getCurrent();
+            if (context.getUser() != null && context.getUser().getToken() != null) {
+                conn.setRequestProperty(HttpHeaders.AUTHORIZATION, context.getUser().getToken());
+            }
             if (!md5sums.isEmpty()) {
                 conn.setRequestMethod(HttpMethod.POST);
                 conn.setRequestProperty("Content-type", MediaType.TEXT_PLAIN);


### PR DESCRIPTION
Each RemoteTask & SourcesManagerImpl request goes with authorization token which allows us to protect `SlaveBuilderService` from unauthorized calls.