### PR TITLE
Support for maxItems, skipCount query parameters - Search API

### DIFF
--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/DefaultSearchResult.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/DefaultSearchResult.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.vfs.server.search;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ * @author I307348 - Ori Libhaber - ori.libhaber@sap.com
+ */
+public class DefaultSearchResult<T> implements SearchResult<T>{
+
+    private final List<T> result;
+    private final Map<String, String> metadata;
+
+    public DefaultSearchResult(List<T> result, Map<String, String> metadata) {
+        this.result = result;
+        this.metadata = metadata;
+    }
+    
+    public DefaultSearchResult(T[] result, Map<String, String> metadata){
+        this(Arrays.asList(result),metadata);
+    }
+
+    public DefaultSearchResult(T[] result) {
+        this(result, new LinkedHashMap<>());
+    }
+
+    @Override
+    public List<T> getResult() {
+        return Collections.synchronizedList(Collections.unmodifiableList(result));
+    }
+
+    @Override
+    public Map<String, String> getMetadata() {
+        return Collections.synchronizedMap(Collections.unmodifiableMap(metadata));
+    }
+
+}

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/QueryExpression.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/QueryExpression.java
@@ -16,6 +16,7 @@ public class QueryExpression {
     private String path;
     private String mediaType;
     private String text;
+    private int maxItems;
 
     public String getPath() {
         return path;
@@ -55,11 +56,21 @@ public class QueryExpression {
 
     @Override
     public String toString() {
-        return "QueryExpression{" +
-               "name='" + name + '\'' +
-               ", path='" + path + '\'' +
-               ", mediaType='" + mediaType + '\'' +
-               ", text='" + text + '\'' +
-               '}';
+        return String.format("QueryExpression{name='%s', path='%s', mediaType='%s', text='%s',maxItems='%d'}", 
+                name, 
+                path,
+                mediaType,
+                text,
+                maxItems
+        );
+    }
+
+    public int getMaxItems() {
+        return maxItems;
+}
+
+    public QueryExpression setMaxItems(int maxItems) {
+        this.maxItems = maxItems;
+        return this;
     }
 }

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/SearchResult.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/SearchResult.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.vfs.server.search;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ * @author I307348 - Ori Libhaber - ori.libhaber@sap.com
+ */
+public interface SearchResult<T> {
+    
+    public static final String TOTAL_HITS = "totalhits";
+    public static final String TIME = "time";
+    
+    /**
+     * get result of search as {@code List<T>}
+     * @return {@code synchronized unmodifiable List<T>} containing the search result
+     */
+    public List<T> getResult();
+
+    /**
+     * get search meta data as {@code Map<String,String>}
+     * @return {@code synchronized unmodifiable Map<String, String>} containing the search meta data
+     */
+    public Map<String, String> getMetadata();
+
+}

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/SearcherWithMetadata.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/SearcherWithMetadata.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.vfs.server.search;
+
+import org.eclipse.che.api.core.ServerException;
+
+/**
+ *
+ * @author I307348 - Ori Libhaber - ori.libhaber@sap.com
+ */
+public interface SearcherWithMetadata<T> extends Searcher{
+    
+    public default SearchResult<T> searchWithMetadata(QueryExpression query) throws ServerException{
+        String[] search = search(query);
+        SearchResult<String> result = new DefaultSearchResult<>(search);
+        return (SearchResult<T>) result;
+    }
+    
+}


### PR DESCRIPTION
1. Added support for <b>maxItems</b> and <b>skipCount</b> query parameters, as described in email thread:<br>
<b>[che-dev] Search API</b>
2. Search result is now <b>encapsulated in SearchResult object</b> which provides additional metadata on search.