### PR TITLE
IDEX-3396: Add ability to save workspace's snapshot

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -461,6 +461,18 @@ public interface CoreLocalizationConstant extends Messages {
     @Key("started.ws")
     String startedWs(String wsName);
 
+    @Key("create.snapshot.title")
+    String createSnapshotTitle();
+
+    @Key("create.snapshot.description")
+    String createSnapshotDescription();
+
+    @Key("create.snapshot.progress")
+    String createSnapshotProgress();
+
+    @Key("create.snapshot.success")
+    String createSnapshotSuccess();
+
     @Key("ext.server.started")
     String extServerStarted();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/CreateSnapshotAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/CreateSnapshotAction.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.actions;
+
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.app.AppContext;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.validation.constraints.NotNull;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * @author Yevhenii Voevodin
+ */
+@Singleton
+public class CreateSnapshotAction extends AbstractPerspectiveAction {
+
+    private static final String MACHINE_PERSPECTIVE_ID = "Machine Perspective";
+
+    private final AppContext               appContext;
+    private final WorkspaceSnapshotCreator snapshotCreator;
+
+    @Inject
+    public CreateSnapshotAction(CoreLocalizationConstant locale, AppContext appContext, WorkspaceSnapshotCreator snapshotCreator) {
+        super(singletonList(MACHINE_PERSPECTIVE_ID), locale.createSnapshotTitle(), locale.createSnapshotDescription(), null, null);
+        this.appContext = appContext;
+        this.snapshotCreator = snapshotCreator;
+    }
+
+    @Override
+    public void updateInPerspective(@NotNull ActionEvent event) {
+        event.getPresentation().setEnabled(!snapshotCreator.isInProgress());
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent event) {
+        snapshotCreator.createSnapshot(appContext.getWorkspace().getId());
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/WorkspaceSnapshotCreator.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/WorkspaceSnapshotCreator.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.actions;
+
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.OperationException;
+import org.eclipse.che.api.promises.client.PromiseError;
+import org.eclipse.che.api.workspace.gwt.client.WorkspaceServiceClient;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.notification.Notification;
+import org.eclipse.che.ide.api.notification.NotificationManager;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Creates snapshot of the workspace using {@link WorkspaceServiceClient}.
+ *
+ * <p>This component is for managing notifications which are related to creating snapshot process.
+ *
+ * @author Yevhenii Voevodin
+ */
+@Singleton
+public class WorkspaceSnapshotCreator {
+
+    private final WorkspaceServiceClient   workspaceService;
+    private final NotificationManager      notificationManager;
+    private final CoreLocalizationConstant locale;
+
+    Notification notification;
+
+    @Inject
+    public WorkspaceSnapshotCreator(WorkspaceServiceClient workspaceService,
+                                    NotificationManager notificationManager,
+                                    CoreLocalizationConstant locale) {
+        this.workspaceService = workspaceService;
+        this.notificationManager = notificationManager;
+        this.locale = locale;
+    }
+
+    /**
+     * Changes notification state to finished with an error.
+     */
+    public void creationError(String message) {
+        notification.setMessage(message);
+        notification.setType(Notification.Type.ERROR);
+        notification.setStatus(Notification.Status.FINISHED);
+        notification = null;
+    }
+
+    /**
+     * Changes notification state to successfully finished.
+     */
+    public void successfullyCreated() {
+        notification.setMessage(locale.createSnapshotSuccess());
+        notification.setType(Notification.Type.INFO);
+        notification.setStatus(Notification.Status.FINISHED);
+        notification = null;
+    }
+
+    /**
+     * Returns true if workspace creation process is not done, otherwise when it is done - returns false
+     */
+    public boolean isInProgress() {
+        return notification != null;
+    }
+
+    /**
+     * Creates snapshot from workspace with given id and shows appropriate notification.
+     *
+     * @param workspaceId
+     *         id of the workspace to create snapshot from.
+     */
+    public void createSnapshot(String workspaceId) {
+        notification = new Notification(locale.createSnapshotProgress(), Notification.Status.PROGRESS);
+        notificationManager.showNotification(notification);
+        workspaceService.createSnapshot(workspaceId)
+                        .catchError(new Operation<PromiseError>() {
+                            @Override
+                            public void apply(PromiseError error) throws OperationException {
+                                creationError(error.getMessage());
+                            }
+                        });
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/bootstrap/DefaultWorkspaceComponent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/bootstrap/DefaultWorkspaceComponent.java
@@ -24,6 +24,7 @@ import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.api.workspace.gwt.client.WorkspaceServiceClient;
 import org.eclipse.che.api.workspace.shared.dto.UsersWorkspaceDto;
 import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.actions.WorkspaceSnapshotCreator;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.preferences.PreferencesManager;
@@ -57,21 +58,22 @@ public class DefaultWorkspaceComponent extends WorkspaceComponent implements Com
 
     @Inject
     public DefaultWorkspaceComponent(WorkspaceServiceClient workspaceServiceClient,
-                              CreateWorkspacePresenter createWorkspacePresenter,
-                              StartWorkspacePresenter startWorkspacePresenter,
-                              CoreLocalizationConstant locale,
-                              DtoUnmarshallerFactory dtoUnmarshallerFactory,
-                              EventBus eventBus,
-                              LoaderPresenter loader,
-                              AppContext appContext,
-                              Provider<MachineManager> machineManagerProvider,
-                              NotificationManager notificationManager,
-                              MessageBusProvider messageBusProvider,
-                              BrowserQueryFieldRenderer browserQueryFieldRenderer,
-                              DialogFactory dialogFactory,
-                              PreferencesManager preferencesManager,
-                              DtoFactory dtoFactory,
-                              InitialLoadingInfo initialLoadingInfo) {
+                                     CreateWorkspacePresenter createWorkspacePresenter,
+                                     StartWorkspacePresenter startWorkspacePresenter,
+                                     CoreLocalizationConstant locale,
+                                     DtoUnmarshallerFactory dtoUnmarshallerFactory,
+                                     EventBus eventBus,
+                                     LoaderPresenter loader,
+                                     AppContext appContext,
+                                     Provider<MachineManager> machineManagerProvider,
+                                     NotificationManager notificationManager,
+                                     MessageBusProvider messageBusProvider,
+                                     BrowserQueryFieldRenderer browserQueryFieldRenderer,
+                                     DialogFactory dialogFactory,
+                                     PreferencesManager preferencesManager,
+                                     DtoFactory dtoFactory,
+                                     InitialLoadingInfo initialLoadingInfo,
+                                     WorkspaceSnapshotCreator snapshotCreator) {
         super(workspaceServiceClient,
               createWorkspacePresenter,
               startWorkspacePresenter,
@@ -87,7 +89,8 @@ public class DefaultWorkspaceComponent extends WorkspaceComponent implements Com
               dialogFactory,
               preferencesManager,
               dtoFactory,
-              initialLoadingInfo);
+              initialLoadingInfo,
+              snapshotCreator);
     }
 
     /** {@inheritDoc} */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/bootstrap/FactoryWorkspaceComponent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/bootstrap/FactoryWorkspaceComponent.java
@@ -32,6 +32,7 @@ import org.eclipse.che.api.workspace.gwt.client.WorkspaceServiceClient;
 import org.eclipse.che.api.workspace.shared.dto.UsersWorkspaceDto;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceConfigDto;
 import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.actions.WorkspaceSnapshotCreator;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.preferences.PreferencesManager;
@@ -81,7 +82,8 @@ public class FactoryWorkspaceComponent extends WorkspaceComponent implements Com
                                      DialogFactory dialogFactory,
                                      PreferencesManager preferencesManager,
                                      DtoFactory dtoFactory,
-                                     InitialLoadingInfo initialLoadingInfo) {
+                                     InitialLoadingInfo initialLoadingInfo,
+                                     WorkspaceSnapshotCreator snapshotCreator) {
         super(workspaceServiceClient,
               createWorkspacePresenter,
               startWorkspacePresenter,
@@ -97,7 +99,8 @@ public class FactoryWorkspaceComponent extends WorkspaceComponent implements Com
               dialogFactory,
               preferencesManager,
               dtoFactory,
-              initialLoadingInfo);
+              initialLoadingInfo,
+              snapshotCreator);
         this.factoryServiceClient = factoryServiceClient;
     }
 

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -207,6 +207,12 @@ project.settings.title=Settings
 stop.ws.title=Stop Workspace
 stop.ws.description=Stop current workspace
 
+############## Create workspace's snapshot action ##########
+create.snapshot.title=Create Snapshot
+create.snapshot.description=Creates snapshot of workspace
+create.snapshot.progress=Creating snapshot...
+create.snapshot.success=Snapshot successfully created
+
 ############## Get workspace #############
 get.ws.error.dialog.title=Error
 get.ws.error.dialog.content=Can not get workspaces. The reason: {0}.

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/CreateSnapshotActionTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/CreateSnapshotActionTest.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.actions;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.eclipse.che.api.workspace.shared.dto.UsersWorkspaceDto;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.Presentation;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link CreateSnapshotAction}.
+ *
+ * @author Yevhenii Voevodin
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class CreateSnapshotActionTest {
+
+    @Mock
+    private WorkspaceSnapshotCreator snapshotCreator;
+
+    @Mock
+    private CoreLocalizationConstant coreLocalizationConstant;
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private ActionEvent event;
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private AppContext appContext;
+
+    @InjectMocks
+    private CreateSnapshotAction createSnapshotAction;
+
+    @Test
+    public void shouldSetTitleAndDescription() {
+        verify(coreLocalizationConstant).createSnapshotTitle();
+        verify(coreLocalizationConstant).createSnapshotDescription();
+    }
+
+    @Test
+    public void eventPresentationShouldBeEnabledIfSnapshotCreatorIsNotInProgress() {
+        when(event.getPresentation()).thenReturn(new Presentation());
+        when(snapshotCreator.isInProgress()).thenReturn(false);
+
+        createSnapshotAction.updateInPerspective(event);
+
+        assertTrue(event.getPresentation().isEnabled());
+    }
+
+    @Test
+    public void eventPresentationShouldBeDisabledIfSnapshotCreatorIsInProgress() {
+        when(event.getPresentation()).thenReturn(new Presentation());
+        when(snapshotCreator.isInProgress()).thenReturn(true);
+
+        createSnapshotAction.updateInPerspective(event);
+
+        assertFalse(event.getPresentation().isEnabled());
+    }
+
+    @Test
+    public void shouldCreateSnapshotWithWorkspaceIdFromAppContextWhenActionPerformed() {
+        when(appContext.getWorkspace()).thenReturn(newDto(UsersWorkspaceDto.class).withId("workspace123"));
+
+        createSnapshotAction.actionPerformed(event);
+
+        verify(snapshotCreator).createSnapshot("workspace123");
+    }
+}

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/WorkspaceSnapshotCreatorTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/actions/WorkspaceSnapshotCreatorTest.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.actions;
+
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.OperationException;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.PromiseError;
+import org.eclipse.che.api.workspace.gwt.client.WorkspaceServiceClient;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.notification.Notification;
+import org.eclipse.che.ide.api.notification.NotificationManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link WorkspaceSnapshotCreator}.
+ *
+ * @author Yevhenii Voevodin
+ */
+@RunWith(GwtMockitoTestRunner.class)
+public class WorkspaceSnapshotCreatorTest {
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private WorkspaceServiceClient workspaceService;
+
+    @Mock
+    private NotificationManager notificationManager;
+
+    @Mock
+    private Notification notification;
+
+    @Mock
+    private Promise<Void> createSnapshotPromise;
+
+    @Mock
+    private PromiseError promiseError;
+
+    @Mock
+    private CoreLocalizationConstant locale;
+
+    @Captor
+    private ArgumentCaptor<Operation<PromiseError>> errorCaptor;
+
+    @InjectMocks
+    private WorkspaceSnapshotCreator snapshotCreator;
+
+    @Test
+    public void shouldShowNotificationWhenCreatingSnapshot() {
+        snapshotCreator.createSnapshot("workspace123");
+
+        verify(notificationManager).showNotification(any());
+    }
+
+    @Test
+    public void shouldChangeNotificationAfterCreationError() {
+        snapshotCreator.createSnapshot("workspace123");
+        snapshotCreator.notification = notification;
+
+        snapshotCreator.creationError("Error");
+
+        verify(notification).setType(Notification.Type.ERROR);
+        verify(notification).setStatus(Notification.Status.FINISHED);
+        verify(notification).setMessage("Error");
+    }
+
+    @Test
+    public void shouldChangeNotificationAfterSuccessfullyCreated() {
+        when(locale.createSnapshotSuccess()).thenReturn("Snapshot successfully created");
+        snapshotCreator.createSnapshot("workspace123");
+        snapshotCreator.notification = notification;
+
+        snapshotCreator.successfullyCreated();
+
+        verify(notification).setType(Notification.Type.INFO);
+        verify(notification).setStatus(Notification.Status.FINISHED);
+        verify(notification).setMessage("Snapshot successfully created");
+    }
+
+    @Test
+    public void shouldChangeNotificationIfErrorCaughtWhileCreatingSnapshot() throws OperationException {
+        when(workspaceService.createSnapshot(anyString())).thenReturn(createSnapshotPromise);
+        snapshotCreator.createSnapshot("workspace123");
+        snapshotCreator.notification = notification;
+
+        verify(createSnapshotPromise).catchError(errorCaptor.capture());
+        errorCaptor.getValue().apply(promiseError);
+
+        verify(notification).setType(Notification.Type.ERROR);
+        verify(notification).setStatus(Notification.Status.FINISHED);
+        verify(notification).setMessage(promiseError.getMessage());
+    }
+
+    @Test
+    public void shouldBeInProgressAfterCreatingSnapshot() {
+        snapshotCreator.createSnapshot("workspace123");
+
+        assertTrue(snapshotCreator.isInProgress());
+    }
+
+    @Test
+    public void shouldNotBeInProgressBeforeCreatingSnapshot() {
+        assertFalse(snapshotCreator.isInProgress());
+    }
+
+    @Test
+    public void shouldNotBeInProgressAfterSuccessfullyCreatedSnapshot() {
+        snapshotCreator.createSnapshot("workspace123");
+
+        snapshotCreator.successfullyCreated();
+
+        assertFalse(snapshotCreator.isInProgress());
+    }
+
+    @Test
+    public void shouldNotBeInProgressAfterSnapshotCreationError() {
+        snapshotCreator.createSnapshot("workspace123");
+
+        snapshotCreator.creationError("Error");
+
+        assertFalse(snapshotCreator.isInProgress());
+    }
+
+    @Test
+    public void shouldNotBeInProgressIfErrorCaughtWhileCreatingSnapshot() throws OperationException {
+        when(workspaceService.createSnapshot(anyString())).thenReturn(createSnapshotPromise);
+        snapshotCreator.createSnapshot("workspace123");
+
+        verify(createSnapshotPromise).catchError(errorCaptor.capture());
+        errorCaptor.getValue().apply(promiseError);
+
+        assertFalse(snapshotCreator.isInProgress());
+    }
+}

