### PR TITLE
Expose direct API for converting DTOs to JSON objects

### DIFF
--- a/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImplServerTemplate.java
+++ b/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImplServerTemplate.java
@@ -279,6 +279,7 @@ public class DtoImplServerTemplate extends DtoImpl {
     }
 
     private void emitSerializer(List<Method> getters, StringBuilder builder) {
+        builder.append("    @Override\n");
         builder.append("    public JsonElement toJsonElement() {\n");
         // The default toJsonElement() returns JSONs for unsafe use thus 'any' properties should be copied
         builder.append("      return toJsonElementInt(true);\n");

--- a/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/DtoFactory.java
+++ b/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/DtoFactory.java
@@ -132,6 +132,13 @@ public final class DtoFactory {
         throw new IllegalArgumentException("JsonSerializable instance required. ");
     }
 
+    public <T> JsonElement toJsonElement(T dto) {
+        if (dto instanceof JsonSerializable) {
+            return ((JsonSerializable)dto).toJsonElement();
+        }
+        throw new IllegalArgumentException("JsonSerializable instance required. ");
+    }
+
     /**
      * Creates new instance of class which implements specified DTO interface.
      *

--- a/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/JsonArrayImpl.java
+++ b/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/JsonArrayImpl.java
@@ -13,6 +13,7 @@ package org.eclipse.che.dto.server;
 import org.eclipse.che.dto.shared.JsonArray;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -151,6 +152,11 @@ public class JsonArrayImpl<T> implements JsonArray<T> {
     @Override
     public String toJson() {
         return gson.toJson(this);
+    }
+
+    @Override
+    public JsonElement toJsonElement() {
+        return gson.toJsonTree(this);
     }
 
     @Override

--- a/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/JsonSerializable.java
+++ b/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/JsonSerializable.java
@@ -15,9 +15,14 @@ package org.eclipse.che.dto.server;
 
 import java.io.Serializable;
 
+import com.google.gson.JsonElement;
+
 /** An entity that may serialize itself to JSON. */
 public interface JsonSerializable extends Serializable {
 
     /** Serializes DTO to JSON format. */
     String toJson();
+
+    /** Serializes DTO to JSON object. */
+    JsonElement toJsonElement();
 }

--- a/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/JsonStringMapImpl.java
+++ b/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/JsonStringMapImpl.java
@@ -13,6 +13,7 @@ package org.eclipse.che.dto.server;
 import org.eclipse.che.dto.shared.JsonStringMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
 
 import java.util.Collection;
 import java.util.Map;
@@ -98,6 +99,11 @@ public class JsonStringMapImpl<T> implements JsonStringMap<T> {
     @Override
     public String toJson() {
         return gson.toJson(this);
+    }
+
+    @Override
+    public JsonElement toJsonElement() {
+        return gson.toJsonTree(this);
     }
 
     @Override


### PR DESCRIPTION
this is more efficient than using the only API that is currently available
'toJson()'. It returns a string which means two redundant serializations must
be done if the JsonElement is needed directly:
DTO->JsonElement->String->JsonElement

Change-Id: I78cbfe0fd54b28d8b14ba53bc35b8cfd891f19bc