### PR TITLE
Safe /project/{ws}/item/{path} if parent project or item is missing

### DIFF
--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
@@ -1250,7 +1250,22 @@ public class ProjectService extends Service {
                    ProjectTypeConstraintException {
 
         Project project = projectManager.getProject(workspace, projectPath(path));
-        final VirtualFileEntry entry = project.getItem(path);
+        final VirtualFileEntry entry;
+        if (project != null) {
+            // If there is a project, allow it to intercept getting file meta-data
+            entry = project.getItem(path);
+        } else {
+            // If there is no project, try to retrieve the item directly
+            FolderEntry wsRoot = projectManager.getProjectsRoot(workspace);
+            if (wsRoot != null) {
+                entry = wsRoot.getChild(path);
+            } else {
+                entry = null;
+            }
+        }
+        if (entry == null) {
+            throw new NotFoundException(path);
+        }
 
         final UriBuilder uriBuilder = getServiceContext().getServiceUriBuilder();
 

--- a/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
+++ b/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectServiceTest.java
@@ -2306,6 +2306,29 @@ public class ProjectServiceTest {
 
     }
 
+    @Test
+    public void testGetItemWithoutParentProject() throws Exception {
+        FolderEntry a = pm.getProjectsRoot(workspace).createFolder("a");
+        a.createFile("test.txt", "test".getBytes(), MediaType.TEXT_PLAIN);
+        ContainerResponse response = launcher.service(HttpMethod.GET,
+                String.format("http://localhost:8080/api/project/%s/item/a/test.txt",
+                        workspace),
+                "http://localhost:8080/api", null, null, null);
+        assertEquals(response.getStatus(), 200, "Error: " + response.getEntity());
+        ItemReference result = (ItemReference)response.getEntity();
+        assertEquals(result.getType(), "file");
+        assertEquals(result.getMediaType(), MediaType.TEXT_PLAIN);
+    }
+
+    @Test
+    public void testGetMissingItem() throws Exception {
+        ContainerResponse response = launcher.service(HttpMethod.GET,
+                String.format("http://localhost:8080/api/project/%s/item/some_missing_project/a/b",
+                        workspace),
+                "http://localhost:8080/api", null, null, null);
+        assertEquals(response.getStatus(), 404, "Error: " + response.getEntity());
+    }
+
 
     @Test
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
If the item is missing, return 404 instead of 500 NPE
If the item is not inside a project, retrieve without 500 NPE

Signed-off-by: Tareq Sharafy <tareq.sha@gmail.com>