--- a/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/MachineServiceClient.java
+++ b/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/MachineServiceClient.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.che.api.machine.gwt.client;
 
-import org.eclipse.che.api.core.model.machine.Snapshot;
 import org.eclipse.che.api.machine.shared.dto.MachineDto;
 import org.eclipse.che.api.machine.shared.dto.MachineProcessDto;
 import org.eclipse.che.api.machine.shared.dto.MachineStateDto;

--- a/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/MachineServiceClient.java
+++ b/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/MachineServiceClient.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.api.machine.gwt.client;
 
+import org.eclipse.che.api.core.model.machine.Snapshot;
 import org.eclipse.che.api.machine.shared.dto.MachineDto;
 import org.eclipse.che.api.machine.shared.dto.MachineProcessDto;
 import org.eclipse.che.api.machine.shared.dto.MachineStateDto;

--- a/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/MachineServiceClientImpl.java
+++ b/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/MachineServiceClientImpl.java
@@ -294,11 +294,6 @@ public class MachineServiceClientImpl implements MachineServiceClient {
         });
     }
 
-    @Override
-    public Promise<List<Snapshot>> getSnapshots(String workspaceId) {
-        return null;
-    }
-
     private void unbindProject(@NotNull String machineId, @NotNull String projectPath, @NotNull AsyncCallback<Void> callback) {
         asyncRequestFactory.createDeleteRequest(baseHttpUrl + '/' + machineId + "/binding/" + projectPath)
                            .loader(loader, "Unbinding project from machine...")

--- a/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/MachineServiceClientImpl.java
+++ b/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/MachineServiceClientImpl.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.machine.gwt.client;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 
+import org.eclipse.che.api.core.model.machine.Snapshot;
 import org.eclipse.che.api.machine.shared.dto.CommandDto;
 import org.eclipse.che.api.machine.shared.dto.MachineDto;
 import org.eclipse.che.api.machine.shared.dto.MachineProcessDto;
@@ -291,6 +292,11 @@ public class MachineServiceClientImpl implements MachineServiceClient {
                 unbindProject(machineId, projectPath, callback);
             }
         });
