### PR TITLE
CLDIDE-2656 : Support both http and https in git server read-only URL

### DIFF
--- a/che-core-vfs-impl/src/main/java/org/eclipse/che/vfs/impl/fs/GitUrlResolver.java
+++ b/che-core-vfs-impl/src/main/java/org/eclipse/che/vfs/impl/fs/GitUrlResolver.java
@@ -60,7 +60,7 @@ public class GitUrlResolver {
         String mountPathNormalized = uriMountPath.getPath();
 
         StringBuilder result = new StringBuilder();
-        result.append("http");
+        result.append(baseUri.getScheme());
         result.append("://");
         result.append(baseUri.getHost());
         int port = baseUri.getPort();

--- a/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/GitUrlResolverTest.java
+++ b/che-core-vfs-impl/src/test/java/org/eclipse/che/vfs/impl/fs/GitUrlResolverTest.java
@@ -66,4 +66,14 @@ public class GitUrlResolverTest extends LocalFileSystemTest {
         final String url = resolver.resolve(URI.create("http://localhost/some/path"), mountPoint.getVirtualFile(folder));
         assertEquals(expectedUrl, url);
     }
+
+    public void testResolveGitUrlWithHttps() throws Exception {
+        String path = root.toPath().relativize(getIoFile(file).toPath()).toString();
+        path = path.replaceAll("[\\\\]", "/");
+        String expectedUrl = String.format("https://localhost:9000/%s/%s", GIT_SERVER_URI_PREFIX, path);
+
+        GitUrlResolver resolver = new GitUrlResolver(root, GIT_SERVER_URI_PREFIX, new LocalPathResolver());
+        final String url = resolver.resolve(URI.create("https://localhost:9000/some/path"), mountPoint.getVirtualFile(file));
+        assertEquals(expectedUrl, url);
+    }
 }


### PR DESCRIPTION
This pull request is backport  of a commit  from master https://github.com/codenvy/che-core/commit/cc010b2901f1fa30192e7528d46d2735e27d505c