### PR TITLE
Remove gwt compiling for IE9

### DIFF
--- a/commons/che-core-commons-gwt/src/main/resources/org/eclipse/che/ide/Commons.gwt.xml
+++ b/commons/che-core-commons-gwt/src/main/resources/org/eclipse/che/ide/Commons.gwt.xml
@@ -19,33 +19,22 @@
 
     <source path=""/>
 
+    <set-property name="user.agent" value="safari, gecko1_8"/>
+
     <!-- Allow for conditional compilation per user.agent with a single "if": -->
-    <set-property name="user.agent" value="safari, gecko1_8, ie9"/>
     <replace-with class="org.eclipse.che.ide.util.browser.UserAgentStaticProperties.FirefoxImpl">
         <when-type-is class="org.eclipse.che.ide.util.browser.UserAgentStaticProperties"/>
         <when-property-is name="user.agent" value="gecko1_8"/>
     </replace-with>
 
-    <replace-with class="org.eclipse.che.ide.util.browser.UserAgentStaticProperties.IEImpl">
-        <when-type-is class="org.eclipse.che.ide.util.browser.UserAgentStaticProperties"/>
-
-        <any>
-            <when-property-is name="user.agent" value="ie6"/>
-            <when-property-is name="user.agent" value="ie8"/>
-            <when-property-is name="user.agent" value="ie9"/>
-        </any>
+    <replace-with class="org.eclipse.che.ide.util.browser.BrowserUtils.Firefox">
+        <when-type-is class="org.eclipse.che.ide.util.browser.BrowserUtils"/>
+        <when-property-is name="user.agent" value="gecko1_8"/>
     </replace-with>
-
-    <!-- Restrict the build to Chrome, FF and english only for now. -->
-    <set-property name="user.agent" value="safari,gecko1_8"/>
 
     <replace-with class="org.eclipse.che.ide.util.browser.BrowserUtils.Chrome">
         <when-type-is class="org.eclipse.che.ide.util.browser.BrowserUtils"/>
         <when-property-is name="user.agent" value="safari"/>
-    </replace-with>
-    <replace-with class="org.eclipse.che.ide.util.browser.BrowserUtils.Firefox">
-        <when-type-is class="org.eclipse.che.ide.util.browser.BrowserUtils"/>
-        <when-property-is name="user.agent" value="gecko1_8"/>
     </replace-with>
 
     <!-- Following rules are order dependent: android and iphone have to come after "simple" safari -->


### PR DESCRIPTION
@vparfonov @evidolob @azatsarynnyy I removed settings for ie9. 
And I have question: Will it work https://github.com/codenvy/che-core/blob/784fed052d53ea3d98c1232936afeb68a2d0e90b/commons/che-core-commons-gwt/src/main/resources/org/eclipse/che/ide/Commons.gwt.xml#L46-L54 if we don't set user agent to android and iphone?