+    }
+
+    @Override
+    public Promise<List<Snapshot>> getSnapshots(String workspaceId) {
+        return null;
     }
 
     private void unbindProject(@NotNull String machineId, @NotNull String projectPath, @NotNull AsyncCallback<Void> callback) {

--- a/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/MachineServiceClientImpl.java
+++ b/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/MachineServiceClientImpl.java
@@ -13,7 +13,6 @@ package org.eclipse.che.api.machine.gwt.client;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 
-import org.eclipse.che.api.core.model.machine.Snapshot;
 import org.eclipse.che.api.machine.shared.dto.CommandDto;
 import org.eclipse.che.api.machine.shared.dto.MachineDto;
 import org.eclipse.che.api.machine.shared.dto.MachineProcessDto;

--- a/platform-api-client-gwt/che-core-client-gwt-workspace/src/main/java/org/eclipse/che/api/workspace/gwt/client/WorkspaceServiceClient.java
+++ b/platform-api-client-gwt/che-core-client-gwt-workspace/src/main/java/org/eclipse/che/api/workspace/gwt/client/WorkspaceServiceClient.java
@@ -202,7 +202,7 @@ public interface WorkspaceServiceClient {
      *
      * @see WorkspaceService#createSnapshot(String)
      */
-    Promise<List<SnapshotDto>> createSnapshot(String workspaceId);
+    Promise<Void> createSnapshot(String workspaceId);
 
     /**
      * Recovers workspace from snapshot.

--- a/platform-api-client-gwt/che-core-client-gwt-workspace/src/main/java/org/eclipse/che/api/workspace/gwt/client/WorkspaceServiceClient.java
+++ b/platform-api-client-gwt/che-core-client-gwt-workspace/src/main/java/org/eclipse/che/api/workspace/gwt/client/WorkspaceServiceClient.java
@@ -12,6 +12,7 @@ package org.eclipse.che.api.workspace.gwt.client;
 
 import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
 import org.eclipse.che.api.machine.shared.dto.MachineStateDto;
+import org.eclipse.che.api.machine.shared.dto.SnapshotDto;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.workspace.server.WorkspaceService;
 import org.eclipse.che.api.machine.shared.dto.CommandDto;
@@ -26,7 +27,7 @@ import java.util.List;
 /**
  * GWT Client for Workspace Service.
  *
- * @author Eugene Voevodin
+ * @author Yevhenii Voevodin
  */
 public interface WorkspaceServiceClient {
 
@@ -188,4 +189,25 @@ public interface WorkspaceServiceClient {
      * @see WorkspaceService#createMachine(String, MachineConfigDto)
      */
     Promise<MachineStateDto> createMachine(String wsId, MachineConfigDto machineConfig);
+
+    /**
+     * Returns workspace's snapshot.
+     *
+     * @see WorkspaceService#getSnapshot(String)
+     */
+    Promise<List<SnapshotDto>> getSnapshot(String workspaceId);
+
+    /**
+     * Creates snapshot of workspace.
+     *
+     * @see WorkspaceService#createSnapshot(String)
+     */
+    Promise<List<SnapshotDto>> createSnapshot(String workspaceId);
+
+    /**
+     * Recovers workspace from snapshot.
+     *
+     * @see WorkspaceService#recoverWorkspace(String, String, String)
+     */
+    Promise<UsersWorkspaceDto> recoverWorkspace(String workspaceId, String envName, String accountId);
 }

--- a/platform-api-client-gwt/che-core-client-gwt-workspace/src/main/java/org/eclipse/che/api/workspace/gwt/client/WorkspaceServiceClientImpl.java
+++ b/platform-api-client-gwt/che-core-client-gwt-workspace/src/main/java/org/eclipse/che/api/workspace/gwt/client/WorkspaceServiceClientImpl.java
@@ -15,6 +15,7 @@ import com.google.inject.Inject;
 
 import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
 import org.eclipse.che.api.machine.shared.dto.MachineStateDto;
+import org.eclipse.che.api.machine.shared.dto.SnapshotDto;
 import org.eclipse.che.api.promises.client.Function;
 import org.eclipse.che.api.promises.client.FunctionException;
 import org.eclipse.che.api.promises.client.Promise;
@@ -48,6 +49,7 @@ import static org.eclipse.che.ide.rest.HTTPHeader.CONTENT_TYPE;
  * @author Artem Zatsarynnyy
  * @author Dmitry Shnurenko
  * @author Alexander Garagatyi
+ * @author Yevhenii Voevodin
  */
 public class WorkspaceServiceClientImpl implements WorkspaceServiceClient {
 
@@ -348,5 +350,47 @@ public class WorkspaceServiceClientImpl implements WorkspaceServiceClient {
                            .header(CONTENT_TYPE, APPLICATION_JSON)
                            .loader(loader, "Creating machine...")
                            .send(newCallback(callback, dtoUnmarshallerFactory.newUnmarshaller(MachineStateDto.class)));
+    }
+
+    @Override
+    public Promise<List<SnapshotDto>> getSnapshot(String workspaceId) {
+        return newPromise(new RequestCall<List<SnapshotDto>>() {
+            @Override
+            public void makeCall(AsyncCallback<List<SnapshotDto>> callback) {
+                final String url = baseHttpUrl + '/' + workspaceId + "/snapshot";
+                asyncRequestFactory.createGetRequest(url)
+                                   .header(ACCEPT, APPLICATION_JSON)
+                                   .loader(loader, "Getting workspace's snapshot")
+                                   .send(newCallback(callback, dtoUnmarshallerFactory.newListUnmarshaller(SnapshotDto.class)));
+            }
+        });
+    }
+
+    @Override
+    public Promise<List<SnapshotDto>> createSnapshot(String workspaceId) {
+        return newPromise(new RequestCall<List<SnapshotDto>>() {
+            @Override
+            public void makeCall(AsyncCallback<List<SnapshotDto>> callback) {
+                final String url = baseHttpUrl + '/' + workspaceId + "/snapshot";
+                asyncRequestFactory.createPostRequest(url, null)
+                                   .header(ACCEPT, APPLICATION_JSON)
+                                   .loader(loader, "Creating workspace's snapshot")
+                                   .send(newCallback(callback, dtoUnmarshallerFactory.newListUnmarshaller(SnapshotDto.class)));
+            }
+        });
+    }
+
+    @Override
+    public Promise<UsersWorkspaceDto> recoverWorkspace(String workspaceId, String envName, String accountId) {
+        return newPromise(new RequestCall<UsersWorkspaceDto>() {
+            @Override
+            public void makeCall(AsyncCallback<UsersWorkspaceDto> callback) {
+                final String url = baseHttpUrl + '/' + workspaceId + "/snapshot/runtime?environment=" + envName;
+                asyncRequestFactory.createPostRequest(url, null)
+                                   .header(ACCEPT, APPLICATION_JSON)
+                                   .loader(loader, "Recovering workspace from snapshot")
+                                   .send(newCallback(callback, dtoUnmarshallerFactory.newUnmarshaller(UsersWorkspaceDto.class)));
+            }
+        });
     }
 }

--- a/platform-api-client-gwt/che-core-client-gwt-workspace/src/main/java/org/eclipse/che/api/workspace/gwt/client/WorkspaceServiceClientImpl.java
+++ b/platform-api-client-gwt/che-core-client-gwt-workspace/src/main/java/org/eclipse/che/api/workspace/gwt/client/WorkspaceServiceClientImpl.java
@@ -353,7 +353,7 @@ public class WorkspaceServiceClientImpl implements WorkspaceServiceClient {
     }
 
     @Override
-    public Promise<List<SnapshotDto>> getSnapshot(String workspaceId) {
+    public Promise<List<SnapshotDto>> getSnapshot(final String workspaceId) {
         return newPromise(new RequestCall<List<SnapshotDto>>() {
             @Override
             public void makeCall(AsyncCallback<List<SnapshotDto>> callback) {
@@ -367,25 +367,25 @@ public class WorkspaceServiceClientImpl implements WorkspaceServiceClient {
     }
 
     @Override
-    public Promise<List<SnapshotDto>> createSnapshot(String workspaceId) {
-        return newPromise(new RequestCall<List<SnapshotDto>>() {
+    public Promise<Void> createSnapshot(final String workspaceId) {
+        return newPromise(new RequestCall<Void>() {
             @Override
-            public void makeCall(AsyncCallback<List<SnapshotDto>> callback) {
+            public void makeCall(AsyncCallback<Void> callback) {
                 final String url = baseHttpUrl + '/' + workspaceId + "/snapshot";
                 asyncRequestFactory.createPostRequest(url, null)
                                    .header(ACCEPT, APPLICATION_JSON)
                                    .loader(loader, "Creating workspace's snapshot")
-                                   .send(newCallback(callback, dtoUnmarshallerFactory.newListUnmarshaller(SnapshotDto.class)));
+                                   .send(newCallback(callback));
             }
         });
     }
 
     @Override
-    public Promise<UsersWorkspaceDto> recoverWorkspace(String workspaceId, String envName, String accountId) {
+    public Promise<UsersWorkspaceDto> recoverWorkspace(final String workspaceId, final String envName, final String accountId) {
         return newPromise(new RequestCall<UsersWorkspaceDto>() {
             @Override
             public void makeCall(AsyncCallback<UsersWorkspaceDto> callback) {
-                final String url = baseHttpUrl + '/' + workspaceId + "/snapshot/runtime?environment=" + envName;
+                final String url = baseHttpUrl + '/' + workspaceId + "/runtime/snapshot?environment=" + envName;
                 asyncRequestFactory.createPostRequest(url, null)
                                    .header(ACCEPT, APPLICATION_JSON)
                                    .loader(loader, "Recovering workspace from snapshot")

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/model/machine/MachineState.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/model/machine/MachineState.java
@@ -23,6 +23,8 @@ public interface MachineState extends MachineConfig {
 
     String getWorkspaceId();
 
+    String getEnvName();
+
     String getOwner();
 
     MachineStatus getStatus();

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/model/machine/Snapshot.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/model/machine/Snapshot.java
@@ -14,6 +14,7 @@ package org.eclipse.che.api.core.model.machine;
  * Represents saved state of a machine
  *
  * @author gazarenkov
+ * @author Yevhenii Voevodin
  */
 public interface Snapshot {
 
@@ -37,15 +38,25 @@ public interface Snapshot {
      */
     long getCreationDate();
 
-    /**
-     * Id of the workspace that is bound to snapshot
-     */
-    String getWorkspaceId();
-
     boolean isDev();
 
     /**
      * Description of the snapshot
      */
     String getDescription();
+
+    /**
+     * Id of workspace which machines is bound to snapshot
+     */
+    String getWorkspaceId();
+
+    /**
+     * Returns name of bound to this snapshot machine
+     */
+    String getMachineName();
+
+    /**
+     * Returns name of environment which machine belongs to
+     */
+    String getEnvName();
 }

--- a/platform-api/che-core-api-infrastructure-local/src/main/java/org/eclipse/che/api/local/LocalInfrastructureModule.java
+++ b/platform-api/che-core-api-infrastructure-local/src/main/java/org/eclipse/che/api/local/LocalInfrastructureModule.java
@@ -18,6 +18,7 @@ import org.eclipse.che.api.auth.AuthenticationDao;
 import org.eclipse.che.api.core.rest.permission.PermissionManager;
 import org.eclipse.che.api.local.storage.LocalStorageFactory;
 import org.eclipse.che.api.machine.server.dao.RecipeDao;
+import org.eclipse.che.api.machine.server.dao.SnapshotDao;
 import org.eclipse.che.api.user.server.TokenValidator;
 import org.eclipse.che.api.user.server.dao.PreferenceDao;
 import org.eclipse.che.api.user.server.dao.User;
@@ -36,6 +37,7 @@ public class LocalInfrastructureModule extends AbstractModule {
         bind(WorkspaceDao.class).to(LocalWorkspaceDaoImpl.class);
         bind(UserProfileDao.class).to(LocalProfileDaoImpl.class);
         bind(PreferenceDao.class).to(LocalPreferenceDaoImpl.class);
+        bind(SnapshotDao.class).to(LocalSnapshotDaoImpl.class);
 //        bind(MemberDao.class).to(LocalMemberDaoImpl.class);
         bind(AuthenticationDao.class).to(LocalAuthenticationDaoImpl.class);
 //        bind(FactoryStore.class).to(InMemoryFactoryStore.class);

--- a/platform-api/che-core-api-infrastructure-local/src/main/java/org/eclipse/che/api/local/LocalSnapshotDaoImpl.java
+++ b/platform-api/che-core-api-infrastructure-local/src/main/java/org/eclipse/che/api/local/LocalSnapshotDaoImpl.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.local;
+
+import com.google.common.reflect.TypeToken;
+
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.local.storage.LocalStorage;
+import org.eclipse.che.api.local.storage.LocalStorageFactory;
+import org.eclipse.che.api.machine.server.dao.SnapshotDao;
+import org.eclipse.che.api.machine.server.exception.SnapshotException;
+import org.eclipse.che.api.machine.server.impl.SnapshotImpl;
+import org.eclipse.che.api.machine.server.recipe.adapters.InstanceKeyAdapter;
+import org.eclipse.che.api.machine.server.spi.InstanceKey;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * In-memory implementation of {@link SnapshotDao}.
+ *
+ * @author Yevhenii Voevodin
+ */
+@Singleton
+public class LocalSnapshotDaoImpl implements SnapshotDao {
+
+    private final Map<String, SnapshotImpl> snapshots;
+    private final LocalStorage              snapshotStorage;
+
+    @Inject
+    public LocalSnapshotDaoImpl(LocalStorageFactory storageFactory) throws IOException {
+        snapshots = new HashMap<>();
+        snapshotStorage = storageFactory.create("snapshots.json", singletonMap(InstanceKey.class, new InstanceKeyAdapter()));
+    }
+
+    @Override
+    public synchronized SnapshotImpl getSnapshot(String workspaceId, String envName, String machineName) throws NotFoundException,
+                                                                                                                SnapshotException {
+        final Optional<SnapshotImpl> snapshotOpt = doGetSnapshot(workspaceId, envName, machineName);
+        if (!snapshotOpt.isPresent()) {
+            throw new NotFoundException(format("Snapshot with workspace id '%s', environment name '%s', machine name %s doesn't exist",
+                                               workspaceId, envName, machineName));
+        }
+        return snapshotOpt.get();
+    }
+
+    @Override
+    public synchronized SnapshotImpl getSnapshot(String snapshotId) throws NotFoundException, SnapshotException {
+        final SnapshotImpl snapshot = snapshots.get(snapshotId);
+        if (snapshot == null) {
+            throw new NotFoundException("Snapshot with id '" + snapshotId + "' doesn't exist");
+        }
+        return snapshot;
+    }
+
+    @Override
+    public synchronized void saveSnapshot(SnapshotImpl snapshot) throws SnapshotException {
+        Objects.requireNonNull(snapshot, "Required non-null snapshot");
+        final Optional<SnapshotImpl> opt = doGetSnapshot(snapshot.getWorkspaceId(), snapshot.getEnvName(), snapshot.getMachineName());
+        if (opt.isPresent()) {
+            snapshots.remove(opt.get().getId());
+        }
+        snapshots.put(snapshot.getId(), snapshot);
+    }
+
+    @Override
+    public synchronized List<SnapshotImpl> findSnapshots(String owner, String workspaceId) throws SnapshotException {
+        return snapshots.values()
+                        .stream()
+                        .filter(snapshot -> snapshot.getOwner().equals(owner) && snapshot.getWorkspaceId().equals(workspaceId))
+                        .collect(toList());
+    }
+
+    @Override
+    public synchronized void removeSnapshot(String snapshotId) throws NotFoundException, SnapshotException {
+        snapshots.remove(snapshotId);
+    }
+
+    @PostConstruct
+    public synchronized void loadSnapshots() {
+        snapshots.putAll(snapshotStorage.loadMap(new TypeToken<Map<String, SnapshotImpl>>() {}));
+    }
+
+    @PreDestroy
+    public synchronized void saveSnapshots() throws IOException {
+        snapshotStorage.store(snapshots);
+    }
+
+    private Optional<SnapshotImpl> doGetSnapshot(String workspaceId, String envName, String machineName) {
+        return snapshots.values()
+                        .stream()
+                        .filter(snapshot -> snapshot.getWorkspaceId().equals(workspaceId)
+                                            && snapshot.getEnvName().equals(envName)
+                                            && snapshot.getMachineName().equals(machineName))
+                        .findFirst();
+    }
+}

--- a/platform-api/che-core-api-infrastructure-local/src/test/java/org/eclipse/che/api/local/LocalSnapshotDaoTest.java
+++ b/platform-api/che-core-api-infrastructure-local/src/test/java/org/eclipse/che/api/local/LocalSnapshotDaoTest.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.local;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.eclipse.che.api.local.storage.LocalStorageFactory;
+import org.eclipse.che.api.machine.server.impl.SnapshotImpl;
+import org.eclipse.che.api.machine.server.recipe.adapters.InstanceKeyAdapter;
+import org.eclipse.che.api.machine.server.spi.InstanceKey;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static java.nio.file.Files.readAllBytes;
+import static java.nio.file.Files.write;
+import static java.util.Collections.singletonMap;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Tests for {@link LocalSnapshotDaoImpl}
+ *
+ * @author Yevhenii Voevodin
+ */
+public class LocalSnapshotDaoTest {
+
+    private static Gson GSON = new GsonBuilder().setPrettyPrinting()
+                                                .registerTypeAdapter(InstanceKey.class, new InstanceKeyAdapter())
+                                                .create();
+
+    private LocalSnapshotDaoImpl snapshotDao;
+    private Path                 snapshotsPath;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        final URL url = Thread.currentThread().getContextClassLoader().getResource(".");
+        assertNotNull(url);
+        final Path targetDir = Paths.get(url.toURI()).getParent();
+        final Path storageRoot = targetDir.resolve("snapshots");
+        snapshotsPath = storageRoot.resolve("snapshots.json");
+        snapshotDao = new LocalSnapshotDaoImpl(new LocalStorageFactory(storageRoot.toString()));
+    }
+
+    @Test
+    public void testSnapshotsSerialization() throws Exception {
+        final SnapshotImpl snapshot = createSnapshot();
+
+        snapshotDao.saveSnapshot(snapshot);
+        snapshotDao.saveSnapshots();
+
+        assertEquals(GSON.toJson(singletonMap(snapshot.getId(), snapshot)), new String(readAllBytes(snapshotsPath)));
+    }
+
+    @Test
+    public void testSnapshotsDeserialization() throws Exception {
+        final SnapshotImpl snapshot = createSnapshot();
+        write(snapshotsPath, GSON.toJson(singletonMap(snapshot.getId(), snapshot)).getBytes());
+
+        snapshotDao.loadSnapshots();
+
+        final SnapshotImpl result = snapshotDao.getSnapshot(snapshot.getId());
+        assertEquals(result, snapshot);
+    }
+
+    private SnapshotImpl createSnapshot() {
+        return SnapshotImpl.builder()
+                           .generateId()
+                           .setType("docker")
+                           .setInstanceKey(new DummyInstanceKey())
+                           .setOwner("user123")
+                           .setWorkspaceId("workspace123")
+                           .setMachineName("machine123")
+                           .setEnvName("env123")
+                           .setDescription("Test snapshot")
+                           .setDev(true)
+                           .useCurrentCreationDate()
+                           .build();
+    }
+
+    private static class DummyInstanceKey implements InstanceKey {
+
+        Map<String, String> fields = singletonMap("field1", "value1");
+
+        @Override
+        public Map<String, String> getFields() {
+            return fields;
+        }
+
+        @Override
+        public String toJson() {
+            return "{\"field1\":\"value1\"}";
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return obj instanceof InstanceKey && ((InstanceKey)obj).getFields().equals(getFields());
+        }
+    }
+}

--- a/platform-api/che-core-api-infrastructure-local/src/test/java/org/eclipse/che/api/local/LocalWorkspaceDaoTest.java
+++ b/platform-api/che-core-api-infrastructure-local/src/test/java/org/eclipse/che/api/local/LocalWorkspaceDaoTest.java
@@ -81,7 +81,6 @@ public class LocalWorkspaceDaoTest {
         workspaceDao.loadWorkspaces();
 
         final UsersWorkspaceImpl result = workspaceDao.get(workspace.getId());
-        System.out.println(result.equals(workspace));
         assertEquals(result, workspace);
     }
 

--- a/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/MachineManager.java
+++ b/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/MachineManager.java
@@ -19,6 +19,7 @@ import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.model.machine.Command;
+import org.eclipse.che.api.core.model.machine.Machine;
 import org.eclipse.che.api.core.model.machine.MachineConfig;
 import org.eclipse.che.api.core.model.machine.MachineState;
 import org.eclipse.che.api.core.model.machine.MachineStatus;
@@ -84,6 +85,7 @@ import static org.eclipse.che.dto.server.DtoFactory.newDto;
  *
  * @author gazarenkov
  * @author Alexander Garagatyi
+ * @author Yevhenii Voevodin
  */
 @Singleton
 public class MachineManager {
@@ -158,10 +160,52 @@ public class MachineManager {
                    ConflictException,
                    MachineException,
                    BadRequestException {
-        final MachineStateImpl machine = createMachine(machineConfig,
-                                                       workspaceId,
-                                                       environmentName,
-                                                       this::createInstance);
+        LOG.info("Creating machine [ws = {}: env = {}: machine = {}]", workspaceId, environmentName, machineConfig.getName());
+        final MachineStateImpl machine = createMachine(machineConfig, workspaceId, environmentName, this::createInstance, null);
+        LOG.info("Machine [ws = {}: env = {}: machine = {}] was successfully created, its id is '{}'",
+                 workspaceId,
+                 environmentName,
+                 machineConfig.getName(),
+                 machine.getId());
+
+        return instanceToMachineImpl(machineRegistry.get(machine.getId()));
+    }
+
+    /**
+     * Synchronously recovers machine from snapshot.
+     *
+     * @param machineConfig
+     *         machine meta information which is needed for {@link Machine machine} instance creation
+     * @param workspaceId
+     *         workspace id
+     * @param envName
+     *         name of environment
+     * @return machine instance
+     * @throws NotFoundException
+     *         when snapshot doesn't exist
+     * @throws SnapshotException
+     *         when any error occurs during snapshot fetching
+     * @throws MachineException
+     *         when any error occurs during machine start
+     * @throws ConflictException
+     *         when any conflict occurs during machine creation (e.g Machine with given name already registered for certain workspace)
+     * @throws BadRequestException
+     *         when either machineConfig or workspace id, or environment name is not valid
+     */
+    public MachineImpl recoverMachine(MachineConfig machineConfig, String workspaceId, String envName) throws NotFoundException,
+                                                                                                              SnapshotException,
+                                                                                                              MachineException,
+                                                                                                              ConflictException,
+                                                                                                              BadRequestException {
+        final SnapshotImpl snapshot = snapshotDao.getSnapshot(workspaceId, envName, machineConfig.getName());
+
+        LOG.info("Recovering machine [ws = {}: env = {}: machine = {}] from snapshot", workspaceId, envName, machineConfig.getName());
+        final MachineStateImpl machine = createMachine(machineConfig, workspaceId, envName, this::createInstance, snapshot);
+        LOG.info("Machine [ws = {}: env = {}: machine = {}] was successfully recovered, its id '{}'",
+                 workspaceId,
+                 envName,
+                 machineConfig.getName(),
+                 machine.getId());
 
         return instanceToMachineImpl(machineRegistry.get(machine.getId()));
     }
@@ -218,13 +262,15 @@ public class MachineManager {
                                              LOG.error(e.getLocalizedMessage(), e);
                                              // todo what should we do in that case?
                                          }
-                                     })));
+                                     })),
+                             null);
     }
 
     private MachineStateImpl createMachine(MachineConfig machineConfig,
-                                           final String workspaceId,
-                                           final String environmentName,
-                                           MachineInstanceCreator instanceCreator)
+                                           String workspaceId,
+                                           String environmentName,
+                                           MachineInstanceCreator instanceCreator,
+                                           SnapshotImpl snapshot)
             throws NotFoundException,
                    SnapshotException,
                    ConflictException,
@@ -233,13 +279,14 @@ public class MachineManager {
         final InstanceProvider instanceProvider = machineInstanceProviders.getProvider(machineConfig.getType());
         final String sourceType = machineConfig.getSource().getType();
 
-        Recipe recipe = null;
+        Recipe recipe;
         InstanceKey instanceKey = null;
+        if (snapshot != null) {
+            instanceKey = snapshot.getInstanceKey();
+        }
         if ("Recipe".equalsIgnoreCase(sourceType)) {
             // TODO should we check that it is dockerfile?
             recipe = getRecipeByLocation(machineConfig);
-        } else if ("Snapshot".equalsIgnoreCase(sourceType)) {
-            instanceKey = snapshotDao.getSnapshot(machineConfig.getSource().getLocation()).getInstanceKey();
         } else {
             throw new BadRequestException("Source type is unsupported " + sourceType);
         }
@@ -264,8 +311,8 @@ public class MachineManager {
         }
 
         final MachineStateImpl machineState = new MachineStateImpl(machineConfig.isDev(),
-                                                                   machineConfig.getName(),
                                                                    machineConfig.getType(),
+                                                                   machineConfig.getName(),
                                                                    machineConfig.getSource(),
                                                                    machineConfig.getLimits(),
                                                                    machineId,
@@ -274,6 +321,7 @@ public class MachineManager {
                                                                                          environmentName),
                                                                    workspaceId,
                                                                    creator,
+                                                                   environmentName,
                                                                    MachineStatus.CREATING);
 
         createMachineLogsDir(machineId);
@@ -304,14 +352,10 @@ public class MachineManager {
                                            .withMachineName(machineState.getName()));
 
             final Instance instance;
-            if ("recipe".equalsIgnoreCase(machineState.getSource().getType())) {
-                instance = instanceProvider.createInstance(recipe,
-                                                           machineState,
-                                                           machineLogger);
+            if (instanceKey == null) {
+                instance = instanceProvider.createInstance(recipe, machineState, machineLogger);
             } else {
-                instance = instanceProvider.createInstance(instanceKey,
-                                                           machineState,
-                                                           machineLogger);
+                instance = instanceProvider.createInstance(instanceKey, machineState, machineLogger);
             }
 
             machineRegistry.update(instance);
@@ -431,25 +475,25 @@ public class MachineManager {
      * @throws MachineException
      *         if other error occur
      */
-    public SnapshotImpl save(final String machineId, final String owner, final String description)
+    public SnapshotImpl save(String machineId, String owner, String description)
             throws NotFoundException, MachineException {
         final Instance machine = getMachine(machineId);
-
-        final SnapshotImpl snapshot = new SnapshotImpl(generateSnapshotId(),
-                                                       machine.getType(),
-                                                       null,
-                                                       owner,
-                                                       System.currentTimeMillis(),
-                                                       machine.getWorkspaceId(),
-                                                       description,
-                                                       machine.isDev());
-
+        final SnapshotImpl snapshot = SnapshotImpl.builder()
+                                                  .generateId()
+                                                  .setType(machine.getType())
+                                                  .setOwner(owner)
+                                                  .setWorkspaceId(machine.getWorkspaceId())
+                                                  .setDescription(description)
+                                                  .setDev(machine.isDev())
+                                                  .setEnvName(machine.getEnvName())
+                                                  .setMachineName(machine.getName())
+                                                  .useCurrentCreationDate()
+                                                  .build();
         executor.submit(ThreadLocalPropagateContext.wrap(() -> {
             try {
-                final InstanceKey instanceKey = machine.saveToSnapshot(machine.getOwner());
-                snapshot.setInstanceKey(instanceKey);
-
-                snapshotDao.saveSnapshot(snapshot);
+                final SnapshotImpl snapshotWithKey = new SnapshotImpl(snapshot);
+                snapshotWithKey.setInstanceKey(machine.saveToSnapshot(machine.getOwner()));
+                snapshotDao.saveSnapshot(snapshotWithKey);
             } catch (Exception e) {
                 try {
                     machine.getLogger().writeLine("Snapshot storing failed. " + e.getLocalizedMessage());
@@ -457,7 +501,6 @@ public class MachineManager {
                 }
             }
         }));
-
         return snapshot;
     }
 

--- a/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/MachineRegistry.java
+++ b/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/MachineRegistry.java
@@ -157,6 +157,7 @@ public class MachineRegistry {
                                     instance.getChannels(),
                                     instance.getWorkspaceId(),
                                     instance.getOwner(),
+                                    instance.getEnvName(),
                                     instance.getStatus());
     }
 }

--- a/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/dao/SnapshotDao.java
+++ b/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/dao/SnapshotDao.java
@@ -20,8 +20,27 @@ import java.util.List;
  * Stores metadata of snapshots
  *
  * @author andrew00x
+ * @author Yevhenii Voevodin
  */
 public interface SnapshotDao {
+
+    /**
+     * Retrieves snapshot metadata by machine related information.
+     *
+     * @param workspaceId
+     *         workspace id
+     * @param envName
+     *         name of environment
+     * @param machineName
+     *         name of machine
+     * @return snapshot which matches given parameters
+     * @throws NotFoundException
+     *         when snapshot with such workspaceId, envName and machineName doesn't exist
+     * @throws SnapshotException
+     *         when any other error occurs
+     */
+    SnapshotImpl getSnapshot(String workspaceId, String envName, String machineName) throws NotFoundException, SnapshotException;
+
     /**
      * Retrieve snapshot metadata by id
      *
@@ -43,7 +62,7 @@ public interface SnapshotDao {
      * @throws SnapshotException
      *         if error occurs
      */
-    void saveSnapshot(SnapshotImpl snapshot) throws SnapshotException ;
+    void saveSnapshot(SnapshotImpl snapshot) throws SnapshotException;
 
     /**
      * Find snapshots by owner, workspace, project
@@ -56,7 +75,7 @@ public interface SnapshotDao {
      * @throws SnapshotException
      *         if error occurs
      */
-    List<SnapshotImpl> findSnapshots(String owner, String workspaceId) throws SnapshotException ;
+    List<SnapshotImpl> findSnapshots(String owner, String workspaceId) throws SnapshotException;
 
     /**
      * Remove snapshot by id
@@ -68,5 +87,5 @@ public interface SnapshotDao {
      * @throws SnapshotException
      *         if other error occur
      */
-    void removeSnapshot(String snapshotId) throws NotFoundException, SnapshotException ;
+    void removeSnapshot(String snapshotId) throws NotFoundException, SnapshotException;
 }

--- a/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/impl/AbstractInstance.java
+++ b/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/impl/AbstractInstance.java
@@ -30,6 +30,7 @@ public abstract class AbstractInstance implements Instance {
     private final Channels            channels;
     private final Limits              limits;
     private final MachineSource       source;
+    private final String              envName;
 
     private MachineStatus machineStatus;
 
@@ -42,7 +43,8 @@ public abstract class AbstractInstance implements Instance {
                             Channels channels,
                             Limits limits,
                             MachineSource source,
-                            MachineStatus machineStatus) {
+                            MachineStatus machineStatus,
+                            String envName) {
         this.id = id;
         this.type = type;
         this.owner = owner;
@@ -53,6 +55,7 @@ public abstract class AbstractInstance implements Instance {
         this.limits = limits;
         this.source = source;
         this.machineStatus = machineStatus;
+        this.envName = envName;
     }
 
     public AbstractInstance(MachineState machineState) {
@@ -66,6 +69,7 @@ public abstract class AbstractInstance implements Instance {
         this.limits = machineState.getLimits();
         this.source = machineState.getSource();
         this.machineStatus = machineState.getStatus();
+        this.envName = machineState.getEnvName();
     }
 
     @Override
@@ -111,6 +115,11 @@ public abstract class AbstractInstance implements Instance {
     @Override
     public MachineSource getSource() {
         return source;
+    }
+
+    @Override
+    public String getEnvName() {
+        return envName;
     }
 
     @Override

--- a/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/MachineImpl.java
+++ b/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/MachineImpl.java
@@ -43,8 +43,9 @@ public class MachineImpl extends MachineStateImpl implements Machine {
                        Channels channels,
                        String workspace,
                        String owner,
+                       String envName,
                        MachineStatus status) {
-        super(isDev, name, type, source, limits, id, channels, workspace, owner, status);
+        super(isDev, type, name, source, limits, id, channels, workspace, owner, envName, status);
         this.metadata = new MachineMetadataImpl(metadata);
     }
 
@@ -59,6 +60,7 @@ public class MachineImpl extends MachineStateImpl implements Machine {
              machine.getChannels(),
              machine.getWorkspaceId(),
              machine.getOwner(),
+             machine.getEnvName(),
              machine.getStatus());
     }
 
@@ -103,6 +105,7 @@ public class MachineImpl extends MachineStateImpl implements Machine {
         private Channels        channels;
         private String          workspaceId;
         private String          owner;
+        private String          envName;
         private MachineStatus   machineStatus;
 
         public MachineImpl build() {
@@ -116,6 +119,7 @@ public class MachineImpl extends MachineStateImpl implements Machine {
                                    channels,
                                    workspaceId,
                                    owner,
+                                   envName,
                                    machineStatus);
         }
 
@@ -171,6 +175,11 @@ public class MachineImpl extends MachineStateImpl implements Machine {
 
         public MachineImplBuilder setStatus(MachineStatus status) {
             this.machineStatus = status;
+            return this;
+        }
+
+        public MachineImplBuilder setEnvName(String envName){
+            this.envName = envName;
             return this;
         }
     }

--- a/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/MachineStateImpl.java
+++ b/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/model/impl/MachineStateImpl.java
@@ -29,18 +29,20 @@ public class MachineStateImpl extends MachineConfigImpl implements MachineState 
     private String        id;
     private ChannelsImpl  channels;
     private String        workspace;
+    private String        envName;
     private String        owner;
     private MachineStatus machineStatus;
 
     public MachineStateImpl(boolean isDev,
-                            String name,
                             String type,
+                            String name,
                             MachineSource source,
                             Limits limits,
                             String id,
                             Channels channels,
                             String workspaceId,
                             String owner,
+                            String envName,
                             MachineStatus machineStatus) {
         super(isDev, name, type, source, limits);
         this.id = id;
@@ -48,6 +50,7 @@ public class MachineStateImpl extends MachineConfigImpl implements MachineState 
         this.workspace = workspaceId;
         this.owner = owner;
         this.machineStatus = machineStatus;
+        this.envName = envName;
     }
 
     public MachineStateImpl(MachineState machine) {
@@ -60,15 +63,17 @@ public class MachineStateImpl extends MachineConfigImpl implements MachineState 
              machine.getChannels(),
              machine.getWorkspaceId(),
              machine.getOwner(),
+             machine.getEnvName(),
              machine.getStatus());
     }
 
     public MachineStateImpl(MachineConfig machine) {
         this(machine.isDev(),
-             machine.getName(),
              machine.getType(),
+             machine.getName(),
              machine.getSource(),
              machine.getLimits(),
+             null,
              null,
              null,
              null,
@@ -95,6 +100,11 @@ public class MachineStateImpl extends MachineConfigImpl implements MachineState 
     }
 
     @Override
+    public String getEnvName() {
+        return envName;
+    }
+
+    @Override
     public String getOwner() {
         return owner;
     }
@@ -118,10 +128,11 @@ public class MachineStateImpl extends MachineConfigImpl implements MachineState 
         if (!(o instanceof MachineStateImpl)) return false;
         if (!super.equals(o)) return false;
         final MachineStateImpl other = (MachineStateImpl)o;
-        return Objects.equals(id, other.id) &&
-               Objects.equals(getChannels(), other.getChannels()) &&
-               Objects.equals(workspace, other.workspace) &&
-               Objects.equals(owner, other.owner);
+        return Objects.equals(id, other.id)
+               && Objects.equals(getChannels(), other.getChannels())
+               && Objects.equals(workspace, other.workspace)
+               && Objects.equals(owner, other.owner)
+               && Objects.equals(envName, other.envName);
     }
 
     @Override
@@ -131,6 +142,7 @@ public class MachineStateImpl extends MachineConfigImpl implements MachineState 
         hash = hash * 31 + getChannels().hashCode();
         hash = hash * 31 + Objects.hashCode(workspace);
         hash = hash * 31 + Objects.hashCode(owner);
+        hash = hash * 31 + Objects.hashCode(envName);
         return hash;
     }
 }

--- a/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/recipe/adapters/InstanceKeyAdapter.java
+++ b/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/recipe/adapters/InstanceKeyAdapter.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.machine.server.recipe.adapters;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import org.eclipse.che.api.machine.server.spi.InstanceKey;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Type adapter for {@link InstanceKey}.
+ *
+ * @author Yevhenii Voevodin
+ */
+public class InstanceKeyAdapter implements JsonDeserializer<InstanceKey>, JsonSerializer<InstanceKey> {
+
+    @Override
+    public InstanceKey deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext context) throws JsonParseException {
+        final JsonObject recipeObj = jsonElement.getAsJsonObject();
+        return new InstanceKey() {
+
+            Map<String, String> fields;
+
+            @Override
+            public Map<String, String> getFields() {
+                if (fields == null) {
+                    fields = new HashMap<>();
+                    for (Map.Entry<String, JsonElement> entry : recipeObj.entrySet()) {
+                        fields.put(entry.getKey(), entry.getValue().getAsString());
+                    }
+                }
+                return fields;
+            }
+
+            @Override
+            public String toJson() {
+                return null;
+            }
+        };
+    }
+
+    @Override
+    public JsonElement serialize(InstanceKey instanceKey, Type type, JsonSerializationContext context) {
+        final JsonObject fields = new JsonObject();
+        for (Map.Entry<String, String> entry : instanceKey.getFields().entrySet()) {
+            fields.addProperty(entry.getKey(), entry.getValue());
+        }
+        return fields;
+    }
+}

--- a/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/recipe/adapters/RecipeTypeAdapter.java
+++ b/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/recipe/adapters/RecipeTypeAdapter.java
@@ -17,6 +17,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
+import com.google.gson.reflect.TypeToken;
 
 import org.eclipse.che.api.core.model.machine.Recipe;
 import org.eclipse.che.api.machine.server.recipe.RecipeImpl;

--- a/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/shared/dto/SnapshotDto.java
+++ b/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/shared/dto/SnapshotDto.java
@@ -50,6 +50,14 @@ public interface SnapshotDto extends Snapshot, Hyperlinks {
 
     SnapshotDto withDev(boolean isDev);
 
+    SnapshotDto withMachineName(String name);
+
+    void setMachineName(String name);
+
+    SnapshotDto withEnvName(String envName);
+
+    void setEnvName(String envName);
+
     @Override
     SnapshotDto withLinks(List<Link> links);
 }

--- a/platform-api/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/MachineManagerTest.java
+++ b/platform-api/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/MachineManagerTest.java
@@ -24,6 +24,7 @@ import org.eclipse.che.api.core.util.LineConsumer;
 import org.eclipse.che.api.machine.server.dao.SnapshotDao;
 import org.eclipse.che.api.machine.server.exception.MachineException;
 import org.eclipse.che.api.machine.server.impl.AbstractInstance;
+import org.eclipse.che.api.machine.server.impl.SnapshotImpl;
 import org.eclipse.che.api.machine.server.model.impl.ChannelsImpl;
 import org.eclipse.che.api.machine.server.model.impl.LimitsImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineConfigImpl;
@@ -136,7 +137,8 @@ public class MachineManagerTest {
                                                                    new ChannelsImpl("chan1", "chan2"),
                                                                    machineConfig.getLimits(),
                                                                    machineConfig.getSource(),
-                                                                   MachineStatus.CREATING);
+                                                                   MachineStatus.CREATING,
+                                                                   environmentName);
         doReturn(recipe).when(manager).getRecipeByLocation(any(MachineConfig.class));
         when(machineInstanceProviders.getProvider(anyString())).thenReturn(instanceProvider);
         when(instanceProvider.createInstance(eq(recipe), any(MachineState.class), any(LineConsumer.class))).thenReturn(noOpInstance);
@@ -164,8 +166,9 @@ public class MachineManagerTest {
                                 Channels channels,
                                 Limits limits,
                                 MachineSource source,
-                                MachineStatus machineStatus) {
-            super(id, type, workspaceId, owner, isDev, displayName, channels, limits, source, machineStatus);
+                                MachineStatus machineStatus,
+                                String envName) {
+            super(id, type, workspaceId, owner, isDev, displayName, channels, limits, source, machineStatus, envName);
         }
 
         public NoOpInstanceImpl(MachineState machineState) {

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.api.workspace.server;
 
 import org.eclipse.che.api.core.model.machine.Command;
+import org.eclipse.che.api.core.model.machine.Snapshot;
 import org.eclipse.che.api.core.model.project.SourceStorage;
 import org.eclipse.che.api.core.model.workspace.Environment;
 import org.eclipse.che.api.core.model.workspace.EnvironmentState;
@@ -23,6 +24,7 @@ import org.eclipse.che.api.machine.shared.dto.CommandDto;
 import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
 import org.eclipse.che.api.machine.shared.dto.MachineDto;
 import org.eclipse.che.api.machine.shared.dto.MachineStateDto;
+import org.eclipse.che.api.machine.shared.dto.SnapshotDto;
 import org.eclipse.che.api.workspace.shared.dto.EnvironmentDto;
 import org.eclipse.che.api.workspace.shared.dto.EnvironmentStateDto;
 import org.eclipse.che.api.workspace.shared.dto.ModuleConfigDto;
@@ -144,11 +146,11 @@ public final class DtoConverter {
      */
     public static ModuleConfigDto asDto(ModuleConfig moduleConfig) {
         final ModuleConfigDto moduleConfigDto = newDto(ModuleConfigDto.class).withName(moduleConfig.getName())
-                                                                                .withDescription(moduleConfig.getDescription())
-                                                                                .withPath(moduleConfig.getPath())
-                                                                                .withType(moduleConfig.getType())
-                                                                                .withAttributes(moduleConfig.getAttributes())
-                                                                                .withMixins(moduleConfig.getMixins());
+                                                                             .withDescription(moduleConfig.getDescription())
+                                                                             .withPath(moduleConfig.getPath())
+                                                                             .withType(moduleConfig.getType())
+                                                                             .withAttributes(moduleConfig.getAttributes())
+                                                                             .withMixins(moduleConfig.getMixins());
         if (moduleConfig.getModules() != null) {
             final List<ModuleConfigDto> modules = moduleConfig.getModules()
                                                               .stream()
@@ -221,6 +223,17 @@ public final class DtoConverter {
                                                 .withDescription(workspace.getDescription());
     }
 
-    private DtoConverter() {
+    public static SnapshotDto asDto(Snapshot snapshot) {
+        return newDto(SnapshotDto.class).withId(snapshot.getId())
+                                        .withCreationDate(snapshot.getCreationDate())
+                                        .withDescription(snapshot.getDescription())
+                                        .withDev(snapshot.isDev())
+                                        .withOwner(snapshot.getOwner())
+                                        .withType(snapshot.getType())
+                                        .withWorkspaceId(snapshot.getWorkspaceId())
+                                        .withEnvName(snapshot.getEnvName())
+                                        .withMachineName(snapshot.getEnvName());
     }
+
+    private DtoConverter() {}
 }

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -27,7 +27,6 @@ import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.machine.server.MachineManager;
 import org.eclipse.che.api.machine.server.impl.SnapshotImpl;
-import org.eclipse.che.api.machine.server.model.impl.MachineImpl;
 import org.eclipse.che.api.machine.server.model.impl.MachineStateImpl;
 import org.eclipse.che.api.workspace.server.model.impl.EnvironmentStateImpl;
 import org.eclipse.che.api.workspace.server.model.impl.RuntimeWorkspaceImpl;
@@ -213,7 +212,7 @@ public class WorkspaceManager {
      * @throws ServerException
      *         when any other error occurs
      */
-    public List<SnapshotImpl>createSnapshot(String workspaceId) throws BadRequestException, NotFoundException, ServerException {
+    public List<SnapshotImpl> createSnapshot(String workspaceId) throws BadRequestException, NotFoundException, ServerException {
         requiredNotNull(workspaceId, "Required non-null workspace id");
 
         final RuntimeWorkspaceImpl workspace = workspaceRegistry.get(workspaceId);
@@ -226,6 +225,26 @@ public class WorkspaceManager {
             }
         }
         return snapshots;
+    }
+
+    /**
+     * Returns list of machine snapshots which are related to workspace with given id.
+     *
+     * @param workspaceId
+     *         workspace id to get snapshot
+     * @return list of machine snapshots related to given workspace
+     * @throws BadRequestException
+     *         when {@code workspaceId} is null
+     * @throws NotFoundException
+     *         when workspace with given id doesn't exists
+     * @throws ServerException
+     *         when any other error occurs
+     */
+    public List<SnapshotImpl> getSnapshot(String workspaceId) throws ServerException, BadRequestException, NotFoundException {
+        requiredNotNull(workspaceId, "Required non-null workspace id");
+        // check if workspace exists
+        workspaceDao.get(workspaceId);
+        return machineManager.getSnapshots(getCurrentUserId(), workspaceId);
     }
 
     /**

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -278,17 +278,12 @@ public class WorkspaceService extends Service {
 
     @POST
     @Path("/{id}/snapshot")
-    @Produces(APPLICATION_JSON)
     @RolesAllowed("user")
-    public List<SnapshotDto> createSnapshot(@PathParam("id") String workspaceId)
+    public void createSnapshot(@PathParam("id") String workspaceId)
             throws BadRequestException, ForbiddenException, NotFoundException, ServerException {
         ensureUserIsWorkspaceOwner(workspaceId);
 
-        return workspaceManager.createSnapshot(workspaceId)
-                               .stream()
-                               .map(DtoConverter::asDto)
-                               .map(this::injectLinks)
-                               .collect(toList());
+        workspaceManager.createSnapshot(workspaceId);
     }
 
     @GET

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/EnvironmentStateImpl.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/EnvironmentStateImpl.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.api.workspace.server.model.impl;
 
 import org.eclipse.che.api.core.model.machine.MachineConfig;
-import org.eclipse.che.api.core.model.machine.MachineState;
 import org.eclipse.che.api.core.model.machine.Recipe;
 import org.eclipse.che.api.core.model.workspace.Environment;
 import org.eclipse.che.api.core.model.workspace.EnvironmentState;

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/EnvironmentStateImpl.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/EnvironmentStateImpl.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.api.workspace.server.model.impl;
 
 import org.eclipse.che.api.core.model.machine.MachineConfig;
+import org.eclipse.che.api.core.model.machine.MachineState;
 import org.eclipse.che.api.core.model.machine.Recipe;
 import org.eclipse.che.api.core.model.workspace.Environment;
 import org.eclipse.che.api.core.model.workspace.EnvironmentState;

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/RuntimeWorkspaceImpl.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/RuntimeWorkspaceImpl.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.workspace.server.model.impl;
 import org.eclipse.che.api.core.model.machine.Command;
 import org.eclipse.che.api.core.model.workspace.Environment;
 import org.eclipse.che.api.core.model.machine.Machine;
+import org.eclipse.che.api.core.model.workspace.EnvironmentState;
 import org.eclipse.che.api.core.model.workspace.ProjectConfig;
 import org.eclipse.che.api.core.model.workspace.RuntimeWorkspace;
 import org.eclipse.che.api.core.model.workspace.UsersWorkspace;
@@ -141,7 +142,7 @@ public class RuntimeWorkspaceImpl extends UsersWorkspaceImpl implements RuntimeW
         this.activeEnvName = activeEnvName;
     }
     
-    public Environment getActiveEnvironment() {
+    public EnvironmentStateImpl getActiveEnvironment() {
         return getEnvironments().get(activeEnvName);
     }
 

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/shared/dto/event/WorkspaceStatusEvent.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/shared/dto/event/WorkspaceStatusEvent.java
@@ -22,7 +22,7 @@ import org.eclipse.che.dto.shared.DTO;
 @DTO
 public interface WorkspaceStatusEvent {
     enum EventType {
-        STARTING, RUNNING, STOPPING, STOPPED, ERROR
+        STARTING, RUNNING, STOPPING, STOPPED, ERROR, SNAPSHOT_CREATED, SNAPSHOT_CREATION_ERROR
     }
 
     EventType getEventType();


### PR DESCRIPTION
This PR contains server/client logic for adding ability to create and recover from snapshots.

* Client
  * Added _Create Snapshot_ menu item to _Machine_ menu
  * Added start workspace logic which asks user if he wants to recover workspace from snapshot(if snapshot for this workspace exists) .
* Server
  * Changed `Snapshot` model (basically added _machineName_ and _envName_)
  * Added local implementation for `SnapshotDao` 
  * Added new API methods related to snapshots management and workspace recovering

@skabashnyuk, @garagatyi, @akorneta, @sleshchenko  please take a look
   