### PR TITLE
Proposal to add context menu to editor tabs

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/IdeActions.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/IdeActions.java
@@ -10,7 +10,10 @@
  *******************************************************************************/
 package org.eclipse.che.ide.api.action;
 
-/** @author Evgen Vidolob */
+/**
+ * @author Evgen Vidolob
+ * @author Vlad Zhukovskyi
+ **/
 public interface IdeActions {
     String GROUP_MAIN_MENU      = "mainMenu";
     String GROUP_FILE           = "fileGroup";
@@ -29,6 +32,7 @@ public interface IdeActions {
     String GROUP_BUILD_CONTEXT_MENU            = "buildGroupContextMenu";
     String GROUP_RUN_CONTEXT_MENU              = "runGroupContextMenu";
     String GROUP_PROJECT_EXPLORER_CONTEXT_MENU = "projectExplorerContextMenu";
+    String GROUP_EDITOR_TAB_CONTEXT_MENU       = "editorTabContextMenu";
 
     String GROUP_OTHER_MENU      = "otherMenu";
     String GROUP_LEFT_MAIN_MENU  = "leftMainMenu";

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/Presentation.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/Presentation.java
@@ -25,6 +25,7 @@ import java.util.Map;
  * The presentation of an action in a specific place in the user interface.
  *
  * @author Evgen Vidolob
+ * @author Vlad Zhukovskyi
  */
 public final class Presentation {
     private Map<String, Object> userMap;
@@ -255,6 +256,21 @@ public final class Presentation {
         Object oldValue = userMap.get(key);
         userMap.put(key, value);
         firePropertyChange(key, oldValue, value);
+    }
+
+    /**
+     * Return user client property by specified key.
+     *
+     * @param key
+     *         user client property key
+     * @return object, stored by property key
+     */
+    public Object getClientProperty(String key) {
+        if (userMap == null || key == null) {
+            return null;
+        }
+
+        return userMap.get(key);
     }
 
     public int getWeight() {

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/theme/Theme.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/theme/Theme.java
@@ -1355,4 +1355,7 @@ public interface Theme {
 
     String projectExplorerReadonlyItemBackground();
     String projectExplorerTestItemBackground();
+
+    String editorTabPinBackgroundColor();
+    String editorTabPinDropShadow();
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -588,4 +588,40 @@ public interface CoreLocalizationConstant extends Messages {
 
     @Key("select.path.window.title")
     String selectPathWindowTitle();
+
+    @Key("editor.tab.context.menu.close")
+    String editorTabClose();
+
+    @Key("editor.tab.context.menu.close.description")
+    String editorTabCloseDescription();
+
+    @Key("editor.tab.context.menu.close.all")
+    String editorTabCloseAll();
+
+    @Key("editor.tab.context.menu.close.all.description")
+    String editorTabCloseAllDescription();
+
+    @Key("editor.tab.context.menu.close.all.but.pinned")
+    String editorTabCloseAllButPinned();
+
+    @Key("editor.tab.context.menu.close.all.but.pinned.description")
+    String editorTabCloseAllButPinnedDescription();
+
+    @Key("editor.tab.context.menu.close.all.except.selected")
+    String editorTabCloseAllExceptSelected();
+
+    @Key("editor.tab.context.menu.close.all.except.selected.description")
+    String editorTabCloseAllExceptSelectedDescription();
+
+    @Key("editor.tab.context.menu.pin")
+    String editorTabPin();
+
+    @Key("editor.tab.context.menu.pin.description")
+    String editorTabPinDescription();
+
+    @Key("editor.tab.context.menu.reopen.closed.tab")
+    String editorTabReopenClosedTab();
+
+    @Key("editor.tab.context.menu.reopen.closed.tab.description")
+    String editorTabReopenClosedTabDescription();
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ActionManagerImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ActionManagerImpl.java
@@ -45,6 +45,7 @@ import java.util.Set;
 
 /**
  * @author Evgen Vidolob
+ * @author Vlad Zhukovskyi
  */
 public class ActionManagerImpl implements ActionManager {
     public static final String[] EMPTY_ARRAY = new String[0];
@@ -117,6 +118,11 @@ public class ActionManagerImpl implements ActionManager {
         DefaultActionGroup projectExplorerContextMenuGroup =
                 new DefaultActionGroup(IdeActions.GROUP_PROJECT_EXPLORER_CONTEXT_MENU, false, this);
         registerAction(IdeActions.GROUP_PROJECT_EXPLORER_CONTEXT_MENU, projectExplorerContextMenuGroup);
+
+        //Register context menu group for editor tab
+        DefaultActionGroup editorTabContextMenuGroup =
+                new DefaultActionGroup(IdeActions.GROUP_EDITOR_TAB_CONTEXT_MENU, false, this);
+        registerAction(IdeActions.GROUP_EDITOR_TAB_CONTEXT_MENU, editorTabContextMenuGroup);
 
         // register default action groups for main toolbar
         DefaultActionGroup mainToolbarGroup = new DefaultActionGroup(this);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
@@ -69,6 +69,12 @@ import org.eclipse.che.ide.connection.WsConnectionListener;
 import org.eclipse.che.ide.imageviewer.ImageViewerProvider;
 import org.eclipse.che.ide.newresource.NewFileAction;
 import org.eclipse.che.ide.newresource.NewFolderAction;
+import org.eclipse.che.ide.part.editor.actions.CloseAction;
+import org.eclipse.che.ide.part.editor.actions.CloseAllAction;
+import org.eclipse.che.ide.part.editor.actions.CloseAllExceptPinnedAction;
+import org.eclipse.che.ide.part.editor.actions.CloseOtherAction;
+import org.eclipse.che.ide.part.editor.actions.PinEditorTabAction;
+import org.eclipse.che.ide.part.editor.actions.ReopenClosedFileAction;
 import org.eclipse.che.ide.ui.toolbar.MainToolbar;
 import org.eclipse.che.ide.ui.toolbar.ToolbarPresenter;
 import org.eclipse.che.ide.util.input.KeyCodeMap;
@@ -84,6 +90,7 @@ import static org.eclipse.che.ide.projecttype.BlankProjectWizardRegistrar.BLANK_
  *
  * @author Evgen Vidolob
  * @author Dmitry Shnurenko
+ * @author Vlad Zhukovskyi
  */
 @Singleton
 public class StandardComponentInitializer {
@@ -155,6 +162,24 @@ public class StandardComponentInitializer {
 
     @Inject
     private FoldersAlwaysOnTopAction foldersAlwaysOnTopAction;
+
+    @Inject
+    private CloseAction closeAction;
+
+    @Inject
+    private CloseAllAction closeAllAction;
+
+    @Inject
+    private CloseOtherAction closeOtherAction;
+
+    @Inject
+    private CloseAllExceptPinnedAction closeAllExceptPinnedAction;
+
+    @Inject
+    private ReopenClosedFileAction reopenClosedFileAction;
+
+    @Inject
+    private PinEditorTabAction pinEditorTabAction;
 
     @Inject
     private GoIntoAction goIntoAction;
@@ -495,6 +520,23 @@ public class StandardComponentInitializer {
                 (DefaultActionGroup)actionManager.getAction(IdeActions.GROUP_PROJECT_EXPLORER_CONTEXT_MENU);
         projectExplorerContextMenu.add(foldersAlwaysOnTopAction);
         actionManager.registerAction("foldersAlwaysOnTop", foldersAlwaysOnTopAction);
+
+        //Editor context menu group
+        DefaultActionGroup editorTabContextMenu =
+                (DefaultActionGroup)actionManager.getAction(IdeActions.GROUP_EDITOR_TAB_CONTEXT_MENU);
+        editorTabContextMenu.add(closeAction);
+        actionManager.registerAction("closeEditor", closeAction);
+        editorTabContextMenu.add(closeAllAction);
+        actionManager.registerAction("closeAllEditors", closeAllAction);
+        editorTabContextMenu.add(closeOtherAction);
+        actionManager.registerAction("closeOtherEditorExceptCurrent", closeOtherAction);
+        editorTabContextMenu.add(closeAllExceptPinnedAction);
+        actionManager.registerAction("closeAllEditorExceptPinned", closeAllExceptPinnedAction);
+        editorTabContextMenu.addSeparator();
+        editorTabContextMenu.add(reopenClosedFileAction);
+        actionManager.registerAction("reopenClosedEditorTab", reopenClosedFileAction);
+        editorTabContextMenu.add(pinEditorTabAction);
+        actionManager.registerAction("pinEditorTab", pinEditorTabAction);
 
         final DefaultActionGroup loaderToolbarGroup = new DefaultActionGroup("loader", false, actionManager);
         actionManager.registerAction("loader", loaderToolbarGroup);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/inject/CoreGinModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/inject/CoreGinModule.java
@@ -103,6 +103,7 @@ import org.eclipse.che.ide.core.Component;
 import org.eclipse.che.ide.core.StandardComponentInitializer;
 import org.eclipse.che.ide.core.editor.EditorAgentImpl;
 import org.eclipse.che.ide.core.editor.EditorRegistryImpl;
+import org.eclipse.che.ide.part.editor.EditorTabContextMenuFactory;
 import org.eclipse.che.ide.preferences.pages.extensions.ExtensionManagerPresenter;
 import org.eclipse.che.ide.preferences.pages.extensions.ExtensionManagerView;
 import org.eclipse.che.ide.preferences.pages.extensions.ExtensionManagerViewImpl;
@@ -419,6 +420,7 @@ public class CoreGinModule extends AbstractGinModule {
 
         bind(EditorRegistry.class).to(EditorRegistryImpl.class).in(Singleton.class);
         bind(UserActivityManager.class).in(Singleton.class);
+        install(new GinFactoryModuleBuilder().build(EditorTabContextMenuFactory.class));
     }
 
     /** Configure bindings for project's tree. */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/menu/ContextMenu.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/menu/ContextMenu.java
@@ -39,21 +39,22 @@ import org.eclipse.che.ide.ui.toolbar.PresentationFactory;
  *
  * @author Vitaliy Guliy
  * @author Dmitry Shnurenko
+ * @author Vlad Zhukovskyi
  */
 @Singleton
 public class ContextMenu implements CloseMenuHandler, ActionSelectedHandler {
 
-    private final ActionManager   actionManager;
-    private final KeyBindingAgent keyBindingAgent;
+    private static final String place = ActionPlaces.MAIN_CONTEXT_MENU;
 
-    private final PresentationFactory          presentationFactory;
+    private final ActionManager                actionManager;
+    private final KeyBindingAgent              keyBindingAgent;
     private final DefaultActionGroup           actions;
     private final Provider<PerspectiveManager> managerProvider;
 
     private PopupMenu     popupMenu;
     private MenuLockLayer lockLayer;
 
-    private static final String place = ActionPlaces.MAIN_CONTEXT_MENU;
+    protected final PresentationFactory presentationFactory;
 
     @Inject
     public ContextMenu(ActionManager actionManager, KeyBindingAgent keyBindingAgent, Provider<PerspectiveManager> managerProvider) {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorPartStackView.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorPartStackView.java
@@ -204,6 +204,11 @@ public class EditorPartStackView extends ResizeComposite implements PartStackVie
         } catch (NoSuchElementException exception) {
             getElement().getParentElement().getStyle().setDisplay(NONE);
         }
+
+        //this hack need to force redraw dom element to apply correct styles
+        tabsPanel.getElement().getStyle().setDisplay(NONE);
+        tabsPanel.getElement().getOffsetHeight();
+        tabsPanel.getElement().getStyle().setDisplay(BLOCK);
     }
 
     /** {@inheritDoc} */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorTabContextMenu.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorTabContextMenu.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.assistedinject.Assisted;
+
+import org.eclipse.che.ide.api.action.Action;
+import org.eclipse.che.ide.api.action.ActionManager;
+import org.eclipse.che.ide.api.action.IdeActions;
+import org.eclipse.che.ide.api.keybinding.KeyBindingAgent;
+import org.eclipse.che.ide.api.parts.PerspectiveManager;
+import org.eclipse.che.ide.menu.ContextMenu;
+import org.eclipse.che.ide.part.widgets.editortab.EditorTab;
+
+import static org.eclipse.che.ide.part.editor.actions.EditorAbstractAction.CURRENT_FILE_PROP;
+import static org.eclipse.che.ide.part.editor.actions.PinEditorTabAction.PROP_PIN;
+
+/**
+ * Editor tab context menu.
+ * Perform injecting client property into action when last ones performs.
+ * So we may obtain file on which context menu has been shown and editor tab pin state.
+ *
+ * @author Vlad Zhukovskiy
+ */
+public class EditorTabContextMenu extends ContextMenu {
+
+    private final EditorTab editorTab;
+
+    @Inject
+    public EditorTabContextMenu(@Assisted EditorTab editorTab,
+                                ActionManager actionManager,
+                                KeyBindingAgent keyBindingAgent,
+                                Provider<PerspectiveManager> managerProvider) {
+        super(actionManager, keyBindingAgent, managerProvider);
+        this.editorTab = editorTab;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected String getGroupMenu() {
+        return IdeActions.GROUP_EDITOR_TAB_CONTEXT_MENU;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void onActionSelected(Action action) {
+        super.onActionSelected(action);
+
+        //pass into action file property and editor tab pin state
+        presentationFactory.getPresentation(action).putClientProperty(CURRENT_FILE_PROP, editorTab.getFile());
+        presentationFactory.getPresentation(action).putClientProperty(PROP_PIN, editorTab.isPinned());
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorTabContextMenuFactory.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorTabContextMenuFactory.java
@@ -8,23 +8,22 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.ide.client.inject.factories;
+package org.eclipse.che.ide.part.editor;
 
-import org.eclipse.che.ide.api.project.tree.VirtualFile;
 import org.eclipse.che.ide.part.widgets.editortab.EditorTab;
-import org.eclipse.che.ide.part.widgets.partbutton.PartButton;
-import org.vectomatic.dom.svg.ui.SVGResource;
-
-import javax.validation.constraints.NotNull;
-import org.eclipse.che.commons.annotation.Nullable;
 
 /**
- * @author Dmitry Shnurenko
- * @author Vlad Zhukovskyi
+ * Editor tab context menu factory.
+ *
+ * @author Vlad Zhukovskiy
  */
-public interface TabItemFactory {
-
-    PartButton createPartButton(@NotNull String title);
-
-    EditorTab createEditorPartButton(@Nullable VirtualFile virtualFile, @Nullable SVGResource icon, @NotNull String title);
+public interface EditorTabContextMenuFactory {
+    /**
+     * Creates new context menu for editor tab.
+     *
+     * @param editorTab
+     *         editor tab item
+     * @return new context menu
+     */
+    EditorTabContextMenu newContextMenu(EditorTab editorTab);
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/actions/CloseAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/actions/CloseAction.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.actions;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.analytics.client.logger.AnalyticsEventLogger;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.event.FileEvent;
+import org.eclipse.che.ide.api.project.tree.VirtualFile;
+
+import static org.eclipse.che.ide.api.event.FileEvent.FileOperation.CLOSE;
+
+/**
+ * Performs closing selected editor.
+ *
+ * @author Vlad Zhukovskiy
+ */
+@Singleton
+public class CloseAction extends EditorAbstractAction {
+
+    @Inject
+    public CloseAction(EditorAgent editorAgent,
+                       EventBus eventBus,
+                       CoreLocalizationConstant locale,
+                       AnalyticsEventLogger eventLogger) {
+        super(locale.editorTabClose(), locale.editorTabCloseDescription(), null, editorAgent, eventBus, eventLogger);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        eventLogger.log(this);
+        VirtualFile virtualFile = getEditorFile(e);
+
+        for (EditorPartPresenter editor : editorAgent.getOpenedEditors().values()) {
+            if (editor.getEditorInput().getFile().equals(virtualFile)) {
+                eventBus.fireEvent(new FileEvent(editor.getEditorInput().getFile(), CLOSE));
+                return;
+            }
+        }
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/actions/CloseAllAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/actions/CloseAllAction.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.actions;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.analytics.client.logger.AnalyticsEventLogger;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.event.FileEvent;
+import org.eclipse.che.ide.api.project.tree.VirtualFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Performs closing all opened editors.
+ *
+ * @author Vlad Zhukovskiy
+ */
+@Singleton
+public class CloseAllAction extends EditorAbstractAction {
+
+    @Inject
+    public CloseAllAction(EditorAgent editorAgent,
+                          EventBus eventBus,
+                          CoreLocalizationConstant locale,
+                          AnalyticsEventLogger eventLogger) {
+        super(locale.editorTabCloseAll(), locale.editorTabCloseAllDescription(), null, editorAgent, eventBus, eventLogger);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        eventLogger.log(this);
+        List<VirtualFile> toClose = new ArrayList<>();
+
+        for (EditorPartPresenter editor : editorAgent.getOpenedEditors().values()) {
+            toClose.add(editor.getEditorInput().getFile());
+        }
+
+        for (VirtualFile virtualFile : toClose) {
+            eventBus.fireEvent(new FileEvent(virtualFile, FileEvent.FileOperation.CLOSE));
+        }
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/actions/CloseAllExceptPinnedAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/actions/CloseAllExceptPinnedAction.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.actions;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.analytics.client.logger.AnalyticsEventLogger;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.part.editor.event.CloseNonPinnedEditorsEvent;
+
+/**
+ * Performs closing editor tabs with unpinned status.
+ *
+ * @author Vlad Zhukovskiy
+ */
+@Singleton
+public class CloseAllExceptPinnedAction extends EditorAbstractAction {
+
+    @Inject
+    public CloseAllExceptPinnedAction(EditorAgent editorAgent,
+                                      EventBus eventBus,
+                                      CoreLocalizationConstant locale,
+                                      AnalyticsEventLogger eventLogger) {
+        super(locale.editorTabCloseAllButPinned(), locale.editorTabCloseAllButPinnedDescription(), null, editorAgent, eventBus,
+              eventLogger);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        eventLogger.log(this);
+        eventBus.fireEvent(new CloseNonPinnedEditorsEvent());
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/actions/CloseOtherAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/actions/CloseOtherAction.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.actions;
+
+import com.google.common.base.Predicate;
+import com.google.gwt.core.client.Scheduler;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.analytics.client.logger.AnalyticsEventLogger;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.editor.EditorPartPresenter;
+import org.eclipse.che.ide.api.event.FileEvent;
+import org.eclipse.che.ide.api.project.tree.VirtualFile;
+
+import static com.google.common.collect.Iterables.filter;
+
+/**
+ * Performs closing all opened editors except selected one.
+ *
+ * @author Vlad Zhukovskiy
+ */
+@Singleton
+public class CloseOtherAction extends EditorAbstractAction {
+
+    @Inject
+    public CloseOtherAction(EditorAgent editorAgent,
+                            EventBus eventBus,
+                            CoreLocalizationConstant locale,
+                            AnalyticsEventLogger eventLogger) {
+        super(locale.editorTabCloseAllExceptSelected(), locale.editorTabCloseAllExceptSelectedDescription(), null, editorAgent, eventBus,
+              eventLogger);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        eventLogger.log(this);
+        final VirtualFile virtualFile = getEditorFile(e);
+
+        Iterable<EditorPartPresenter> filtered = filter(editorAgent.getOpenedEditors().values(), new Predicate<EditorPartPresenter>() {
+            @Override
+            public boolean apply(EditorPartPresenter input) {
+                return !input.getEditorInput().getFile().equals(virtualFile);
+            }
+        });
+
+        for (final EditorPartPresenter toClose : filtered) {
+            Scheduler.get().scheduleDeferred(new Scheduler.ScheduledCommand() {
+                @Override
+                public void execute() {
+                    eventBus.fireEvent(new FileEvent(toClose.getEditorInput().getFile(), FileEvent.FileOperation.CLOSE));
+                }
+            });
+        }
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/actions/EditorAbstractAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/actions/EditorAbstractAction.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.actions;
+
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.analytics.client.logger.AnalyticsEventLogger;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.api.project.tree.VirtualFile;
+import org.vectomatic.dom.svg.ui.SVGResource;
+
+import javax.validation.constraints.NotNull;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+/**
+ * Base action for editor tab.
+ *
+ * @author Vlad Zhukovskiy
+ */
+public abstract class EditorAbstractAction extends AbstractPerspectiveAction {
+
+    public static final String CURRENT_FILE_PROP = "source";
+
+    protected EditorAgent          editorAgent;
+    protected EventBus             eventBus;
+    protected AnalyticsEventLogger eventLogger;
+
+    public EditorAbstractAction(String tooltip,
+                                String description,
+                                SVGResource icon,
+                                EditorAgent editorAgent,
+                                EventBus eventBus,
+                                AnalyticsEventLogger eventLogger) {
+        super(singletonList(PROJECT_PERSPECTIVE_ID), tooltip, description, null, icon);
+        this.editorAgent = editorAgent;
+        this.eventBus = eventBus;
+        this.eventLogger = eventLogger;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateInPerspective(@NotNull ActionEvent event) {
+        event.getPresentation().setEnabledAndVisible(editorAgent.getOpenedEditors() != null && !editorAgent.getOpenedEditors().isEmpty());
+    }
+
+    /**
+     * Fetch file from the action event. File should be passed by context menu during construction the last one.
+     *
+     * @param e
+     *         action event
+     * @return {@link VirtualFile} file.
+     * @throws IllegalStateException
+     *         in case if file not found in action event
+     */
+    protected VirtualFile getEditorFile(ActionEvent e) {
+        Object o = e.getPresentation().getClientProperty(CURRENT_FILE_PROP);
+
+        if (o instanceof VirtualFile) {
+            return (VirtualFile)o;
+        }
+
+        throw new IllegalStateException("File doesn't provided");
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/actions/PinEditorTabAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/actions/PinEditorTabAction.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.actions;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.analytics.client.logger.AnalyticsEventLogger;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.editor.EditorAgent;
+import org.eclipse.che.ide.part.editor.event.PinEditorTabEvent;
+
+/**
+ * Pin/Unpin current selected editor tab.
+ *
+ * @author Vlad Zhukovskiy
+ */
+@Singleton
+public class PinEditorTabAction extends EditorAbstractAction {
+
+    public static final String PROP_PIN = "pin";
+
+    @Inject
+    public PinEditorTabAction(EditorAgent editorAgent,
+                              EventBus eventBus,
+                              CoreLocalizationConstant locale,
+                              AnalyticsEventLogger eventLogger) {
+        super(locale.editorTabPin(), locale.editorTabPinDescription(), null, editorAgent, eventBus, eventLogger);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        eventLogger.log(this);
+        eventBus.fireEvent(new PinEditorTabEvent(getEditorFile(e), !isPinned(e)));
+    }
+
+    private boolean isPinned(ActionEvent e) {
+        Object o = e.getPresentation().getClientProperty(PROP_PIN);
+
+        return o instanceof Boolean && (Boolean)o;
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/actions/ReopenClosedFileAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/actions/ReopenClosedFileAction.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.actions;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.analytics.client.logger.AnalyticsEventLogger;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.event.FileEvent;
+import org.eclipse.che.ide.api.event.FileEventHandler;
+import org.eclipse.che.ide.api.project.tree.VirtualFile;
+
+import javax.validation.constraints.NotNull;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.api.event.FileEvent.FileOperation.CLOSE;
+import static org.eclipse.che.ide.api.event.FileEvent.FileOperation.OPEN;
+import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+
+/**
+ * Performs restoring closed editor tab.
+ *
+ * @author Vlad Zhukovskiy
+ */
+@Singleton
+public class ReopenClosedFileAction extends AbstractPerspectiveAction implements FileEventHandler {
+
+    private final EventBus             eventBus;
+    private final AnalyticsEventLogger eventLogger;
+
+    private VirtualFile lastClosed;
+
+    @Inject
+    public ReopenClosedFileAction(EventBus eventBus, CoreLocalizationConstant locale, AnalyticsEventLogger eventLogger) {
+        super(singletonList(PROJECT_PERSPECTIVE_ID), locale.editorTabReopenClosedTab(), locale.editorTabReopenClosedTabDescription(), null,
+              null);
+        this.eventBus = eventBus;
+        this.eventLogger = eventLogger;
+
+        eventBus.addHandler(FileEvent.TYPE, this);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void onFileOperation(FileEvent event) {
+        if (event.getOperationType() == CLOSE) {
+            lastClosed = event.getFile();
+        } else if (event.getOperationType() == OPEN && lastClosed != null && lastClosed.equals(event.getFile())) {
+            lastClosed = null;
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateInPerspective(@NotNull ActionEvent event) {
+        event.getPresentation().setEnabled(lastClosed != null);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        eventLogger.log(this);
+        eventBus.fireEvent(new FileEvent(lastClosed, OPEN));
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/event/CloseNonPinnedEditorsEvent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/event/CloseNonPinnedEditorsEvent.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.event;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+/**
+ * Close non pinned editor tabs event.
+ *
+ * @author Vlad Zhukovskiy
+ */
+public class CloseNonPinnedEditorsEvent extends GwtEvent<CloseNonPinnedEditorsEvent.CloseNonPinnedEditorsHandler> {
+
+    public interface CloseNonPinnedEditorsHandler extends EventHandler {
+        void onCloseNonPinnedEditors(CloseNonPinnedEditorsEvent event);
+    }
+
+    private static Type<CloseNonPinnedEditorsHandler> TYPE;
+
+    public static Type<CloseNonPinnedEditorsHandler> getType() {
+        if (TYPE == null) {
+            TYPE = new Type<>();
+        }
+        return TYPE;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Type<CloseNonPinnedEditorsHandler> getAssociatedType() {
+        return getType();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void dispatch(CloseNonPinnedEditorsHandler handler) {
+        handler.onCloseNonPinnedEditors(this);
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/event/PinEditorTabEvent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/event/PinEditorTabEvent.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.event;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+import org.eclipse.che.ide.api.project.node.Node;
+import org.eclipse.che.ide.api.project.tree.VirtualFile;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Event fires when editor tab either pinned or not.
+ *
+ * @author Vlad Zhukovskiy
+ */
+public class PinEditorTabEvent extends GwtEvent<PinEditorTabEvent.PinEditorTabEventHandler> {
+
+    public interface PinEditorTabEventHandler extends EventHandler {
+        void onEditorTabPinned(PinEditorTabEvent event);
+    }
+
+    private static Type<PinEditorTabEventHandler> TYPE;
+
+    public static Type<PinEditorTabEventHandler> getType() {
+        if (TYPE == null) {
+            TYPE = new Type<>();
+        }
+        return TYPE;
+    }
+
+    private final VirtualFile file;
+    private final boolean     pin;
+
+    public PinEditorTabEvent(VirtualFile file, boolean pin) {
+        this.file = file;
+        this.pin = pin;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Type<PinEditorTabEventHandler> getAssociatedType() {
+        return getType();
+    }
+
+    /**
+     * Return file associated with pin operation.
+     *
+     * @return {@link VirtualFile} file
+     */
+    public VirtualFile getFile() {
+        return file;
+    }
+
+    /**
+     * Return true if opened file should be pinned.
+     *
+     * @return true if opened file should be pinned
+     */
+    public boolean isPin() {
+        return pin;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void dispatch(PinEditorTabEventHandler handler) {
+        handler.onEditorTabPinned(this);
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTab.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTab.java
@@ -14,6 +14,7 @@ import com.google.gwt.event.dom.client.DoubleClickHandler;
 
 import org.eclipse.che.ide.api.mvp.View;
 import org.eclipse.che.ide.api.parts.PartStackView.TabItem;
+import org.eclipse.che.ide.api.project.tree.VirtualFile;
 
 import javax.validation.constraints.NotNull;
 
@@ -27,6 +28,28 @@ public interface EditorTab extends View<EditorTab.ActionDelegate>, TabItem, Doub
     void setErrorMark(boolean isVisible);
 
     void setWarningMark(boolean isVisible);
+
+    /**
+     * Return virtual file associated with editor tab.
+     *
+     * @return {@link VirtualFile} file
+     */
+    VirtualFile getFile();
+
+    /**
+     * Set pin mark to editor tab item.
+     *
+     * @param pinned
+     *         true if tab should be pinned, otherwise false
+     */
+    void setPinMark(boolean pinned);
+
+    /**
+     * Indicates whether editor tab is either pinned or not.
+     *
+     * @return true if editor tab is pinned
+     */
+    boolean isPinned();
 
     interface ActionDelegate {
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidget.ui.xml
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidget.ui.xml
@@ -29,6 +29,8 @@
         @eval focusedEditorTabBorderBottomColor org.eclipse.che.ide.api.theme.Style.theme.focusedEditorTabBorderBottomColor();
         @eval editorReadonlyTabBackgroundColor org.eclipse.che.ide.api.theme.Style.theme.editorReadonlyTabBackgroundColor();
         @eval activeEditorReadonlyTabBackgroundColor org.eclipse.che.ide.api.theme.Style.theme.activeEditorReadonlyTabBackgroundColor();
+        @eval editorTabPinBackgroundColor org.eclipse.che.ide.api.theme.Style.theme.editorTabPinBackgroundColor();
+        @eval editorTabPinDropShadow org.eclipse.che.ide.api.theme.Style.theme.editorTabPinDropShadow();
 
         .mainPanel {
             -webkit-box-sizing: border-box;
@@ -125,6 +127,40 @@
 
         .mainPanel[active] .closeTabPanel svg {
             display: block;
+        }
+
+        .mainPanel[pinned] .iconPanel::before {
+            content: '';
+            width: 6px;
+            height: 6px;
+            -moz-border-radius: 1px;
+            -webkit-border-radius: 3px;
+            border-radius: 3px;
+            background-color: editorTabPinBackgroundColor;
+            position: absolute;
+            top: 4px;
+            margin-left: 7px;
+            z-index: 1;
+            -webkit-filter: editorTabPinDropShadow;
+            filter: editorTabPinDropShadow;
+            -webkit-animation: pin 0.3s;
+            animation: pin 0.3s;
+            -webkit-transition: all 0.3s ease-in-out,
+                                fill 0.3s ease-in-out,
+                                stroke 0.3s ease-in-out;
+            transition: all 0.3s ease-in-out,
+                        fill 0.3s ease-in-out,
+                        stroke 0.3s ease-in-out;
+        }
+
+        @-webkit-keyframes pin {
+            from {opacity: 0;}
+            to {opacity: 1;}
+        }
+
+        @keyframes pin {
+            from {opacity: 0;}
+            to {opacity: 1;}
         }
 
         /**

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/theme/DarkTheme.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/theme/DarkTheme.java
@@ -1269,4 +1269,14 @@ public class DarkTheme implements Theme {
     public String projectExplorerTestItemBackground() {
         return "rgba(45, 74, 48, 0.71)";
     }
+
+    @Override
+    public String editorTabPinBackgroundColor() {
+        return "#6AAF32";
+    }
+
+    @Override
+    public String editorTabPinDropShadow() {
+        return "drop-shadow(1px 1px 1px rgba(0, 0, 0, 0.4))";
+    }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/theme/LightTheme.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/theme/LightTheme.java
@@ -1246,4 +1246,14 @@ public class LightTheme implements Theme {
     public String projectExplorerTestItemBackground() {
         return "#effae7";
     }
+
+    @Override
+    public String editorTabPinBackgroundColor() {
+        return "#6AAF32";
+    }
+
+    @Override
+    public String editorTabPinDropShadow() {
+        return "drop-shadow(1px 1px 1px rgba(0, 0, 0, 0.4))";
+    }
 }

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -270,3 +270,17 @@ text.search.title=Find Text
 text.search.file.mask=File mask:
 text.search.directory=Root directory:
 select.path.window.title=Select Path
+
+############# Editor tab context menu #############
+editor.tab.context.menu.close=Close
+editor.tab.context.menu.close.description=Close current editor
+editor.tab.context.menu.close.all=Close All
+editor.tab.context.menu.close.all.description=Close all editors
+editor.tab.context.menu.close.all.but.pinned=Close All But Pinned
+editor.tab.context.menu.close.all.but.pinned.description=Close all editors but leave pinned
+editor.tab.context.menu.close.all.except.selected=Close Other
+editor.tab.context.menu.close.all.except.selected.description=Close all editors but leave current selected
+editor.tab.context.menu.pin=Pin/Unpin Tab
+editor.tab.context.menu.pin.description=Pin/Unpin current editor tab
+editor.tab.context.menu.reopen.closed.tab=Reopen Closed Tab
+editor.tab.context.menu.reopen.closed.tab.description=Reopen last closed editor tab

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidgetTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidgetTest.java
@@ -16,6 +16,8 @@ import com.google.gwt.user.client.Element;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 
 import org.eclipse.che.ide.api.parts.PartStackUIResources;
+import org.eclipse.che.ide.api.project.tree.VirtualFile;
+import org.eclipse.che.ide.part.editor.EditorTabContextMenuFactory;
 import org.eclipse.che.ide.part.widgets.editortab.EditorTab.ActionDelegate;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,7 +47,7 @@ public class EditorTabWidgetTest {
     private SVGResource          icon;
 
     @Mock
-    private SVGImage             iconImage;
+    private SVGImage iconImage;
 
     //additional mocks
     @Mock
@@ -56,6 +58,10 @@ public class EditorTabWidgetTest {
     private ActionDelegate  delegate;
     @Mock
     private ClickEvent      event;
+    @Mock
+    private VirtualFile     file;
+    @Mock
+    private EditorTabContextMenuFactory editorTabContextMenuFactory;
 
     private EditorTabWidget tab;
 
@@ -64,7 +70,7 @@ public class EditorTabWidgetTest {
         when(icon.getSvg()).thenReturn(svg);
         when(event.getNativeButton()).thenReturn(NativeEvent.BUTTON_LEFT);
 
-        tab = new EditorTabWidget(resources, icon, SOME_TEXT);
+        tab = new EditorTabWidget(file, icon, SOME_TEXT, resources, editorTabContextMenuFactory);
         tab.setDelegate(delegate);
     }
 


### PR DESCRIPTION
Context menu contains:

1. Close action - closes current selected editor.
2. Close All action - closes all opened editors.
3. Close All but Pinned action - closes all editors that don't have pin.
4. Close Other action - closes all editors but leaves current selected.
5. Reopen Closed Tab action - reopens last closed editor.
6. Pin/Unpin Editor Tab - mark/unmark current selected tab with pin.

![- 20 12 2015 - 01 41 17](https://cloud.githubusercontent.com/assets/1968177/11915729/adffec34-a6bc-11e5-976e-ecb006307b17.png)

Screencast: https://slack-files.com/T02G3VAG4-F0H1D6P47-d3213511d4

@vparfonov @evidolob @skabashnyuk wdyt?