### PR TITLE
Source level

### DIFF
--- a/ide/che-core-ide-app/pom.xml
+++ b/ide/che-core-ide-app/pom.xml
@@ -24,6 +24,8 @@
     <properties>
         <dto-generator-out-directory>${project.build.directory}/generated-sources/dto/</dto-generator-out-directory>
         <generated.sources.directory>${project.build.directory}/generated-sources/gen</generated.sources.directory>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
     </properties>


### PR DESCRIPTION
It will avoid static analyzers in IDE's to propose use java 8 features. Because java 8 isn't available on the client side.
@vparfonov @skabashnyuk WDYT about it?