### PR TITLE
CLDIDE-2622 : Change the scope dependency com.google.gwt:gwt-dev for fix javadoc generation

### DIFF
--- a/ide/che-core-ide-app/pom.xml
+++ b/ide/che-core-ide-app/pom.xml
@@ -146,6 +146,11 @@
         </dependency>
         <dependency>
             <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-dev</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.gwt</groupId>
             <artifactId>gwt-elemental</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -158,11 +163,6 @@
             <groupId>org.vectomatic</groupId>
             <artifactId>lib-gwt-svg</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.gwt</groupId>
-            <artifactId>gwt-dev</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.gwt.gwtmockito</groupId>


### PR DESCRIPTION
This is pull request for issue https://jira.codenvycorp.com/browse/CLDIDE-2622

The scope of dependency com.google.gwt:gwt-dev was changed from "test" to "provided".
