### PR TITLE
CLDIDE-2648: Implement save factory without image

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/bootstrap/FactoryWorkspaceComponent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/bootstrap/FactoryWorkspaceComponent.java
@@ -20,6 +20,7 @@ import com.google.web.bindery.event.shared.EventBus;
 
 import org.eclipse.che.api.factory.gwt.client.FactoryServiceClient;
 import org.eclipse.che.api.factory.shared.dto.Factory;
+import org.eclipse.che.api.factory.shared.dto.Policies;
 import org.eclipse.che.api.machine.gwt.client.MachineManager;
 import org.eclipse.che.api.promises.client.Function;
 import org.eclipse.che.api.promises.client.FunctionException;
@@ -157,8 +158,8 @@ public class FactoryWorkspaceComponent extends WorkspaceComponent implements Com
      */
     private Promise<UsersWorkspaceDto> getWorkspaceToStart() {
         final WorkspaceConfigDto workspaceConfigDto = factory.getWorkspace();
-
-        switch (factory.getPolicies().getCreate()) {
+        final String policy = factory.getPolicies() == null ? "perClick" : factory.getPolicies().getCreate();
+        switch (policy) {
             case "perUser":
                 return getWorkspaceByConditionOrCreateNew(workspaceConfigDto, new Function<UsersWorkspaceDto, Boolean>() {
                     @Override

--- a/platform-api-client-gwt/che-core-client-gwt-factory/pom.xml
+++ b/platform-api-client-gwt/che-core-client-gwt-factory/pom.xml
@@ -26,6 +26,10 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>
@@ -56,6 +60,10 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-client-gwt-workspace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>

--- a/platform-api-client-gwt/che-core-client-gwt-factory/src/main/java/org/eclipse/che/api/factory/gwt/client/FactoryServiceClient.java
+++ b/platform-api-client-gwt/che-core-client-gwt-factory/src/main/java/org/eclipse/che/api/factory/gwt/client/FactoryServiceClient.java
@@ -10,10 +10,16 @@
  *******************************************************************************/
 package org.eclipse.che.api.factory.gwt.client;
 
+import org.eclipse.che.api.factory.server.FactoryService;
 import org.eclipse.che.api.factory.shared.dto.Factory;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.rest.AsyncRequestCallback;
+import org.eclipse.che.ide.util.Pair;
 
 import javax.validation.constraints.NotNull;
+import javax.ws.rs.core.UriInfo;
+import java.util.List;
 
 /**
  * Client for IDE3 Factory service.
@@ -49,4 +55,25 @@ public interface FactoryServiceClient {
      * @param callback callback which returns snippet of the factory or exception if occurred
      */
     void getFactoryJson(@NotNull String workspaceId, @NotNull String path, @NotNull AsyncRequestCallback<Factory> callback);
+
+    /**
+     * Save factory to storage.
+     *
+     * @see FactoryService#getFactoryJson(String, String)
+     */
+    Promise<Factory> getFactoryJson(@NotNull String workspaceId, @Nullable String path);
+
+    /**
+     * Save factory to storage.
+     *
+     * @see FactoryService#saveFactory(Factory)
+     */
+    Promise<Factory> saveFactory(@NotNull Factory factory);
+
+    /**
+     * Save factory to storage.
+     *
+     * @see FactoryService#getFactoryByAttribute(Integer, Integer, UriInfo)
+     */
+    Promise<List<Factory>> findFactory(Integer skipCount, Integer maxItems, List<Pair<String, String>> params);
 }

--- a/platform-api-client-gwt/che-core-client-gwt-factory/src/main/java/org/eclipse/che/api/factory/gwt/client/FactoryServiceClientImpl.java
+++ b/platform-api-client-gwt/che-core-client-gwt-factory/src/main/java/org/eclipse/che/api/factory/gwt/client/FactoryServiceClientImpl.java
@@ -10,15 +10,25 @@
  *******************************************************************************/
 package org.eclipse.che.api.factory.gwt.client;
 
-import org.eclipse.che.api.factory.shared.dto.Factory;
-import org.eclipse.che.ide.MimeType;
-import org.eclipse.che.ide.rest.AsyncRequestCallback;
-import org.eclipse.che.ide.rest.AsyncRequestFactory;
-import org.eclipse.che.ide.rest.HTTPHeader;
+import com.google.common.base.Joiner;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
+import org.eclipse.che.api.factory.shared.dto.Factory;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.ide.MimeType;
+import org.eclipse.che.ide.rest.AsyncRequestCallback;
+import org.eclipse.che.ide.rest.AsyncRequestFactory;
+import org.eclipse.che.ide.rest.AsyncRequestLoader;
+import org.eclipse.che.ide.rest.DtoUnmarshallerFactory;
+import org.eclipse.che.ide.rest.HTTPHeader;
+import org.eclipse.che.ide.util.Pair;
+
 import javax.validation.constraints.NotNull;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Implementation of {@link FactoryServiceClient} service.
@@ -27,17 +37,27 @@ import javax.validation.constraints.NotNull;
  */
 @Singleton
 public class FactoryServiceClientImpl implements FactoryServiceClient {
-    private AsyncRequestFactory asyncRequestFactory;
+    public static final String API_FACTORY_BASE_URL = "/api/factory/";
+
+    private final AsyncRequestFactory    asyncRequestFactory;
+    private final DtoUnmarshallerFactory unmarshallerFactory;
+    private final AsyncRequestLoader     loader;
 
     @Inject
-    public FactoryServiceClientImpl(AsyncRequestFactory asyncRequestFactory) {
+    public FactoryServiceClientImpl(AsyncRequestFactory asyncRequestFactory,
+                                    DtoUnmarshallerFactory unmarshallerFactory,
+                                    AsyncRequestLoader loader) {
         this.asyncRequestFactory = asyncRequestFactory;
+        this.unmarshallerFactory = unmarshallerFactory;
+        this.loader = loader;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void getFactory(@NotNull String factoryId, boolean validate, @NotNull AsyncRequestCallback<Factory> callback) {
-        StringBuilder url = new StringBuilder("/api/factory/").append(factoryId);
+        StringBuilder url = new StringBuilder(API_FACTORY_BASE_URL).append(factoryId);
         if (validate) {
             url.append("?").append("validate=true");
         }
@@ -45,22 +65,87 @@ public class FactoryServiceClientImpl implements FactoryServiceClient {
                            .send(callback);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void getFactorySnippet(String factoryId, String type, AsyncRequestCallback<String> callback) {
-        final String requestUrl = "/api/factory/" + factoryId + "/snippet?type=" + type;
+        final String requestUrl = API_FACTORY_BASE_URL + factoryId + "/snippet?type=" + type;
         asyncRequestFactory.createGetRequest(requestUrl).header(HTTPHeader.ACCEPT, MimeType.TEXT_PLAIN).send(callback);
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void getFactoryJson(String workspaceId, String path, AsyncRequestCallback<Factory> callback) {
-        final StringBuilder url = new StringBuilder("/api/factory/workspace/").append(workspaceId);
+        final StringBuilder url = new StringBuilder(API_FACTORY_BASE_URL + "workspace/").append(workspaceId);
         if (path != null) {
             url.append("?path=").append(path);
         }
         asyncRequestFactory.createGetRequest(url.toString())
                            .header(HTTPHeader.ACCEPT, MimeType.APPLICATION_JSON)
                            .send(callback);
+    }
+
+    @Override
+    public Promise<Factory> getFactoryJson(String workspaceId, String path) {
+        String url = API_FACTORY_BASE_URL + "workspace/" + workspaceId;
+        if (path != null) {
+            url += path;
+        }
+        return asyncRequestFactory.createGetRequest(url)
+                                  .header(HTTPHeader.ACCEPT, MimeType.APPLICATION_JSON)
+                                  .loader(loader, "Getting info about factory...")
+                                  .send(unmarshallerFactory.newUnmarshaller(Factory.class));
+    }
+
+    @Override
+    public Promise<Factory> saveFactory(@NotNull Factory factory) {
+        return asyncRequestFactory.createPostRequest(API_FACTORY_BASE_URL, factory)
+                                  .header(HTTPHeader.ACCEPT, MimeType.APPLICATION_JSON)
+                                  .header(HTTPHeader.CONTENT_TYPE, MimeType.APPLICATION_JSON)
+                                  .loader(loader, "Creating factory...")
+                                  .send(unmarshallerFactory.newUnmarshaller(Factory.class));
+    }
+
+    @Override
+    public Promise<List<Factory>> findFactory(@Nullable Integer skipCount,
+                                              @Nullable Integer maxItems,
+                                              @Nullable List<Pair<String, String>> params) {
+        final List<Pair<String, String>> allParams = new LinkedList<>();
+        if (params != null) {
+            allParams.addAll(params);
+        }
+        if (maxItems != null) {
+            allParams.add(Pair.of("maxItems", maxItems.toString()));
+        }
+        if (skipCount != null) {
+            allParams.add(Pair.of("skipCount", skipCount.toString()));
+        }
+        return asyncRequestFactory.createGetRequest(API_FACTORY_BASE_URL + "find" + queryString(allParams))
+                                  .header(HTTPHeader.ACCEPT, MimeType.APPLICATION_JSON)
+                                  .header(HTTPHeader.CONTENT_TYPE, MimeType.APPLICATION_JSON)
+                                  .loader(loader, "Creating factory...")
+                                  .send(unmarshallerFactory.newListUnmarshaller(Factory.class));
+    }
+
+    /**
+     * Forms the query string from collection of query params
+     *
+     * @param pairs
+     *         an iterable collection of query params
+     * @return query string
+     */
+    private static String queryString(Collection<Pair<String, String>> pairs) {
+        if (pairs.isEmpty()) {
+            return "";
+        }
+        final Joiner joiner = Joiner.on("&");
+        final List<String> params = new LinkedList<>();
+        for (Pair<String, String> pair : pairs) {
+            params.add(pair.first + '=' + pair.second);
+        }
+        return '?' + joiner.join(params);
     }
 }

--- a/platform-api/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/LinksHelper.java
+++ b/platform-api/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/LinksHelper.java
@@ -17,62 +17,129 @@ import org.eclipse.che.dto.server.DtoFactory;
 
 import javax.inject.Singleton;
 import javax.ws.rs.HttpMethod;
-import javax.ws.rs.core.*;
-
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toList;
 
 /** Helper class for creation links. */
 @Singleton
 public class LinksHelper {
 
+    private static final String IMAGE_REL_ATT            = "image";
+    private static final String RETRIEVE_FACTORY_REL_ATT = "self";
+    private static final String SNIPPET_REL_ATT          = "snippet/";
+    private static final String CREATE_WORKSPACE_REL_ATT = "create-project";
+    private static final String ACCEPTED_REL_ATT         = "accepted";
+
     private static List<String> snippetTypes = Collections.unmodifiableList(Arrays.asList("markdown", "url", "html", "iframe"));
 
-    public List<Link> createLinks(Factory factory, Set<FactoryImage> images, UriInfo uriInfo)
-            throws UnsupportedEncodingException {
-        List<Link> links = new LinkedList<>();
+    /**
+     * Creates factory links and links on factory images.
+     *
+     * @param images
+     *         a set of factory images
+     * @param uriInfo
+     *         URI information about relative URIs are relative to the base URI
+     * @return list of factory links
+     * @throws UnsupportedEncodingException
+     *         occurs when impossible to encode URL
+     */
+    public List<Link> createLinks(Factory factory, Set<FactoryImage> images, UriInfo uriInfo) throws UnsupportedEncodingException {
+        final List<Link> links = new LinkedList<>(createLinks(factory, uriInfo));
+        final UriBuilder baseUriBuilder = uriInfo != null ? UriBuilder.fromUri(uriInfo.getBaseUri()) : UriBuilder.fromUri("/");
 
-        final UriBuilder baseUriBuilder;
-        if (uriInfo != null) {
-            baseUriBuilder = UriBuilder.fromUri(uriInfo.getBaseUri());
-        } else {
-            baseUriBuilder = UriBuilder.fromUri("/");
-        }
         // add path to factory service
-        UriBuilder factoryUriBuilder = baseUriBuilder.clone().path(FactoryService.class);
-        String factoryId = factory.getId();
-        Link createProject;
-
-        // uri to retrieve factory
-        links.add(createLink(HttpMethod.GET, "self", null, MediaType.APPLICATION_JSON,
-                             factoryUriBuilder.clone().path(FactoryService.class, "getFactory").build(factoryId).toString(), null));
+        final UriBuilder factoryUriBuilder = baseUriBuilder.clone().path(FactoryService.class);
+        final String factoryId = factory.getId();
 
         // uri's to retrieve images
-        for (FactoryImage image : images) {
-            links.add(createLink(HttpMethod.GET, "image", null, image.getMediaType(),
-                                 factoryUriBuilder.clone().path(FactoryService.class, "getImage").queryParam("imgId", image.getName())
-                                                  .build(factoryId).toString(), null));
-        }
+        links.addAll(images.stream()
+                           .map(image -> createLink(HttpMethod.GET,
+                                                    IMAGE_REL_ATT,
+                                                    null,
+                                                    image.getMediaType(),
+                                                    factoryUriBuilder.clone()
+                                                                     .path(FactoryService.class, "getImage")
+                                                                     .queryParam("imgId", image.getName())
+                                                                     .build(factoryId)
+                                                                     .toString()))
+                           .collect(toList()));
+        return links;
+    }
+
+    /**
+     * Creates factory links.
+     *
+     * @param uriInfo
+     *         URI information about relative URIs are relative to the base URI
+     * @return list of factory links
+     * @throws UnsupportedEncodingException
+     *         occurs when impossible to encode URL
+     */
+    public List<Link> createLinks(Factory factory, UriInfo uriInfo) throws UnsupportedEncodingException {
+        final List<Link> links = new LinkedList<>();
+        final UriBuilder baseUriBuilder = uriInfo != null ? UriBuilder.fromUri(uriInfo.getBaseUri()) : UriBuilder.fromUri("/");
+
+        // add path to factory service
+        final UriBuilder factoryUriBuilder = baseUriBuilder.clone().path(FactoryService.class);
+        final String factoryId = factory.getId();
+
+        // uri to retrieve factory
+        links.add(createLink(HttpMethod.GET,
+                             RETRIEVE_FACTORY_REL_ATT,
+                             null,
+                             MediaType.APPLICATION_JSON,
+                             factoryUriBuilder.clone()
+                                              .path(FactoryService.class, "getFactory")
+                                              .build(factoryId)
+                                              .toString()));
 
         // uri's of snippets
-        for (String snippetType : snippetTypes) {
-            links.add(createLink(HttpMethod.GET, "snippet/" + snippetType, null, MediaType.TEXT_PLAIN,
-                                 factoryUriBuilder.clone().path(FactoryService.class, "getFactorySnippet").queryParam("type", snippetType)
-                                                  .build(factoryId).toString(), null));
-        }
+        links.addAll(snippetTypes.stream()
+                                 .map(snippet -> createLink(HttpMethod.GET,
+                                                            SNIPPET_REL_ATT + snippet,
+                                                            null,
+                                                            MediaType.TEXT_PLAIN,
+                                                            factoryUriBuilder.clone()
+                                                                             .path(FactoryService.class, "getFactorySnippet")
+                                                                             .queryParam("type", snippet)
+                                                                             .build(factoryId)
+                                                                             .toString()))
+                                 .collect(toList()));
 
         // uri to accept factory
-        createProject = createLink(HttpMethod.GET, "create-project", null, MediaType.TEXT_HTML,
-                                   baseUriBuilder.clone().replacePath("f").queryParam("id", factoryId).build().toString(), null);
-        links.add(createProject);
+        final Link createWorkspace = createLink(HttpMethod.GET,
+                                                CREATE_WORKSPACE_REL_ATT,
+                                                null,
+                                                MediaType.TEXT_HTML,
+                                                baseUriBuilder.clone()
+                                                              .replacePath("f")
+                                                              .queryParam("id", factoryId)
+                                                              .build()
+                                                              .toString());
+        links.add(createWorkspace);
 
         // links of analytics
-        links.add(createLink(HttpMethod.GET, "accepted", null, MediaType.TEXT_PLAIN,
-                             baseUriBuilder.clone().path("analytics").path("public-metric/factory_used")
-                                           .queryParam("factory", URLEncoder.encode(createProject.getHref(), "UTF-8")).build().toString(),
-                             null));
+        links.add(createLink(HttpMethod.GET,
+                             ACCEPTED_REL_ATT,
+                             null,
+                             MediaType.TEXT_PLAIN,
+                             baseUriBuilder.clone()
+                                           .path("analytics")
+                                           .path("public-metric/factory_used")
+                                           .queryParam("factory", URLEncoder.encode(createWorkspace.getHref(), "UTF-8"))
+                                           .build()
+                                           .toString()));
         return links;
     }
 
@@ -80,10 +147,10 @@ public class LinksHelper {
      * Find links with given relation.
      *
      * @param links
-     *         - links for searching
+     *         links for searching
      * @param relation
-     *         - searching relation
-     * @return - set of links with relation equal to desired, empty set if there is no such links
+     *         searching relation
+     * @return set of links with relation equal to desired, empty set if there is no such links
      */
     public List<Link> getLinkByRelation(List<Link> links, String relation) {
         if (relation == null || links == null) {
@@ -91,11 +158,18 @@ public class LinksHelper {
         }
         return links.stream()
                     .filter(link -> relation.equals(link.getRel()))
-                    .collect(Collectors.toCollection(LinkedList::new));
+                    .collect(toCollection(LinkedList::new));
     }
 
+    /** Creates factory Link */
+    private Link createLink(String method, String rel, String consumes, String produces, String href) {
+        return createLink(method, rel, consumes, produces, href, null);
+    }
+
+    /** Creates factory Link */
     private Link createLink(String method, String rel, String consumes, String produces, String href, List<LinkParameter> params) {
-        return DtoFactory.getInstance().createDto(Link.class)
+        return DtoFactory.getInstance()
+                         .createDto(Link.class)
                          .withMethod(method)
                          .withRel(rel)
                          .withProduces(produces)

--- a/platform-api/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/impl/FactoryBaseValidator.java
+++ b/platform-api/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/impl/FactoryBaseValidator.java
@@ -60,20 +60,14 @@ public abstract class FactoryBaseValidator {
      * TODO for now validates only git source
      *
      * @param factory
-     *         - factory to validate
+     *         factory to validate
      * @throws ConflictException
      */
     protected void validateSource(Factory factory) throws ConflictException {
         for (ProjectConfigDto project : factory.getWorkspace().getProjects()) {
-            String type = project.getSource().getType();
             String location = project.getSource().getLocation();
-            String parameterTypeName = "project.storage.type";
             String parameterLocationName = "project.storage.location";
 
-            // check that vcs value is correct
-            if (!("git".equals(type) || "esbwso2".equals(type))) {
-                throw new ConflictException("Parameter '" + parameterTypeName + "' has illegal value.");
-            }
             if (isNullOrEmpty(location)) {
                 throw new ConflictException(
                         format(FactoryConstants.PARAMETRIZED_ILLEGAL_PARAMETER_VALUE_MESSAGE, parameterLocationName, location));

--- a/platform-api/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/impl/FactoryBaseValidatorTest.java
+++ b/platform-api/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/impl/FactoryBaseValidatorTest.java
@@ -43,7 +43,6 @@ import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import javax.servlet.http.HttpServletRequest;
-
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
@@ -78,7 +77,7 @@ public class FactoryBaseValidatorTest {
     private FactoryBuilder builder;
 
     @Mock
-    private HttpServletRequest request;
+    private HttpServletRequest      request;
 
     private TesterFactoryBaseValidator validator;
 
@@ -97,11 +96,9 @@ public class FactoryBaseValidatorTest {
         User user = new User().withId("userid");
 
         member = new Member().withUserId("userid")
-                             .withRoles(Arrays.asList("account/owner"));
-        when(accountDao.getMembers(anyString())).thenReturn(Arrays.asList(member));
+                             .withRoles(Collections.singletonList("account/owner"));
+        when(accountDao.getMembers(anyString())).thenReturn(Collections.singletonList(member));
         when(userDao.getById("userid")).thenReturn(user);
-
-
         validator = new TesterFactoryBaseValidator(accountDao, preferenceDao);
     }
 


### PR DESCRIPTION
In case when we create a factory from the workspace inside ide we cannot choose factory image without ugly workarounds, it was proposed to add a method that consumes factory dto instance without images.