### PR TITLE
Improve using of async requests

### DIFF
--- a/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/api/promises/client/callback/PromiseHelper.java
+++ b/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/api/promises/client/callback/PromiseHelper.java
@@ -26,7 +26,11 @@ import static org.eclipse.che.api.promises.client.callback.AsyncPromiseHelper.cr
  * Helps to combine promises with async requests.
  *
  * @author Artem Zatsarynnyi
+ * @see org.eclipse.che.ide.rest.AsyncRequest#send()
+ * @see org.eclipse.che.ide.rest.AsyncRequest#send(org.eclipse.che.ide.rest.Unmarshallable)
+ * @deprecated since org.eclipse.che.ide.rest.AsyncRequest#send() returns Promise
  */
+@Deprecated
 public class PromiseHelper {
 
     /** Not instantiable. */
@@ -36,7 +40,12 @@ public class PromiseHelper {
     /**
      * Creates new {@link Promise} from the given {@code requestCall}.
      * When the promise is rejected - an error will be logged to the browser's console.
+     *
+     * @see org.eclipse.che.ide.rest.AsyncRequest#send()
+     * @see org.eclipse.che.ide.rest.AsyncRequest#send(org.eclipse.che.ide.rest.Unmarshallable)
+     * @deprecated since org.eclipse.che.ide.rest.AsyncRequest#send() returns Promise
      */
+    @Deprecated
     public static <T> Promise<T> newPromise(AsyncPromiseHelper.RequestCall<T> requestCall) {
         final Promise<T> promise = createFromAsyncRequest(requestCall);
         promise.catchError(new Operation<PromiseError>() {
@@ -48,7 +57,14 @@ public class PromiseHelper {
         return promise;
     }
 
-    /** Creates new {@link AsyncRequestCallback} that returns {@code Void} value and invokes the given {@code callback}. */
+    /**
+     * Creates new {@link AsyncRequestCallback} that returns {@code Void} value and invokes the given {@code callback}.
+     *
+     * @see org.eclipse.che.ide.rest.AsyncRequest#send()
+     * @see org.eclipse.che.ide.rest.AsyncRequest#send(org.eclipse.che.ide.rest.Unmarshallable)
+     * @deprecated since org.eclipse.che.ide.rest.AsyncRequest#send() returns Promise
+     */
+    @Deprecated
     public static AsyncRequestCallback<Void> newCallback(final AsyncCallback<Void> callback) {
         return new AsyncRequestCallback<Void>() {
             @Override
@@ -63,7 +79,14 @@ public class PromiseHelper {
         };
     }
 
-    /** Creates new {@link AsyncRequestCallback} that invokes the given {@code callback}. */
+    /**
+     * Creates new {@link AsyncRequestCallback} that invokes the given {@code callback}.
+     *
+     * @see org.eclipse.che.ide.rest.AsyncRequest#send()
+     * @see org.eclipse.che.ide.rest.AsyncRequest#send(org.eclipse.che.ide.rest.Unmarshallable)
+     * @deprecated since org.eclipse.che.ide.rest.AsyncRequest#send() returns Promise
+     */
+    @Deprecated
     public static <T> AsyncRequestCallback<T> newCallback(final AsyncCallback<T> callback, Unmarshallable<T> unmarshallable) {
         return new AsyncRequestCallback<T>(unmarshallable) {
             @Override

--- a/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/ide/rest/AsyncRequest.java
+++ b/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/ide/rest/AsyncRequest.java
@@ -17,9 +17,7 @@ import com.google.gwt.http.client.RequestBuilder.Method;
 import com.google.gwt.http.client.RequestCallback;
 import com.google.gwt.http.client.RequestException;
 import com.google.gwt.http.client.Response;
-import com.google.gwt.http.client.URL;
 import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.Window.Location;
 
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.callback.CallbackPromiseHelper;
@@ -68,34 +66,12 @@ public class AsyncRequest {
             }
         }
 
-        this.requestBuilder = new RequestBuilder(method, getCheckedURL(url));
+        this.requestBuilder = new RequestBuilder(method, url);
         this.loader = new EmptyLoader();
         this.async = async;
         this.checkAsyncTaskStatusTimer = new CheckEverRestTaskStatusTimer();
         this.asyncRequestCallback = new EverRestAsyncRequestCallback();
     }
-
-    private static String getCheckedURL(String url) {
-        final String proxyServiceContext = getProxyServiceContext();
-        if (proxyServiceContext == null || "".equals(proxyServiceContext)) {
-            return url;
-        }
-
-        if (!(url.startsWith("http://") || url.startsWith("https://"))) {
-            return url;
-        }
-
-        final String currentHost = Location.getProtocol() + "//" + Location.getHost();
-        if (url.startsWith(currentHost)) {
-            return url;
-        }
-
-        return proxyServiceContext + "?url=" + URL.encodeQueryString(url);
-    }
-
-    private static native String getProxyServiceContext() /*-{
-        return $wnd.proxyServiceContext;
-    }-*/;
 
     public final AsyncRequest header(String header, String value) {
         requestBuilder.setHeader(header, value);

--- a/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/ide/rest/AsyncRequest.java
+++ b/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/ide/rest/AsyncRequest.java
@@ -10,8 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.ide.rest;
 
-import org.eclipse.che.ide.commons.exception.JobNotFoundException;
-import org.eclipse.che.ide.commons.exception.ServerException;
+import com.google.gwt.core.client.Callback;
 import com.google.gwt.http.client.Request;
 import com.google.gwt.http.client.RequestBuilder;
 import com.google.gwt.http.client.RequestBuilder.Method;
@@ -22,86 +21,31 @@ import com.google.gwt.http.client.URL;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window.Location;
 
-/** Wrapper under RequestBuilder to simplify the stuffs. */
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.callback.CallbackPromiseHelper;
+import org.eclipse.che.ide.commons.exception.JobNotFoundException;
+import org.eclipse.che.ide.commons.exception.ServerException;
+
+import static com.google.gwt.http.client.Response.SC_ACCEPTED;
+import static com.google.gwt.http.client.Response.SC_NOT_FOUND;
+
+/**
+ * Wrapper under {@link RequestBuilder} to simplify the stuffs.
+ *
+ * @author Artem Zatsarynnyi
+ */
 public class AsyncRequest {
-    protected RequestBuilder     builder;
-    protected AsyncRequestLoader loader;
-    protected boolean            async;
-    protected String             loaderMessage;
-    protected int delay = 5000;
-    protected RequestStatusHandler    handler;
-    protected String                  requestStatusUrl;
-    private   AsyncRequestCallback<?> callback;
-    private AsyncRequestCallback<String> initCallback = new AsyncRequestCallback<String>(new LocationUnmarshaller()) {
-        {
-            setSuccessCodes(new int[]{Response.SC_ACCEPTED});
-        }
+    protected RequestBuilder requestBuilder;
+    protected int asyncTaskCheckingPeriodMillis = 5000;
 
-        @Override
-        protected void onSuccess(String result) {
-            requestStatusUrl = result;
-            if (handler != null) {
-                handler.requestInProgress(requestStatusUrl);
-            }
-
-            requestTimer.schedule(delay);
-        }
-
-        @Override
-        protected void onFailure(Throwable exception) {
-            if (handler != null) {
-                handler.requestError(requestStatusUrl, exception);
-            }
-            callback.onError(null, exception);
-        }
-    };
-    private Timer requestTimer = new Timer() {
-        @Override
-        public void run() {
-            RequestBuilder request = new RequestBuilder(RequestBuilder.GET, requestStatusUrl);
-            request.setCallback(new RequestCallback() {
-
-                public void onResponseReceived(Request request, Response response) {
-                    if (Response.SC_NOT_FOUND == response.getStatusCode()) {
-                        callback.onError(request, new JobNotFoundException(response));
-                        if (handler != null) {
-                            handler.requestError(requestStatusUrl, new JobNotFoundException(response));
-                        }
-                    } else if (response.getStatusCode() != Response.SC_ACCEPTED) {
-                        callback.onResponseReceived(request, response);
-                        if (handler != null) {
-                            // check is response successful, for correct handling failed responses
-                            if (callback.isSuccessful(response))
-                                handler.requestFinished(requestStatusUrl);
-                            else
-                                handler.requestError(requestStatusUrl, new ServerException(response));
-                        }
-                    } else {
-                        if (handler != null)
-                            handler.requestInProgress(requestStatusUrl);
-
-                        requestTimer.schedule(delay);
-                    }
-                }
-
-                public void onError(Request request, Throwable exception) {
-                    if (handler != null)
-                        handler.requestError(requestStatusUrl, exception);
-
-                    callback.onError(request, exception);
-                }
-            });
-            try {
-                request.send();
-            } catch (RequestException e) {
-                e.printStackTrace();
-                if (handler != null) {
-                    handler.requestError(requestStatusUrl, e);
-                }
-                callback.onFailure(e);
-            }
-        }
-    };
+    private AsyncRequestCallback<?>      callback;
+    private boolean                      async;
+    private Timer                        checkAsyncTaskStatusTimer;
+    private AsyncRequestCallback<String> asyncRequestCallback;
+    private String                       asyncTaskStatusURL;
+    private AsyncRequestLoader           loader;
+    private String                       loaderMessage;
+    private RequestStatusHandler         asyncTaskStatusHandler;
 
     /**
      * Create new {@link AsyncRequest} instance.
@@ -111,7 +55,9 @@ public class AsyncRequest {
      * @param url
      *         request URL
      * @param async
-     *         if <b>true</b> - request will be sent in asynchronous mode
+     *         if {@code true} - request will be send in asynchronous mode (as asynchronous EverRest task).<br>
+     *         See <a href="https://github.com/codenvy/everrest/wiki/Asynchronous-Requests">
+     *         EverRest Asynchronous requests</a> for details.
      */
     protected AsyncRequest(Method method, String url, boolean async) {
         if (async) {
@@ -121,32 +67,16 @@ public class AsyncRequest {
                 url += "?async=true";
             }
         }
-        this.builder = new RequestBuilder(method, getCheckedURL(url));
+
+        this.requestBuilder = new RequestBuilder(method, getCheckedURL(url));
         this.loader = new EmptyLoader();
         this.async = async;
+        this.checkAsyncTaskStatusTimer = new CheckEverRestTaskStatusTimer();
+        this.asyncRequestCallback = new EverRestAsyncRequestCallback();
     }
-
-    /** @deprecated use {@link AsyncRequestFactory} instead. */
-    @Deprecated
-    protected AsyncRequest(RequestBuilder builder) {
-        this.builder = builder;
-        this.loader = new EmptyLoader();
-        async = false;
-    }
-
-    /** @deprecated use {@link AsyncRequestFactory} instead. */
-    @Deprecated
-    protected AsyncRequest(RequestBuilder builder, boolean async) {
-        this(builder);
-        this.async = async;
-    }
-
-    private static native String getProxyServiceContext() /*-{
-        return $wnd.proxyServiceContext;
-    }-*/;
 
     private static String getCheckedURL(String url) {
-        String proxyServiceContext = getProxyServiceContext();
+        final String proxyServiceContext = getProxyServiceContext();
         if (proxyServiceContext == null || "".equals(proxyServiceContext)) {
             return url;
         }
@@ -155,7 +85,7 @@ public class AsyncRequest {
             return url;
         }
 
-        String currentHost = Location.getProtocol() + "//" + Location.getHost();
+        final String currentHost = Location.getProtocol() + "//" + Location.getHost();
         if (url.startsWith(currentHost)) {
             return url;
         }
@@ -163,54 +93,27 @@ public class AsyncRequest {
         return proxyServiceContext + "?url=" + URL.encodeQueryString(url);
     }
 
-    /** @deprecated use {@link AsyncRequestFactory} instead. */
-    @Deprecated
-    public static final AsyncRequest build(Method method, String url) {
-        return build(method, url, false);
-    }
-
-    /**
-     * Build AsyncRequest with run REST Service in async mode.
-     *
-     * @param method
-     *         HTTP method
-     * @param url
-     *         of service
-     * @param async
-     *         is run async
-     * @return instance of {@link AsyncRequest}
-     * @deprecated use {@link AsyncRequestFactory} instead.
-     */
-    @Deprecated
-    public static final AsyncRequest build(Method method, String url, boolean async) {
-        if (async) {
-            if (url.contains("?")) {
-                url += "&async=true";
-            } else {
-                url += "?async=true";
-            }
-        }
-        String checkedURL = getCheckedURL(url);
-        return new AsyncRequest(new RequestBuilder(method, checkedURL), async);
-    }
+    private static native String getProxyServiceContext() /*-{
+        return $wnd.proxyServiceContext;
+    }-*/;
 
     public final AsyncRequest header(String header, String value) {
-        builder.setHeader(header, value);
+        requestBuilder.setHeader(header, value);
         return this;
     }
 
     public final AsyncRequest user(String user) {
-        builder.setUser(user);
+        requestBuilder.setUser(user);
         return this;
     }
 
     public final AsyncRequest password(String password) {
-        builder.setPassword(password);
+        requestBuilder.setPassword(password);
         return this;
     }
 
     public final AsyncRequest data(String requestData) {
-        builder.setRequestData(requestData);
+        requestBuilder.setRequestData(requestData);
         return this;
     }
 
@@ -226,41 +129,78 @@ public class AsyncRequest {
     }
 
     /**
-     * Set delay between requests to async REST Service<br>
-     * (Default: 5000 ms).
+     * Set period for checking asynchronous task status. (5000 ms by default).<br>
+     * Makes sense for request sent in async mode only.
      *
-     * @param delay
-     *         the amount of time to wait between request resending (in milliseconds)
-     * @return this {@code AsyncRequest}
+     * @param period
+     *         period of checking asynchronous task status (in milliseconds)
+     * @return this {@link AsyncRequest}
      */
-    public final AsyncRequest delay(int delay) {
-        this.delay = delay;
+    public final AsyncRequest period(int period) {
+        this.asyncTaskCheckingPeriodMillis = period;
         return this;
     }
 
     /**
-     * Set handler of async REST Service status.
+     * Set handler of async task status. Makes sense for request sent in async mode only.
      *
      * @param handler
-     * @return
+     *         handler to set
+     * @return this {@link AsyncRequest}
      */
     public final AsyncRequest requestStatusHandler(RequestStatusHandler handler) {
-        this.handler = handler;
+        this.asyncTaskStatusHandler = handler;
         return this;
     }
 
-    private void sendRequest(AsyncRequestCallback<?> callback) throws RequestException {
-        callback.setLoader(loader, loaderMessage);
-        callback.setRequest(this);
-        builder.setCallback(callback);
+    /**
+     * Sends an HTTP request based on the current {@link AsyncRequest} configuration.
+     *
+     * @return promise that may be resolved with the {@link Void} or rejected in case request error
+     */
+    public final Promise<Void> send() {
+        return CallbackPromiseHelper.createFromCallback(new CallbackPromiseHelper.Call<Void, Throwable>() {
+            @Override
+            public void makeCall(final Callback<Void, Throwable> callback) {
+                send(new AsyncRequestCallback<Void>() {
+                    @Override
+                    protected void onSuccess(Void result) {
+                        callback.onSuccess(null);
+                    }
 
-        if (loaderMessage == null) {
-            loader.show();
-        } else {
-            loader.show(loaderMessage);
-        }
+                    @Override
+                    protected void onFailure(Throwable exception) {
+                        callback.onFailure(exception);
+                    }
+                });
+            }
+        });
+    }
 
-        builder.send();
+    /**
+     * Sends an HTTP request based on the current {@link AsyncRequest} configuration.
+     *
+     * @param unmarshaller
+     *         unmarshaller that should be used to deserialize a response
+     * @return promise that may be resolved with the deserialized response value or rejected in case request error
+     */
+    public final <R> Promise<R> send(final Unmarshallable<R> unmarshaller) {
+        return CallbackPromiseHelper.createFromCallback(new CallbackPromiseHelper.Call<R, Throwable>() {
+            @Override
+            public void makeCall(final Callback<R, Throwable> callback) {
+                send(new AsyncRequestCallback<R>(unmarshaller) {
+                    @Override
+                    protected void onSuccess(R result) {
+                        callback.onSuccess(result);
+                    }
+
+                    @Override
+                    protected void onFailure(Throwable exception) {
+                        callback.onFailure(exception);
+                    }
+                });
+            }
+        });
     }
 
     /**
@@ -274,13 +214,27 @@ public class AsyncRequest {
         try {
             if (async) {
                 this.callback.setRequest(this);
-                sendRequest(initCallback);
+                sendRequest(asyncRequestCallback);
             } else {
                 sendRequest(callback);
             }
         } catch (RequestException e) {
             callback.onFailure(e);
         }
+    }
+
+    private void sendRequest(AsyncRequestCallback<?> callback) throws RequestException {
+        callback.setLoader(loader, loaderMessage);
+        callback.setRequest(this);
+        requestBuilder.setCallback(callback);
+
+        if (loaderMessage == null) {
+            loader.show();
+        } else {
+            loader.show(loaderMessage);
+        }
+
+        requestBuilder.send();
     }
 
     /**
@@ -292,6 +246,10 @@ public class AsyncRequest {
         return callback;
     }
 
+    public RequestBuilder getRequestBuilder() {
+        return requestBuilder;
+    }
+
     private class EmptyLoader implements AsyncRequestLoader {
         @Override
         public void hide() {
@@ -299,7 +257,6 @@ public class AsyncRequest {
 
         @Override
         public void hide(String message) {
-
         }
 
         @Override
@@ -308,11 +265,84 @@ public class AsyncRequest {
 
         @Override
         public void show(String message) {
-
         }
     }
 
-    public RequestBuilder getRequestBuilder() {
-        return builder;
+    /** Timer that checks status of the EverRest asynchronous task caused by this request. */
+    private class CheckEverRestTaskStatusTimer extends Timer {
+        @Override
+        public void run() {
+            final RequestBuilder requestBuilder = new RequestBuilder(RequestBuilder.GET, asyncTaskStatusURL);
+            requestBuilder.setCallback(new RequestCallback() {
+                @Override
+                public void onResponseReceived(Request request, Response response) {
+                    if (SC_NOT_FOUND == response.getStatusCode()) {
+                        callback.onError(request, new JobNotFoundException(response));
+                        if (asyncTaskStatusHandler != null) {
+                            asyncTaskStatusHandler.requestError(asyncTaskStatusURL, new JobNotFoundException(response));
+                        }
+                    } else if (response.getStatusCode() != SC_ACCEPTED) {
+                        callback.onResponseReceived(request, response);
+                        if (asyncTaskStatusHandler != null) {
+                            // check is response successful, for correct handling failed responses
+                            if (callback.isSuccessful(response)) {
+                                asyncTaskStatusHandler.requestFinished(asyncTaskStatusURL);
+                            } else {
+                                asyncTaskStatusHandler.requestError(asyncTaskStatusURL, new ServerException(response));
+                            }
+                        }
+                    } else {
+                        if (asyncTaskStatusHandler != null) {
+                            asyncTaskStatusHandler.requestInProgress(asyncTaskStatusURL);
+                        }
+                        CheckEverRestTaskStatusTimer.this.schedule(asyncTaskCheckingPeriodMillis);
+                    }
+                }
+
+                @Override
+                public void onError(Request request, Throwable exception) {
+                    if (asyncTaskStatusHandler != null) {
+                        asyncTaskStatusHandler.requestError(asyncTaskStatusURL, exception);
+                    }
+
+                    callback.onError(request, exception);
+                }
+            });
+
+            try {
+                requestBuilder.send();
+            } catch (RequestException e) {
+                if (asyncTaskStatusHandler != null) {
+                    asyncTaskStatusHandler.requestError(asyncTaskStatusURL, e);
+                }
+                callback.onFailure(e);
+            }
+        }
+    }
+
+    /** Callback that will be called on response to a request that was sent in EverRest async mode. */
+    private class EverRestAsyncRequestCallback extends AsyncRequestCallback<String> {
+
+        EverRestAsyncRequestCallback() {
+            super(new LocationUnmarshaller());
+            setSuccessCodes(new int[]{SC_ACCEPTED});
+        }
+
+        @Override
+        protected void onSuccess(String result) {
+            asyncTaskStatusURL = result;
+            if (asyncTaskStatusHandler != null) {
+                asyncTaskStatusHandler.requestInProgress(asyncTaskStatusURL);
+            }
+            checkAsyncTaskStatusTimer.schedule(asyncTaskCheckingPeriodMillis);
+        }
+
+        @Override
+        protected void onFailure(Throwable exception) {
+            if (asyncTaskStatusHandler != null) {
+                asyncTaskStatusHandler.requestError(asyncTaskStatusURL, exception);
+            }
+            callback.onError(null, exception);
+        }
     }
 }

--- a/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/MachineServiceClient.java
+++ b/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/MachineServiceClient.java
@@ -43,17 +43,7 @@ public interface MachineServiceClient {
     Promise<MachineStateDto> getMachineState(@NotNull String machineId);
 
     /**
-     * Find machines bound to the workspace/project.
-     *
-     * @param workspaceId workspace id
-     * @param projectPath
-     *         project binding. If {@code projectPath} is {@code null} returns machines which bound to the current workspace,
-     *         if {@code projectPath} is not {@code null} - returns machines which bound to the specified project
-     */
-    Promise<List<MachineDto>> getMachines(@NotNull String workspaceId, @Nullable String projectPath);
-
-    /**
-     * Returns list of machines which are bounded to current workspace.
+     * Returns list of machines which are bounded to the specified workspace.
      *
      * @param workspaceId
      *         workspace id
@@ -62,14 +52,11 @@ public interface MachineServiceClient {
     Promise<List<MachineDto>> getWorkspaceMachines(String workspaceId);
 
     /**
-     * Find machines states bound to the workspace/project.
+     * Find machines states bound to the workspace.
      *
      * @param workspaceId workspace id
-     * @param projectPath
-     *         project binding. If {@code projectPath} is {@code null} returns machines which bound to the current workspace,
-     *         if {@code projectPath} is not {@code null} - returns machines which bound to the specified project
      */
-    Promise<List<MachineStateDto>> getMachinesStates(@NotNull String workspaceId, @Nullable String projectPath);
+    Promise<List<MachineStateDto>> getMachinesStates(@NotNull String workspaceId);
 
     /**
      * Destroy machine with the specified ID.

--- a/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/MachineServiceClientImpl.java
+++ b/platform-api-client-gwt/che-core-client-gwt-machine/src/main/java/org/eclipse/che/api/machine/gwt/client/MachineServiceClientImpl.java
@@ -10,17 +10,13 @@
  *******************************************************************************/
 package org.eclipse.che.api.machine.gwt.client;
 
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 
 import org.eclipse.che.api.machine.shared.dto.CommandDto;
 import org.eclipse.che.api.machine.shared.dto.MachineDto;
 import org.eclipse.che.api.machine.shared.dto.MachineProcessDto;
 import org.eclipse.che.api.machine.shared.dto.MachineStateDto;
-import org.eclipse.che.api.promises.client.Function;
-import org.eclipse.che.api.promises.client.FunctionException;
 import org.eclipse.che.api.promises.client.Promise;
-import org.eclipse.che.api.promises.client.callback.AsyncPromiseHelper.RequestCall;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.rest.AsyncRequestFactory;
@@ -30,19 +26,16 @@ import org.eclipse.che.ide.rest.RestContext;
 import org.eclipse.che.ide.rest.StringUnmarshaller;
 
 import javax.validation.constraints.NotNull;
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.gwt.http.client.RequestBuilder.DELETE;
-import static org.eclipse.che.api.promises.client.callback.PromiseHelper.newCallback;
-import static org.eclipse.che.api.promises.client.callback.PromiseHelper.newPromise;
 import static org.eclipse.che.ide.MimeType.APPLICATION_JSON;
 import static org.eclipse.che.ide.rest.HTTPHeader.ACCEPT;
 
 /**
  * Implementation for {@link MachineServiceClient}.
  *
- * @author Artem Zatsarynnyy
+ * @author Artem Zatsarynnyi
  * @author Dmitry Shnurenko
  */
 public class MachineServiceClientImpl implements MachineServiceClient {
@@ -65,256 +58,91 @@ public class MachineServiceClientImpl implements MachineServiceClient {
         this.baseHttpUrl = restContext + "/machine";
     }
 
-    /** {@inheritDoc} */
     @Override
     public Promise<MachineDto> getMachine(@NotNull final String machineId) {
-        return newPromise(new RequestCall<MachineDto>() {
-            @Override
-            public void makeCall(AsyncCallback<MachineDto> callback) {
-                getMachine(machineId, callback);
-            }
-        });
+        return asyncRequestFactory.createGetRequest(baseHttpUrl + '/' + machineId)
+                                  .header(ACCEPT, APPLICATION_JSON)
+                                  .loader(loader, "Getting info about machine...")
+                                  .send(dtoUnmarshallerFactory.newUnmarshaller(MachineDto.class));
     }
 
-    private void getMachine(@NotNull String machineId, @NotNull AsyncCallback<MachineDto> callback) {
-        final String url = baseHttpUrl + '/' + machineId;
-        asyncRequestFactory.createGetRequest(url)
-                           .header(ACCEPT, APPLICATION_JSON)
-                           .loader(loader, "Getting info about machine...")
-                           .send(newCallback(callback, dtoUnmarshallerFactory.newUnmarshaller(MachineDto.class)));
-    }
-
-    /** {@inheritDoc} */
     @Override
     public Promise<MachineStateDto> getMachineState(@NotNull final String machineId) {
-        return newPromise(new RequestCall<MachineStateDto>() {
-            @Override
-            public void makeCall(AsyncCallback<MachineStateDto> callback) {
-                getMachineState(machineId, callback);
-            }
-        });
+        return asyncRequestFactory.createGetRequest(baseHttpUrl + '/' + machineId + "/state")
+                                  .header(ACCEPT, APPLICATION_JSON)
+                                  .loader(loader, "Getting info about machine...")
+                                  .send(dtoUnmarshallerFactory.newUnmarshaller(MachineStateDto.class));
     }
 
-    private void getMachineState(@NotNull String machineId, @NotNull AsyncCallback<MachineStateDto> callback) {
-        final String url = baseHttpUrl + '/' + machineId + "/state";
-        asyncRequestFactory.createGetRequest(url)
-                           .header(ACCEPT, APPLICATION_JSON)
-                           .loader(loader, "Getting info about machine...")
-                           .send(newCallback(callback, dtoUnmarshallerFactory.newUnmarshaller(MachineStateDto.class)));
-    }
-
-    /** {@inheritDoc} */
     @Override
-    public Promise<List<MachineDto>> getMachines(@NotNull final String workspaceId, @Nullable final String projectPath) {
-        return newPromise(new RequestCall<List<MachineDto>>() {
-            @Override
-            public void makeCall(AsyncCallback<List<MachineDto>> callback) {
-                getMachines(workspaceId, projectPath, callback);
-            }
-        }).then(new Function<List<MachineDto>, List<MachineDto>>() {
-            @Override
-            public List<MachineDto> apply(List<MachineDto> arg) throws FunctionException {
-                final List<MachineDto> descriptors = new ArrayList<>();
-                for (MachineDto descriptor : arg) {
-                    descriptors.add(descriptor);
-                }
-                return descriptors;
-            }
-        });
+    public Promise<List<MachineDto>> getWorkspaceMachines(@NotNull String workspaceId) {
+        return asyncRequestFactory.createGetRequest(baseHttpUrl + "?workspace=" + workspaceId)
+                                  .header(ACCEPT, APPLICATION_JSON)
+                                  .loader(loader, "Getting info about bound machines...")
+                                  .send(dtoUnmarshallerFactory.newListUnmarshaller(MachineDto.class));
     }
 
-    /** {@inheritDoc} */
     @Override
-    public Promise<List<MachineDto>> getWorkspaceMachines(final String workspaceId) {
-        return newPromise(new RequestCall<List<MachineDto>>() {
-            @Override
-            public void makeCall(AsyncCallback<List<MachineDto>> callback) {
-                getMachines(workspaceId, null, callback);
-            }
-        }).then(new Function<List<MachineDto>, List<MachineDto>>() {
-            @Override
-            public List<MachineDto> apply(List<MachineDto> arg) throws FunctionException {
-                final List<MachineDto> descriptors = new ArrayList<>();
-                for (MachineDto descriptor : arg) {
-                    descriptors.add(descriptor);
-                }
-                return descriptors;
-            }
-        });
+    public Promise<List<MachineStateDto>> getMachinesStates(@NotNull final String workspaceId) {
+        return asyncRequestFactory.createGetRequest(baseHttpUrl + "/state" + "?workspace=" + workspaceId)
+                                  .header(ACCEPT, APPLICATION_JSON)
+                                  .loader(loader, "Getting info about bound machines...")
+                                  .send(dtoUnmarshallerFactory.newListUnmarshaller(MachineStateDto.class));
     }
 
-    private void getMachines(@NotNull String workspaceId, @Nullable String projectPath,
-                             @NotNull AsyncCallback<List<MachineDto>> callback) {
-        final String url = baseHttpUrl + "?workspace=" + workspaceId + (projectPath != null ? "&project=" + projectPath : "");
-        asyncRequestFactory.createGetRequest(url)
-                           .header(ACCEPT, APPLICATION_JSON)
-                           .loader(loader, "Getting info about bound machines...")
-                           .send(newCallback(callback, dtoUnmarshallerFactory.newListUnmarshaller(MachineDto.class)));
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Promise<List<MachineStateDto>> getMachinesStates(@NotNull final String workspaceId, @Nullable final String projectPath) {
-        return newPromise(new RequestCall<List<MachineStateDto>>() {
-            @Override
-            public void makeCall(AsyncCallback<List<MachineStateDto>> callback) {
-                getMachinesStates(workspaceId, projectPath, callback);
-            }
-        }).then(new Function<List<MachineStateDto>, List<MachineStateDto>>() {
-            @Override
-            public List<MachineStateDto> apply(List<MachineStateDto> arg) throws FunctionException {
-                final List<MachineStateDto> descriptors = new ArrayList<>();
-                for (MachineStateDto descriptor : arg) {
-                    descriptors.add(descriptor);
-                }
-                return descriptors;
-            }
-        });
-    }
-
-    private void getMachinesStates(@NotNull String workspaceId, @Nullable String projectPath,
-                                   @NotNull AsyncCallback<List<MachineStateDto>> callback) {
-        final String url = baseHttpUrl + "/state" + "?workspace=" + workspaceId + (projectPath != null ? "&project=" + projectPath : "");
-        asyncRequestFactory.createGetRequest(url)
-                           .header(ACCEPT, APPLICATION_JSON)
-                           .loader(loader, "Getting info about bound machines...")
-                           .send(newCallback(callback, dtoUnmarshallerFactory.newListUnmarshaller(MachineStateDto.class)));
-    }
-
-    /** {@inheritDoc} */
     @Override
     public Promise<Void> destroyMachine(@NotNull final String machineId) {
-        return newPromise(new RequestCall<Void>() {
-            @Override
-            public void makeCall(AsyncCallback<Void> callback) {
-                destroyMachine(machineId, callback);
-            }
-        });
-    }
-
-    private void destroyMachine(@NotNull String machineId, @NotNull AsyncCallback<Void> callback) {
-        asyncRequestFactory.createRequest(DELETE, baseHttpUrl + '/' + machineId, null, false)
+        return asyncRequestFactory.createRequest(DELETE, baseHttpUrl + '/' + machineId, null, false)
                            .loader(loader, "Destroying machine...")
-                           .send(newCallback(callback));
+                           .send();
     }
 
-    /** {@inheritDoc} */
     @Override
     public Promise<MachineProcessDto> executeCommand(@NotNull final String machineId,
                                                      @NotNull final String commandLine,
                                                      @Nullable final String outputChannel) {
-        return newPromise(new RequestCall<MachineProcessDto>() {
-            @Override
-            public void makeCall(AsyncCallback<MachineProcessDto> callback) {
-                executeCommand(machineId, commandLine, outputChannel, callback);
-            }
-        });
+        final CommandDto request = dtoFactory.createDto(CommandDto.class).withCommandLine(commandLine);
+        return asyncRequestFactory.createPostRequest(baseHttpUrl + '/' + machineId + "/command?outputChannel=" + outputChannel, request)
+                                  .header(ACCEPT, APPLICATION_JSON)
+                                  .loader(loader, "Executing command...")
+                                  .send(dtoUnmarshallerFactory.newUnmarshaller(MachineProcessDto.class));
     }
 
-    private void executeCommand(@NotNull String machineId,
-                                @NotNull String commandLine,
-                                @Nullable String outputChannel,
-                                @NotNull AsyncCallback<MachineProcessDto> callback) {
-        final CommandDto request = dtoFactory.createDto(CommandDto.class)
-                                             .withCommandLine(commandLine);
-
-        asyncRequestFactory.createPostRequest(baseHttpUrl + '/' + machineId + "/command?outputChannel=" + outputChannel, request)
-                           .header(ACCEPT, APPLICATION_JSON)
-                           .loader(loader, "Executing command...")
-                           .send(newCallback(callback, dtoUnmarshallerFactory.newUnmarshaller(MachineProcessDto.class)));
-    }
-
-    /** {@inheritDoc} */
     @Override
     public Promise<List<MachineProcessDto>> getProcesses(@NotNull final String machineId) {
-        return newPromise(new RequestCall<List<MachineProcessDto>>() {
-            @Override
-            public void makeCall(AsyncCallback<List<MachineProcessDto>> callback) {
-                final String url = baseHttpUrl + "/" + machineId + "/process";
-                asyncRequestFactory.createGetRequest(url)
-                                   .header(ACCEPT, APPLICATION_JSON)
-                                   .loader(loader, "Getting machine processes...")
-                                   .send(newCallback(callback, dtoUnmarshallerFactory.newListUnmarshaller(MachineProcessDto.class)));
-            }
-        }).then(new Function<List<MachineProcessDto>, List<MachineProcessDto>>() {
-            @Override
-            public List<MachineProcessDto> apply(List<MachineProcessDto> arg) throws FunctionException {
-                final List<MachineProcessDto> descriptors = new ArrayList<>();
-                for (MachineProcessDto descriptor : arg) {
-                    descriptors.add(descriptor);
-                }
-                return descriptors;
-            }
-        });
+        return asyncRequestFactory.createGetRequest(baseHttpUrl + "/" + machineId + "/process")
+                                  .header(ACCEPT, APPLICATION_JSON)
+                                  .loader(loader, "Getting machine processes...")
+                                  .send(dtoUnmarshallerFactory.newListUnmarshaller(MachineProcessDto.class));
     }
 
-    /** {@inheritDoc} */
     @Override
     public Promise<Void> stopProcess(@NotNull final String machineId, final int processId) {
-        return newPromise(new RequestCall<Void>() {
-            @Override
-            public void makeCall(AsyncCallback<Void> callback) {
-                stopProcess(machineId, processId, callback);
-            }
-        });
+        return asyncRequestFactory.createDeleteRequest(baseHttpUrl + '/' + machineId + "/process/" + processId)
+                                  .loader(loader, "Stopping process...")
+                                  .send();
     }
 
-    private void stopProcess(@NotNull String machineId, int processId, @NotNull AsyncCallback<Void> callback) {
-        asyncRequestFactory.createDeleteRequest(baseHttpUrl + '/' + machineId + "/process/" + processId)
-                           .loader(loader, "Stopping process...")
-                           .send(newCallback(callback));
-    }
-
-    /** {@inheritDoc} */
     @Override
     public Promise<Void> bindProject(@NotNull final String machineId, @NotNull final String projectPath) {
-        return newPromise(new RequestCall<Void>() {
-            @Override
-            public void makeCall(AsyncCallback<Void> callback) {
-                bindProject(machineId, projectPath, callback);
-            }
-        });
+        return asyncRequestFactory.createPostRequest(baseHttpUrl + '/' + machineId + "/binding/" + projectPath, null)
+                                  .loader(loader, "Binding project to machine...")
+                                  .send();
     }
 
-    private void bindProject(@NotNull String machineId, @NotNull String projectPath, @NotNull AsyncCallback<Void> callback) {
-        asyncRequestFactory.createPostRequest(baseHttpUrl + '/' + machineId + "/binding/" + projectPath, null)
-                           .loader(loader, "Binding project to machine...")
-                           .send(newCallback(callback));
-    }
-
-    /** {@inheritDoc} */
     @Override
     public Promise<Void> unbindProject(@NotNull final String machineId, @NotNull final String projectPath) {
-        return newPromise(new RequestCall<Void>() {
-            @Override
-            public void makeCall(AsyncCallback<Void> callback) {
-                unbindProject(machineId, projectPath, callback);
-            }
-        });
-    }
-
-    private void unbindProject(@NotNull String machineId, @NotNull String projectPath, @NotNull AsyncCallback<Void> callback) {
-        asyncRequestFactory.createDeleteRequest(baseHttpUrl + '/' + machineId + "/binding/" + projectPath)
-                           .loader(loader, "Unbinding project from machine...")
-                           .send(newCallback(callback));
+        return asyncRequestFactory.createDeleteRequest(baseHttpUrl + '/' + machineId + "/binding/" + projectPath)
+                                  .loader(loader, "Unbinding project from machine...")
+                                  .send();
     }
 
     @Override
     public Promise<String> getFileContent(@NotNull final String machineId, final @NotNull String path, final int startFrom,
                                           final int limit) {
-        return newPromise(new RequestCall<String>() {
-            @Override
-            public void makeCall(AsyncCallback<String> callback) {
-                getFileContent(machineId, path, startFrom, limit, callback);
-            }
-        });
-    }
-
-    private void getFileContent(@NotNull String machineId, @NotNull String path, int startFrom, int limit,
-                                @NotNull AsyncCallback<String> callback) {
         String url = baseHttpUrl + "/" + machineId + "/filepath/" + path + "?startFrom=" + startFrom + "&limit=" + limit;
-        asyncRequestFactory.createGetRequest(url)
-                           .loader(loader, "Loading file content...")
-                           .send(newCallback(callback, new StringUnmarshaller()));
+        return asyncRequestFactory.createGetRequest(url)
+                                  .loader(loader, "Loading file content...")
+                                  .send(new StringUnmarshaller());
     }
 }


### PR DESCRIPTION
* Added ability to get result of AsyncRequest via Promise.
* Deprecated PromiseHelper since AsyncRequest#send() returns Promise with request result.
* Refactored AsyncRequest class to make it more readable.
* Reworked MachineServiceClientImpl in order to get result of asynchronous requests via Promise. Avoid using deprecated PromiseHelper.
* Removed obsolete methods from MachineServiceClient.