### PR TITLE
Implemented new search logic with support for maxItems and skipCount

### DIFF
--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
@@ -17,7 +17,40 @@ import com.wordnik.swagger.annotations.ApiOperation;
 import com.wordnik.swagger.annotations.ApiParam;
 import com.wordnik.swagger.annotations.ApiResponse;
 import com.wordnik.swagger.annotations.ApiResponses;
-
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.regex.Pattern;
+import static java.util.stream.Collectors.toMap;
+import javax.annotation.PreDestroy;
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
 import org.apache.commons.fileupload.FileItem;
 import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.core.ConflictException;
@@ -70,42 +103,6 @@ import org.eclipse.che.commons.lang.ws.rs.ExtMediaType;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.annotation.PreDestroy;
-import javax.annotation.security.RolesAllowed;
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.regex.Pattern;
-
-import static java.util.stream.Collectors.toMap;
 
 /**
  * @author andrew00x
@@ -1327,7 +1324,8 @@ public class ProjectService extends Service {
                     .setPath(path.startsWith("/") ? path : ('/' + path))
                     .setName(name)
                     .setMediaType(mediatype)
-                    .setText(text);
+                    .setText(text)
+                    .setMaxItems(maxItems);
 
             final String[] result = searcherProvider.getSearcher(folder.getVirtualFile().getMountPoint(), true).search(expr);
             if (skipCount > 0) {

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/DefaultSearchResult.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/DefaultSearchResult.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.vfs.server.search;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ * @author I307348 - Ori Libhaber - ori.libhaber@sap.com
+ */
+public class DefaultSearchResult<T> implements SearchResult<T>{
+
+    private final List<T> result;
+    private final Map<String, String> metadata;
+
+    public DefaultSearchResult(List<T> result, Map<String, String> metadata) {
+        this.result = result;
+        this.metadata = metadata;
+    }
+    
+    public DefaultSearchResult(T[] result, Map<String, String> metadata){
+        this(Arrays.asList(result),metadata);
+    }
+
+    public DefaultSearchResult(T[] result) {
+        this(result, new LinkedHashMap<>());
+    }
+
+    @Override
+    public List<T> getResult() {
+        return Collections.synchronizedList(Collections.unmodifiableList(result));
+    }
+
+    @Override
+    public Map<String, String> getMetadata() {
+        return Collections.synchronizedMap(Collections.unmodifiableMap(metadata));
+    }
+
+}

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/LuceneSearcher.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/LuceneSearcher.java
@@ -10,17 +10,16 @@
  *******************************************************************************/
 package org.eclipse.che.api.vfs.server.search;
 
-import org.eclipse.che.api.core.ForbiddenException;
-import org.eclipse.che.api.core.ServerException;
-import org.eclipse.che.api.vfs.server.LazyIterator;
-import org.eclipse.che.api.vfs.server.MountPoint;
-import org.eclipse.che.api.vfs.server.VirtualFile;
-import org.eclipse.che.api.vfs.server.VirtualFileFilter;
-import org.eclipse.che.api.vfs.server.util.MediaTypeFilter;
-
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.Set;
 import org.apache.lucene.analysis.Analyzer;
-import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.core.LowerCaseFilter;
 import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.apache.lucene.document.Document;
@@ -43,22 +42,22 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.IOUtils;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.vfs.server.LazyIterator;
+import org.eclipse.che.api.vfs.server.MountPoint;
+import org.eclipse.che.api.vfs.server.VirtualFile;
+import org.eclipse.che.api.vfs.server.VirtualFileFilter;
+import org.eclipse.che.api.vfs.server.util.MediaTypeFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.LinkedList;
-import java.util.Set;
 
 /**
  * Lucene based searcher.
  *
  * @author andrew00x
  */
