### PR TITLE
BUG FIX: result limit propagation in search operations

### DIFF
--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/VirtualFileSystemImpl.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/VirtualFileSystemImpl.java
@@ -544,7 +544,8 @@ public abstract class VirtualFileSystemImpl implements VirtualFileSystem {
                     .setPath(query.getFirst("path"))
                     .setName(query.getFirst("name"))
                     .setMediaType(query.getFirst("mediaType"))
-                    .setText(query.getFirst("text"));
+                    .setText(query.getFirst("text"))
+                    .setMaxItems(maxItems);
 
             final String[] result = searcherProvider.getSearcher(mountPoint, true).search(expr);
             if (skipCount > 0) {

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/LuceneSearcher.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/LuceneSearcher.java
@@ -154,10 +154,8 @@ public abstract class LuceneSearcher implements Searcher {
         try {
             searcherManager.maybeRefresh();
             luceneSearcher = searcherManager.acquire();
-            final TopDocs topDocs = luceneSearcher.search(luceneQuery, RESULT_LIMIT);
-            if (topDocs.totalHits > RESULT_LIMIT) {
-                throw new ServerException(String.format("Too many (%d) matched results found. ", topDocs.totalHits));
-            }
+            final int actualLimit = (query.getMaxItems() > 0 ? query.getMaxItems() : RESULT_LIMIT);
+            final TopDocs topDocs = luceneSearcher.search(luceneQuery, actualLimit);
             final String[] result = new String[topDocs.scoreDocs.length];
             for (int i = 0, length = result.length; i < length; i++) {
                 result[i] = luceneSearcher.doc(topDocs.scoreDocs[i].doc).getField("path").stringValue();

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/QueryExpression.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/search/QueryExpression.java
@@ -16,6 +16,7 @@ public class QueryExpression {
     private String path;
     private String mediaType;
     private String text;
+    private int maxItems = -1;
 
     public String getPath() {
         return path;
@@ -53,6 +54,15 @@ public class QueryExpression {
         return this;
     }
 
+    public int getMaxItems() {
+        return maxItems;
+    }
+
+    public QueryExpression setMaxItems(int maxItems) {
+        this.maxItems = maxItems;
+        return this;
+    }
+
     @Override
     public String toString() {
         return "QueryExpression{" +
@@ -60,6 +70,7 @@ public class QueryExpression {
                ", path='" + path + '\'' +
                ", mediaType='" + mediaType + '\'' +
                ", text='" + text + '\'' +
+               ", maxItems=" + maxItems +
                '}';
     }
 }


### PR DESCRIPTION
1. Pass original request's maxItems through QueryExpression
2. Remove check of totalHits - the result is limited regardless

Currently, there is an incorrect check for TopDocs.totalHits that throws an exception if the total is greater than a hard-coded limit (1000). The limit that is given int the request is totally ignored when the actual search is ignored. Also, The maxItems should be propagated through the QueryExpression, and the check for totalHits should be totally removed since Lucene limits the number of result according to the parameters regardless of the total number of hits in the main index.

Signed-off-by: Tareq Sharafy tareq.sha@gmail.com
