### PR TITLE
IDEX-3406: Use environment name in WorkspaceHooks#beforeStart method

### DIFF
--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/RuntimeWorkspaceRegistry.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/RuntimeWorkspaceRegistry.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
@@ -92,12 +91,12 @@ public class RuntimeWorkspaceRegistry {
      * @param usersWorkspace
      *         workspace which should be started
      * @param envName
-     *         name of environment or null when default environment should be used
+     *         name of environment
      * @return runtime view of {@code usersWorkspace} with status {@link WorkspaceStatus#RUNNING}
      * @throws ConflictException
      *         when workspace is already running or any other conflict error occurs during environment start
      * @throws BadRequestException
-     *         when active environment is in inconsistent state
+     *         when active environment is in inconsistent state or {@code envName} is null
      * @throws NotFoundException
      *         whe any not found exception occurs during environment start
      * @throws ServerException
@@ -108,11 +107,14 @@ public class RuntimeWorkspaceRegistry {
                                                                                             ServerException,
                                                                                             BadRequestException,
                                                                                             NotFoundException {
+        if (envName == null) {
+            throw new BadRequestException("Required non-null environment name");
+        }
         checkIsNotStopped();
         // Prepare runtime workspace for start
         RuntimeWorkspaceImpl newRuntime = RuntimeWorkspaceImpl.builder()
                                                               .fromWorkspace(usersWorkspace)
-                                                              .setActiveEnvName(firstNonNull(envName, usersWorkspace.getDefaultEnvName()))
+                                                              .setActiveEnvName(envName)
                                                               .setStatus(STARTING)
                                                               .build();
         // Save workspace with 'STARTING' status

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceHooks.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceHooks.java
@@ -33,7 +33,7 @@ public interface WorkspaceHooks {
      */
     WorkspaceHooks NOOP_WORKSPACE_HOOKS = new WorkspaceHooks() {
         @Override
-        public void beforeStart(UsersWorkspace workspace, String accountId) throws NotFoundException, ServerException {}
+        public void beforeStart(UsersWorkspace workspace, String evnName, String accountId) throws NotFoundException, ServerException {}
 
         @Override
         public void beforeCreate(UsersWorkspace workspace, String accountId) throws NotFoundException, ServerException {}
@@ -52,16 +52,20 @@ public interface WorkspaceHooks {
      *         workspace which is going to be started
      * @param accountId
      *         account identifier indicates the account which should be used for runtime workspace
+     * @param envName
+     *         the name of environment which is going to be started
      * @throws NotFoundException
      *         when any not found error occurs
      * @throws ForbiddenException
      *         when user doesn't have access to start workspace in certain account
      * @throws ServerException
      *         when any other error occurs
+     * @throws NullPointerException
+     *         when either {@code workspace} or {@code envName} is null
      */
-    void beforeStart(@NotNull UsersWorkspace workspace, @Nullable String accountId) throws NotFoundException,
-                                                                                           ForbiddenException,
-                                                                                           ServerException;
+    void beforeStart(@NotNull UsersWorkspace workspace, @NotNull String envName, @Nullable String accountId) throws NotFoundException,
+                                                                                                                    ForbiddenException,
+                                                                                                                    ServerException;
 
     /**
      * Called before creating workspace.

--- a/platform-api/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/RuntimeWorkspaceRegistryTest.java
+++ b/platform-api/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/RuntimeWorkspaceRegistryTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.api.workspace.server;
 
+import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.machine.server.MachineManager;
 
 import org.eclipse.che.api.core.ConflictException;
@@ -77,15 +78,15 @@ public class RuntimeWorkspaceRegistryTest {
     public void shouldNotStartRunningWorkspaces() throws Exception {
         final RuntimeWorkspaceImpl workspace = createWorkspace();
 
-        registry.start(workspace, null);
-        registry.start(workspace, null);
+        registry.start(workspace, workspace.getDefaultEnvName());
+        registry.start(workspace, workspace.getDefaultEnvName());
     }
 
     @Test
     public void shouldStartWorkspace() throws Exception {
         final RuntimeWorkspaceImpl workspace = createWorkspace();
 
-        final RuntimeWorkspaceImpl running = registry.start(workspace, null);
+        final RuntimeWorkspaceImpl running = registry.start(workspace, workspace.getDefaultEnvName());
 
         assertEquals(running.getStatus(), RUNNING);
         assertNotNull(running.getDevMachine());
@@ -95,7 +96,7 @@ public class RuntimeWorkspaceRegistryTest {
     @Test
     public void shouldUpdateRunningWorkspace() throws Exception {
         final RuntimeWorkspaceImpl workspace = createWorkspace();
-        registry.start(workspace, null);
+        registry.start(workspace, workspace.getDefaultEnvName());
 
         final RuntimeWorkspaceImpl running = registry.get(workspace.getId());
         running.setStatus(STOPPING);
@@ -115,6 +116,11 @@ public class RuntimeWorkspaceRegistryTest {
         final RuntimeWorkspaceImpl workspace = createWorkspace();
 
         registry.update(workspace);
+    }
+
+    @Test(expectedExceptions = BadRequestException.class, expectedExceptionsMessageRegExp = "Required non-null environment name")
+    public void shouldThrowBadRequestExceptionWhenStartingWorkspaceWithNullEnvironment() throws Exception {
+        registry.start(createWorkspace(), null);
     }
 
     private static RuntimeWorkspaceImpl createWorkspace() {

--- a/platform-api/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/platform-api/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -142,8 +142,8 @@ public class WorkspaceManagerTest {
         final UsersWorkspace workspace2 = manager.startWorkspaceById(workspace.getId(), null, null);
 
         assertEquals(workspace2.getStatus(), STARTING);
-        verify(manager).startWorkspaceAsync(workspace, null);
-        verify(workspaceHooks).beforeStart(workspace, null);
+        verify(manager).startWorkspaceAsync(workspace, workspace.getDefaultEnvName());
+        verify(workspaceHooks).beforeStart(workspace, workspace.getDefaultEnvName(), null);
     }
 
     @Test(expectedExceptions = ConflictException.class,
@@ -167,7 +167,7 @@ public class WorkspaceManagerTest {
         final RuntimeWorkspaceImpl workspace2 = manager.startTemporaryWorkspace(config, "account");
 
         assertEquals(runtime, workspace2);
-        verify(workspaceHooks).beforeStart(workspace, "account");
+        verify(workspaceHooks).beforeStart(workspace, workspace.getDefaultEnvName(), "account");
     }
 
     @Test


### PR DESCRIPTION
We need to know environment name which is used for start as well as account id to analyze resources and related stuff.