### PR TITLE
Mark readonly opened files with another color

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/theme/Theme.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/theme/Theme.java
@@ -128,6 +128,20 @@ public interface Theme {
     String activeEditorTabBackgroundColor();
 
     /**
+     * Background color for readonly editor tab.
+     *
+     * @return color
+     */
+    String editorReadonlyTabBackgroundColor();
+
+    /**
+     * Background color for readonly active (selected) editor tab.
+     *
+     * @return color
+     */
+    String activeEditorReadonlyTabBackgroundColor();
+
+    /**
      * Background color for focused editor tab.
      *
      * @return color

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorPartStackPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorPartStackPresenter.java
@@ -165,6 +165,15 @@ public class EditorPartStackPresenter extends PartStackPresenter implements Edit
 
             final EditorTab editorTab = tabItemFactory.createEditorPartButton(part.getTitleSVGImage(), part.getTitle());
 
+            part.addPropertyListener(new PropertyListener() {
+                @Override
+                public void propertyChanged(PartPresenter source, int propId) {
+                    if (propId == EditorPartPresenter.PROP_INPUT && source instanceof EditorPartPresenter) {
+                        editorTab.setReadOnlyMark(((EditorPartPresenter)source).getEditorInput().getFile().isReadOnly());
+                    }
+                }
+            });
+
             editorTab.setDelegate(this);
 
             parts.put(editorTab, part);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTab.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTab.java
@@ -22,6 +22,8 @@ import javax.validation.constraints.NotNull;
  */
 public interface EditorTab extends View<EditorTab.ActionDelegate>, TabItem, DoubleClickHandler {
 
+    void setReadOnlyMark(boolean isVisible);
+
     void setErrorMark(boolean isVisible);
 
     void setWarningMark(boolean isVisible);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidget.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidget.java
@@ -172,4 +172,12 @@ public class EditorTabWidget extends Composite implements EditorTab {
         delegate.onTabClose(this);
     }
 
+    @Override
+    public void setReadOnlyMark(boolean isVisible) {
+        if (isVisible) {
+            getElement().setAttribute("readonly", "");
+        } else {
+            getElement().removeAttribute("readonly");
+        }
+    }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidget.ui.xml
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidget.ui.xml
@@ -27,6 +27,8 @@
         @eval activeEditorTabBackgroundColor org.eclipse.che.ide.api.theme.Style.theme.activeEditorTabBackgroundColor();
         @eval focusedEditorTabBackgroundColor org.eclipse.che.ide.api.theme.Style.theme.focusedEditorTabBackgroundColor();
         @eval focusedEditorTabBorderBottomColor org.eclipse.che.ide.api.theme.Style.theme.focusedEditorTabBorderBottomColor();
+        @eval editorReadonlyTabBackgroundColor org.eclipse.che.ide.api.theme.Style.theme.editorReadonlyTabBackgroundColor();
+        @eval activeEditorReadonlyTabBackgroundColor org.eclipse.che.ide.api.theme.Style.theme.activeEditorReadonlyTabBackgroundColor();
 
         .mainPanel {
             -webkit-box-sizing: border-box;
@@ -39,6 +41,13 @@
             color: tabTextColor;
             cursor: default;
             margin-bottom: 1px;
+
+            -webkit-transition: all 0.3s ease-in-out,
+                                fill 0.3s ease-in-out,
+                                stroke 0.3s ease-in-out;
+            transition: all 0.3s ease-in-out,
+                        fill 0.3s ease-in-out,
+                        stroke 0.3s ease-in-out;
         }
 
         .iconPanel {
@@ -104,6 +113,14 @@
          */
         .mainPanel[active] {
             background-color: activeEditorTabBackgroundColor;
+        }
+
+        .mainPanel[readonly] {
+            background-color: editorReadonlyTabBackgroundColor;
+        }
+
+        .mainPanel[active][readonly] {
+            background-color: activeEditorReadonlyTabBackgroundColor;
         }
 
         .mainPanel[active] .closeTabPanel svg {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/theme/DarkTheme.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/theme/DarkTheme.java
@@ -136,6 +136,16 @@ public class DarkTheme implements Theme {
     }
 
     @Override
+    public String editorReadonlyTabBackgroundColor() {
+        return "#3b372f";
+    }
+
+    @Override
+    public String activeEditorReadonlyTabBackgroundColor() {
+        return "#4f4838";
+    }
+
+    @Override
     public String focusedEditorTabBackgroundColor() {
         return "#353E50";
     }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/theme/LightTheme.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/theme/LightTheme.java
@@ -113,6 +113,16 @@ public class LightTheme implements Theme {
     }
 
     @Override
+    public String editorReadonlyTabBackgroundColor() {
+        return "#d4d4be";
+    }
+
+    @Override
+    public String activeEditorReadonlyTabBackgroundColor() {
+        return "#ffffe4";
+    }
+
+    @Override
     public String getEditorTabIconColor() {
         return "#555555";
     }


### PR DESCRIPTION
Feature request.
If user navigates in source code by pressing F4, he can open decompiled class from jar library, so we may mark editor tab with special color to allow user understand where exactly he is.

Screencast of this functionality https://slack-files.com/T02G3VAG4-F0GTN22GZ-354488aedd

@evidolob @vparfonov @skabashnyuk 