-public abstract class LuceneSearcher implements Searcher {
+public abstract class LuceneSearcher implements SearcherWithMetadata<String> {
     private static final Logger LOG          = LoggerFactory.getLogger(LuceneSearcher.class);
     private static final int    RESULT_LIMIT = 1000;
 
@@ -66,7 +65,7 @@ public abstract class LuceneSearcher implements Searcher {
 
     private IndexWriter     luceneIndexWriter;
     private SearcherManager searcherManager;
-    private boolean         closed;
+    private boolean isClosed;
 
     public LuceneSearcher(Set<String> indexedMediaTypes) {
         this(new MediaTypeFilter(indexedMediaTypes));
@@ -111,14 +110,15 @@ public abstract class LuceneSearcher implements Searcher {
         }
     }
 
+    @Override
     public synchronized void close() {
-        if (!closed) {
+        if (!isClosed) {
             try {
                 IOUtils.close(getIndexWriter(), getIndexWriter().getDirectory(), searcherManager);
             } catch (IOException e) {
                 LOG.error(e.getMessage(), e);
             }
-            closed = true;
+            isClosed = true;
         }
     }
 
@@ -128,11 +128,24 @@ public abstract class LuceneSearcher implements Searcher {
 
     @Override
     public String[] search(QueryExpression query) throws ServerException {
+        String[] theResult = (String[]) searchWithMetadata(query).getResult().toArray();
+        return theResult;
+    }
+
+    @Override
+    public SearchResult<String> searchWithMetadata(QueryExpression query) throws ServerException {
         final BooleanQuery luceneQuery = new BooleanQuery();
         final String name = query.getName();
         final String path = query.getPath();
         final String mediaType = query.getMediaType();
         final String text = query.getText();
+        final int maxItems = query.getMaxItems();
+        
+        if (maxItems < -1) {
+            throw new ServerException(String.format("Query parameter 'maxItems' =%d should be a natural number or have value of -1 to indicate maximum result count.",
+                maxItems));
+        }
+
         if (path != null) {
             luceneQuery.add(new PrefixQuery(new Term("path", path)), BooleanClause.Occur.MUST);
         }
@@ -154,15 +167,25 @@ public abstract class LuceneSearcher implements Searcher {
         try {
             searcherManager.maybeRefresh();
             luceneSearcher = searcherManager.acquire();
-            final TopDocs topDocs = luceneSearcher.search(luceneQuery, RESULT_LIMIT);
-            if (topDocs.totalHits > RESULT_LIMIT) {
-                throw new ServerException(String.format("Too many (%d) matched results found. ", topDocs.totalHits));
-            }
+            // search result is capped to at most RESULT_LIMIT in case maxItems is set to -1 or higher then RESULT_LIMIT
+            int resultLimit = maxItems == -1 ? RESULT_LIMIT : Math.min(maxItems, RESULT_LIMIT);
+            // setting start time
+            long startTime = System.currentTimeMillis();
+            // conducting search
+            final TopDocs topDocs = luceneSearcher.search(luceneQuery, resultLimit);
+            // setting end time
+            long endTime = System.currentTimeMillis();
+            // calculating elapsed time for search operation
+            double elapsedTime = (double)(endTime - startTime)/1000;
+            final int totalHits = topDocs.totalHits;
             final String[] result = new String[topDocs.scoreDocs.length];
-            for (int i = 0, length = result.length; i < length; i++) {
+            for (int i = 0; i < result.length; ++i) {
                 result[i] = luceneSearcher.doc(topDocs.scoreDocs[i].doc).getField("path").stringValue();
             }
-            return result;
+            LinkedHashMap<String, String> metadata = new LinkedHashMap<>();
+            metadata.put(SearchResult.TOTAL_HITS, Integer.toString(totalHits));
+            metadata.put(SearchResult.ELAPSED_TIME, Double.toString(elapsedTime));
+            return new DefaultSearchResult<>(result, metadata);
         } catch (IOException e) {
             throw new ServerException(e.getMessage(), e);
         } finally {
@@ -283,6 +306,18 @@ public abstract class LuceneSearcher implements Searcher {
             mediaType = mediaType.substring(0, paramStartIndex).trim();
         }
         return mediaType;
+    }
+
+    private void validateParameters(Integer maxItems, Integer skipCount) throws ServerException {
+        if (maxItems < -1) {
+            throw new ServerException(String.format("Query parameter 'maxItems' =%d should be a natural number or have value of -1 to indicate maximum result count.",
+                maxItems));
+}
+        if (skipCount > maxItems) {
+            throw new ServerException(String.format(
+                "Query parameter 'skipCount' contins value =%d larger then value of query parameter 'maxItems' =%d",
+                skipCount, maxItems));
+        }
     }
 
 }

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/QueryExpression.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/QueryExpression.java
@@ -16,6 +16,7 @@ public class QueryExpression {
     private String path;
     private String mediaType;
     private String text;
+    private int maxItems = -1;
 
     public String getPath() {
         return path;
@@ -55,11 +56,21 @@ public class QueryExpression {
 
     @Override
     public String toString() {
-        return "QueryExpression{" +
-               "name='" + name + '\'' +
-               ", path='" + path + '\'' +
-               ", mediaType='" + mediaType + '\'' +
-               ", text='" + text + '\'' +
-               '}';
+        return String.format("QueryExpression{name='%s', path='%s', mediaType='%s', text='%s',maxItems='%d'}", 
+                name, 
+                path,
+                mediaType,
+                text,
+                maxItems
+        );
+    }
+
+    public int getMaxItems() {
+        return maxItems;
+}
+
+    public QueryExpression setMaxItems(int maxItems) {
+        this.maxItems = maxItems;
+        return this;
     }
 }

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/SearchResult.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/SearchResult.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.vfs.server.search;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ * @author I307348 - Ori Libhaber - ori.libhaber@sap.com
+ */
+public interface SearchResult<T> {
+    
+    public static final String TOTAL_HITS = "totalHits";
+    public static final String ELAPSED_TIME = "time";
+    
+    /**
+     * get result of search as {@code List<T>}
+     * @return {@code synchronized unmodifiable List<T>} containing the search result
+     */
+    public List<T> getResult();
+
+    /**
+     * get search meta data as {@code Map<String,String>}
+     * @return {@code synchronized unmodifiable Map<String, String>} containing the search meta data
+     */
+    public Map<String, String> getMetadata();
+
+}

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/SearcherWithMetadata.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/SearcherWithMetadata.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.vfs.server.search;
+
+import org.eclipse.che.api.core.ServerException;
+
+/**
+ *
+ * @author I307348 - Ori Libhaber - ori.libhaber@sap.com
+ */
+public interface SearcherWithMetadata<T> extends Searcher{
+    
+    public default SearchResult<T> searchWithMetadata(QueryExpression query) throws ServerException{
+        String[] search = search(query);
+        SearchResult<String> result = new DefaultSearchResult<>(search);
+        return (SearchResult<T>) result;
+    }
+    
+}


### PR DESCRIPTION
1. Added support for maxItems and skipCount query parameters, as described in email thread:
    [che-dev] Search API
2. Search result is now encapsulated in SearchResult object which provides additional metadata on search.