### PR TITLE
Allow subscribing to a specific event type explicitly in EventService

### DIFF
--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/EventService.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/EventService.java
@@ -111,13 +111,29 @@ public class EventService {
     }
 
     /**
-     * Subscribe event listener.
+     * Subscribe event listener. The event to subscribe to is inferred by checking the generic type arguments of the
+     * given subscriber.
      *
      * @param subscriber
      *         event subscriber
      */
     public void subscribe(EventSubscriber<?> subscriber) {
         final Class<?> eventType = getEventType(subscriber);
+        doSubscribe(subscriber, eventType);
+    }
+
+    /**
+     * Subscribe to an event. The given subscriber will be called whenever an instance of the specified event is
+     * published.
+     *
+     * @param subscriber The subscriber to call when an event is published.
+     * @param eventType The event to subscribe to.
+     */
+    public <T> void subscribe(EventSubscriber<? extends T> subscriber, Class<T> eventType) {
+        doSubscribe(subscriber, eventType);
+    }
+
+    private void doSubscribe(EventSubscriber<?> subscriber, Class<?> eventType) {
         Set<EventSubscriber> entries = subscribersByEventType.get(eventType);
         if (entries == null) {
             Set<EventSubscriber> newEntries = new CopyOnWriteArraySet<>();


### PR DESCRIPTION
Currently the only way to subscribe to an event is by providing an implementation of EventSubscriber whose only generic type argument is a concrete event class. Passing generic event subscribers fails, e.g.:

    class MySubsriber<T> implements EventSubscriber<T> {
     @Override
     public void onEvent(T event) { ... }
    }

    class MyController {
     @Inject
     EventService eventService;
     @PostConstruct
     public void init() {
      eventService.subscribe(new MySubsriber<MyEvent>());
     }
    }

the above example will fail because the current code looks for generic type arguments that are concrete classes. It also fails in other cases like lambda expressions and factory functions. My patch allows generalized event subscription like this:

    eventService.subscribe(new MySubsriber<MyEvent>(), MyEvent.class);



