### PR TITLE
Proposal to add recent files functionality

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/IdeActions.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/action/IdeActions.java
@@ -18,11 +18,13 @@ public interface IdeActions {
     String GROUP_MAIN_MENU      = "mainMenu";
     String GROUP_FILE           = "fileGroup";
     String GROUP_FILE_NEW       = "newGroup";
+    String GROUP_EDIT           = "editGroup";
     String GROUP_CODE           = "codeGroup";
     String GROUP_IMPORT_PROJECT = "importProjectGroup";
     String GROUP_WINDOW         = "windowGroup";
     String GROUP_HELP           = "helpGroup";
     String GROUP_REFACTORING    = "refactoringGroup";
+    String GROUP_RECENT_FILES   = "recentFiles";
 
     String GROUP_MAIN_TOOLBAR   = "mainToolBar";
     String GROUP_CENTER_TOOLBAR = "centerToolBar";

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/recent/RecentList.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/recent/RecentList.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.api.recent;
+
+import java.util.List;
+
+/**
+ * Recent list of abstract items.
+ *
+ * @author Vlad Zhukovskiy
+ */
+public interface RecentList<T> {
+    /**
+     * Check whether recent list is empty.
+     *
+     * @return true if empty
+     */
+    boolean isEmpty();
+
+    /**
+     * Add abstract item to the recent list.
+     *
+     * @param item
+     *         item to add
+     * @return true if item has been added
+     */
+    boolean add(T item);
+
+    /**
+     * Remove abstract item from the recent list.
+     *
+     * @param item
+     *         item to remove
+     * @return true if item has been removed
+     */
+    boolean remove(T item);
+
+    /**
+     * Check if item contains in recent list.
+     *
+     * @param item
+     *         item to check
+     * @return true if contains
+     */
+    boolean contains(T item);
+
+    /**
+     * Get all recent list items.
+     *
+     * @return list of abstract items
+     */
+    List<T> getAll();
+
+    /**
+     * Clear recent list.
+     */
+    void clear();
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -589,6 +589,21 @@ public interface CoreLocalizationConstant extends Messages {
     @Key("select.path.window.title")
     String selectPathWindowTitle();
 
+    @Key("open.recent.file.title")
+    String openRecentFileTitle();
+
+    @Key("open.recent.file.description")
+    String openRecentFileDescription();
+
+    @Key("open.recent.files.title")
+    String openRecentFilesTitle();
+
+    @Key("open.recent.file.clear.title")
+    String openRecentFileClearTitle();
+
+    @Key("open.recent.file.clear.description")
+    String openRecentFileClearDescription();
+
     @Key("editor.tab.context.menu.close")
     String editorTabClose();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ActionManagerImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/ActionManagerImpl.java
@@ -79,6 +79,11 @@ public class ActionManagerImpl implements ActionManager {
         registerAction(IdeActions.GROUP_FILE, fileGroup);
         mainMenu.add(fileGroup);
 
+        DefaultActionGroup editGroup = new DefaultActionGroup("Edit", true, this);
+        registerAction(IdeActions.GROUP_EDIT, editGroup);
+        Constraints afterFile = new Constraints(Anchor.BEFORE, IdeActions.GROUP_CODE);
+        mainMenu.add(editGroup, afterFile);
+
         DefaultActionGroup codeGroup = new DefaultActionGroup("Code", true, this);
         registerAction(IdeActions.GROUP_CODE, codeGroup);
         Constraints afterView = new Constraints(Anchor.AFTER, IdeActions.GROUP_FILE);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/StandardComponentInitializer.java
@@ -69,6 +69,7 @@ import org.eclipse.che.ide.connection.WsConnectionListener;
 import org.eclipse.che.ide.imageviewer.ImageViewerProvider;
 import org.eclipse.che.ide.newresource.NewFileAction;
 import org.eclipse.che.ide.newresource.NewFolderAction;
+import org.eclipse.che.ide.part.editor.recent.OpenRecentFilesAction;
 import org.eclipse.che.ide.part.editor.actions.CloseAction;
 import org.eclipse.che.ide.part.editor.actions.CloseAllAction;
 import org.eclipse.che.ide.part.editor.actions.CloseAllExceptPinnedAction;
@@ -266,6 +267,9 @@ public class StandardComponentInitializer {
     private HotKeysListAction hotKeysListAction;
 
     @Inject
+    private OpenRecentFilesAction openRecentFilesAction;
+
+    @Inject
     @Named("XMLFileType")
     private FileType xmlFile;
 
@@ -400,6 +404,11 @@ public class StandardComponentInitializer {
         saveGroup.addSeparator();
         saveGroup.add(saveAction);
         saveGroup.add(saveAllAction);
+
+        actionManager.registerAction("openRecentFiles", openRecentFilesAction);
+
+        DefaultActionGroup editGroup = (DefaultActionGroup)actionManager.getAction(IdeActions.GROUP_EDIT);
+        editGroup.add(openRecentFilesAction);
 
         // Compose File menu
         DefaultActionGroup fileGroup = (DefaultActionGroup)actionManager.getAction(IdeActions.GROUP_FILE);
@@ -554,6 +563,7 @@ public class StandardComponentInitializer {
         keyBinding.getGlobal().addKey(new KeyBuilder().action().charCode('v').build(), "paste");
         keyBinding.getGlobal().addKey(new KeyBuilder().alt().charCode(KeyCodeMap.ARROW_LEFT).build(), "switchLeftTab");
         keyBinding.getGlobal().addKey(new KeyBuilder().alt().charCode(KeyCodeMap.ARROW_RIGHT).build(), "switchRightTab");
+        keyBinding.getGlobal().addKey(new KeyBuilder().action().charCode('e').build(), "openRecentFiles");
     }
 
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/inject/CoreGinModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/inject/CoreGinModule.java
@@ -103,6 +103,9 @@ import org.eclipse.che.ide.core.Component;
 import org.eclipse.che.ide.core.StandardComponentInitializer;
 import org.eclipse.che.ide.core.editor.EditorAgentImpl;
 import org.eclipse.che.ide.core.editor.EditorRegistryImpl;
+import org.eclipse.che.ide.part.editor.recent.RecentFileActionFactory;
+import org.eclipse.che.ide.part.editor.recent.RecentFileList;
+import org.eclipse.che.ide.part.editor.recent.RecentFileStore;
 import org.eclipse.che.ide.part.editor.EditorTabContextMenuFactory;
 import org.eclipse.che.ide.preferences.pages.extensions.ExtensionManagerPresenter;
 import org.eclipse.che.ide.preferences.pages.extensions.ExtensionManagerView;
@@ -412,6 +415,9 @@ public class CoreGinModule extends AbstractGinModule {
         bind(HotKeysDialogView.class).to(HotKeysDialogViewImpl.class).in(Singleton.class);
 
         GinMultibinder.newSetBinder(binder(), SettingsPagePresenter.class);
+
+        bind(RecentFileList.class).to(RecentFileStore.class).in(Singleton.class);
+        install(new GinFactoryModuleBuilder().build(RecentFileActionFactory.class));
     }
 
     /** Configures binding for Editor API */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/OpenRecentFileViewImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/OpenRecentFileViewImpl.java
@@ -1,0 +1,202 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.recent;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.event.dom.client.DoubleClickEvent;
+import com.google.gwt.event.dom.client.DoubleClickHandler;
+import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.CssResource;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.user.client.ui.DockLayoutPanel;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.project.node.HasAttributes;
+import org.eclipse.che.ide.api.project.node.HasProjectConfig;
+import org.eclipse.che.ide.api.project.node.HasStorablePath;
+import org.eclipse.che.ide.api.project.node.Node;
+import org.eclipse.che.ide.api.project.node.interceptor.NodeInterceptor;
+import org.eclipse.che.ide.project.node.FileReferenceNode;
+import org.eclipse.che.ide.ui.smartTree.NodeUniqueKeyProvider;
+import org.eclipse.che.ide.ui.smartTree.Tree;
+import org.eclipse.che.ide.ui.smartTree.TreeNodeLoader;
+import org.eclipse.che.ide.ui.smartTree.TreeNodeStorage;
+import org.eclipse.che.ide.ui.smartTree.event.SelectionChangedEvent;
+import org.eclipse.che.ide.ui.smartTree.presentation.DefaultPresentationRenderer;
+import org.eclipse.che.ide.ui.window.Window;
+
+import javax.validation.constraints.NotNull;
+import java.util.Collections;
+import java.util.List;
+
+import static com.google.gwt.dom.client.Style.Overflow.AUTO;
+import static org.eclipse.che.ide.part.editor.recent.RecentFileStore.getShortPath;
+import static org.eclipse.che.ide.project.node.AbstractProjectBasedNode.CUSTOM_BACKGROUND_FILL;
+import static org.eclipse.che.ide.ui.smartTree.TreeSelectionModel.Mode.SINGLE;
+
+/**
+ * Implementation for the {@link OpenRecentFilesView}.
+ *
+ * @author Vlad Zhukovskiy
+ */
+@Singleton
+public class OpenRecentFileViewImpl extends Window implements OpenRecentFilesView {
+
+    interface OpenRecentFileViewImplUiBinder extends UiBinder<Widget, OpenRecentFileViewImpl> {
+    }
+
+    private static OpenRecentFileViewImplUiBinder uiBinder = GWT.create(OpenRecentFileViewImplUiBinder.class);
+
+    @UiField
+    DockLayoutPanel content;
+
+    private Tree  tree;
+    private Label pathLabel;
+
+    @Inject
+    public OpenRecentFileViewImpl(CoreLocalizationConstant locale, Styles styles) {
+
+        setWidget(uiBinder.createAndBindUi(this));
+
+        styles.css().ensureInjected();
+
+        pathLabel = new Label();
+        pathLabel.setStyleName(styles.css().label());
+
+        TreeNodeStorage storage = new TreeNodeStorage(new NodeUniqueKeyProvider() {
+            @Override
+            public String getKey(@NotNull Node item) {
+                if (item instanceof HasStorablePath) {
+                    return ((HasStorablePath)item).getStorablePath();
+                } else {
+                    return String.valueOf(item.hashCode());
+                }
+            }
+        });
+        TreeNodeLoader loader = new TreeNodeLoader(Collections.<NodeInterceptor>emptySet());
+        tree = new Tree(storage, loader);
+        tree.setNodePresentationRenderer(new DefaultPresentationRenderer<Node>(tree.getTreeStyles()) {
+            @Override
+            public Element render(Node node, String domID, Tree.Joint joint, int depth) {
+                Element element = super.render(node, domID, joint, depth);
+
+                element.setAttribute("name", node.getName());
+
+                if (node instanceof HasStorablePath) {
+                    element.setAttribute("path", ((HasStorablePath)node).getStorablePath());
+                }
+
+                if (node instanceof HasProjectConfig) {
+                    element.setAttribute("project", ((HasProjectConfig)node).getProjectConfig().getPath());
+                }
+
+                if (node instanceof HasAttributes && ((HasAttributes)node).getAttributes().containsKey(CUSTOM_BACKGROUND_FILL)) {
+                    element.getFirstChildElement().getStyle()
+                           .setBackgroundColor(((HasAttributes)node).getAttributes().get(CUSTOM_BACKGROUND_FILL).get(0));
+                }
+
+                return element;
+            }
+        });
+        tree.setAutoSelect(true);
+        tree.getSelectionModel().setSelectionMode(SINGLE);
+        tree.getSelectionModel().addSelectionChangedHandler(new SelectionChangedEvent.SelectionChangedHandler() {
+            @Override
+            public void onSelectionChanged(SelectionChangedEvent event) {
+                List<Node> selection = event.getSelection();
+                if (selection == null || selection.isEmpty()) {
+                    pathLabel.setText("");
+                    pathLabel.setTitle("");
+                    return;
+                }
+
+                Node head = selection.get(0);
+
+                if (head instanceof HasStorablePath) {
+                    String path = getShortPath(((HasStorablePath)head).getStorablePath());
+                    pathLabel.setText(path);
+                    pathLabel.setTitle(path);
+                    return;
+                }
+
+                pathLabel.setText("");
+                pathLabel.setTitle("");
+            }
+        });
+
+        tree.addDomHandler(new DoubleClickHandler() {
+            @Override
+            public void onDoubleClick(DoubleClickEvent event) {
+                hide();
+            }
+        }, DoubleClickEvent.getType());
+
+        tree.ensureDebugId("recent-files");
+        tree.getElement().getStyle().setOverflowY(AUTO);
+
+        content.addSouth(pathLabel, 20.);
+        content.add(tree);
+
+        setTitle(locale.openRecentFilesTitle());
+
+        setHideOnEscapeEnabled(true);
+
+        getFooter().setVisible(false);
+
+        getWidget().setStyleName(styles.css().window());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setDelegate(ActionDelegate delegate) {
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setRecentFiles(List<FileReferenceNode> recentFiles) {
+        tree.getNodeStorage().clear();
+        for (FileReferenceNode recentFile : recentFiles) {
+            tree.getNodeStorage().add(recentFile);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void clearRecentFiles() {
+        tree.getNodeStorage().clear();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void show() {
+        super.show();
+        if (!tree.getRootNodes().isEmpty()) {
+            tree.getSelectionModel().select(tree.getRootNodes().get(0), false);
+        }
+    }
+
+    public interface Styles extends ClientBundle {
+        interface Css extends CssResource {
+            String window();
+
+            String label();
+        }
+
+        @Source("recent.css")
+        Css css();
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/OpenRecentFileViewImpl.ui.xml
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/OpenRecentFileViewImpl.ui.xml
@@ -1,0 +1,16 @@
+<!--
+
+    Copyright (c) 2012-2015 Codenvy, S.A.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Codenvy, S.A. - initial API and implementation
+
+-->
+<ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
+             xmlns:g="urn:import:com.google.gwt.user.client.ui">
+    <g:DockLayoutPanel unit="PX" height="330px" width="300px" ui:field="content"/>
+</ui:UiBinder>

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/OpenRecentFilesAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/OpenRecentFilesAction.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.recent;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.api.analytics.client.logger.AnalyticsEventLogger;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+
+import javax.validation.constraints.NotNull;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+/**
+ * Action shows dialog with recently opened files.
+ *
+ * @author Vlad Zhukovskiy
+ */
+@Singleton
+public class OpenRecentFilesAction extends AbstractPerspectiveAction {
+
+    private final RecentFileList       recentFileList;
+    private final AnalyticsEventLogger eventLogger;
+
+    @Inject
+    public OpenRecentFilesAction(RecentFileList recentFileList,
+                                 AnalyticsEventLogger eventLogger,
+                                 CoreLocalizationConstant locale) {
+        super(singletonList(PROJECT_PERSPECTIVE_ID), locale.openRecentFileTitle(), locale.openRecentFileDescription(), null, null);
+        this.recentFileList = recentFileList;
+        this.eventLogger = eventLogger;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateInPerspective(@NotNull ActionEvent event) {
+        event.getPresentation().setEnabledAndVisible(!recentFileList.isEmpty());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        eventLogger.log(this);
+        recentFileList.getRecentViewDialog().show();
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/OpenRecentFilesPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/OpenRecentFilesPresenter.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.recent;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import org.eclipse.che.ide.project.node.FileReferenceNode;
+
+import java.util.List;
+
+/**
+ * Presenter for showing recently opened files.
+ *
+ * @author Vlad Zhukovskiy
+ */
+@Singleton
+public class OpenRecentFilesPresenter implements OpenRecentFilesView.ActionDelegate {
+
+    private final OpenRecentFilesView view;
+
+    @Inject
+    public OpenRecentFilesPresenter(OpenRecentFilesView view) {
+        this.view = view;
+
+        view.setDelegate(this);
+    }
+
+    /**
+     * Show dialog.
+     */
+    public void show() {
+        view.show();
+    }
+
+    /**
+     * Set recent file list.
+     *
+     * @param recentFiles
+     *         recent file list
+     */
+    public void setRecentFiles(List<FileReferenceNode> recentFiles) {
+        view.setRecentFiles(recentFiles);
+    }
+
+    /**
+     * Clear recent file list.
+     */
+    public void clearRecentFiles() {
+        view.clearRecentFiles();
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/OpenRecentFilesView.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/OpenRecentFilesView.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.recent;
+
+import com.google.inject.ImplementedBy;
+
+import org.eclipse.che.ide.api.mvp.View;
+import org.eclipse.che.ide.project.node.FileReferenceNode;
+
+import java.util.List;
+
+/**
+ * View for the {@link OpenRecentFilesPresenter}.
+ *
+ * @author Vlad Zhukovskiy
+ */
+@ImplementedBy(OpenRecentFileViewImpl.class)
+public interface OpenRecentFilesView extends View<OpenRecentFilesView.ActionDelegate> {
+
+    /**
+     * Set recent file list.
+     *
+     * @param recentFiles
+     *         recent file list
+     */
+    void setRecentFiles(List<FileReferenceNode> recentFiles);
+
+    /**
+     * Clear recent file list.
+     */
+    void clearRecentFiles();
+
+    /**
+     * Show dialog.
+     */
+    void show();
+
+    interface ActionDelegate {
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/RecentFileAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/RecentFileAction.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.recent;
+
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.project.node.FileReferenceNode;
+
+import javax.validation.constraints.NotNull;
+
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.part.editor.recent.RecentFileStore.getShortPath;
+import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+/**
+ * Action for the recent file. When user click on this action, recent file opens again in editor.
+ *
+ * @author Vlad Zhukovskiy
+ */
+public class RecentFileAction extends AbstractPerspectiveAction {
+
+    private final FileReferenceNode file;
+
+    @Inject
+    public RecentFileAction(@Assisted FileReferenceNode file) {
+        super(singletonList(PROJECT_PERSPECTIVE_ID), getShortPath(file.getStorablePath()), null, null, null);
+        this.file = file;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void updateInPerspective(@NotNull ActionEvent event) {
+        event.getPresentation().setEnabledAndVisible(true);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        file.actionPerformed();
+    }
+
+    /**
+     * Return an id for the registration in action manager.
+     *
+     * @return action id
+     */
+    public String getId() {
+        return "close-file-" + file.getName();
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/RecentFileActionFactory.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/RecentFileActionFactory.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.recent;
+
+import org.eclipse.che.ide.project.node.FileReferenceNode;
+
+/**
+ * Factory for the recent files action.
+ *
+ * @author Vlad Zhukovskiy
+ */
+public interface RecentFileActionFactory {
+    /**
+     * Creates new recent file action to show in main menu.
+     *
+     * @param file
+     *         file associated with
+     * @return action
+     */
+    RecentFileAction newRecentFileAction(FileReferenceNode file);
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/RecentFileList.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/RecentFileList.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.recent;
+
+import org.eclipse.che.ide.api.recent.RecentList;
+import org.eclipse.che.ide.project.node.FileReferenceNode;
+
+/**
+ * Extension for the recent list which process recent file lists.
+ *
+ * @author Vlad Zhukovskiy
+ */
+public interface RecentFileList extends RecentList<FileReferenceNode> {
+    /**
+     * Return recent file list user dialog.
+     *
+     * @return user dialog with recent file list
+     */
+    OpenRecentFilesPresenter getRecentViewDialog();
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/RecentFileStore.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/recent/RecentFileStore.java
@@ -1,0 +1,247 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.ide.part.editor.recent;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+
+import org.eclipse.che.api.promises.client.Operation;
+import org.eclipse.che.api.promises.client.OperationException;
+import org.eclipse.che.ide.CoreLocalizationConstant;
+import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
+import org.eclipse.che.ide.api.action.ActionEvent;
+import org.eclipse.che.ide.api.action.ActionManager;
+import org.eclipse.che.ide.api.action.DefaultActionGroup;
+import org.eclipse.che.ide.api.action.IdeActions;
+import org.eclipse.che.ide.api.constraints.Constraints;
+import org.eclipse.che.ide.api.event.FileEvent;
+import org.eclipse.che.ide.api.event.FileEventHandler;
+import org.eclipse.che.ide.api.project.node.HasStorablePath.StorablePath;
+import org.eclipse.che.ide.api.project.node.Node;
+import org.eclipse.che.ide.api.project.tree.VirtualFile;
+import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
+import org.eclipse.che.ide.project.node.FileReferenceNode;
+import org.eclipse.che.ide.util.Pair;
+
+import javax.validation.constraints.NotNull;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import static com.google.common.collect.Lists.newLinkedList;
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.ide.api.constraints.Anchor.BEFORE;
+import static org.eclipse.che.ide.api.constraints.Constraints.FIRST;
+import static org.eclipse.che.ide.api.constraints.Constraints.LAST;
+import static org.eclipse.che.ide.api.event.FileEvent.FileOperation.OPEN;
+import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
+
+/**
+ * Default implementation of Recent File List.
+ *
+ * @author Vlad Zhukovskiy
+ */
+@Singleton
+public class RecentFileStore implements RecentFileList, FileEventHandler {
+
+    public static final int MAX_FILES_IN_STACK         = 25;
+    public static final int MAX_PATH_LENGTH_TO_DISPLAY = 50;
+
+    private final ProjectExplorerPresenter projectExplorer;
+    private final OpenRecentFilesPresenter openRecentFilesPresenter;
+    private final ActionManager            actionManager;
+    private final RecentFileActionFactory  recentFileActionFactory;
+    private final CoreLocalizationConstant locale;
+    private final DefaultActionGroup       recentGroup;
+
+    private LinkedList<FileReferenceNode>                         recentStorage = newLinkedList();
+    private LinkedList<Pair<FileReferenceNode, RecentFileAction>> fileToAction  = newLinkedList();
+
+    @Inject
+    public RecentFileStore(EventBus eventBus,
+                           ProjectExplorerPresenter projectExplorer,
+                           OpenRecentFilesPresenter openRecentFilesPresenter,
+                           ActionManager actionManager,
+                           RecentFileActionFactory recentFileActionFactory,
+                           CoreLocalizationConstant locale) {
+        this.projectExplorer = projectExplorer;
+        this.openRecentFilesPresenter = openRecentFilesPresenter;
+        this.actionManager = actionManager;
+        this.recentFileActionFactory = recentFileActionFactory;
+        this.locale = locale;
+
+        ClearRecentListAction action = new ClearRecentListAction();
+
+        recentGroup = new DefaultActionGroup("Recent", true, actionManager);
+        actionManager.registerAction(IdeActions.GROUP_RECENT_FILES, recentGroup);
+
+        actionManager.registerAction("clearRecentList", action);
+        recentGroup.addSeparator();
+        recentGroup.add(action, LAST);
+
+        DefaultActionGroup editGroup = (DefaultActionGroup)actionManager.getAction(IdeActions.GROUP_EDIT);
+        editGroup.add(recentGroup, new Constraints(BEFORE, "openRecentFiles"));
+
+        eventBus.addHandler(FileEvent.TYPE, this);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void onFileOperation(FileEvent event) {
+        if (event.getOperationType() == OPEN) {
+            VirtualFile file = event.getFile();
+            if (file instanceof FileReferenceNode) {
+                add((FileReferenceNode)file);
+            } else {
+                //we got this file not from the project explorer
+                projectExplorer.getNodeByPath(new StorablePath(file.getPath())).then(new Operation<Node>() {
+                    @Override
+                    public void apply(Node node) throws OperationException {
+                        if (node instanceof FileReferenceNode) {
+                            add((FileReferenceNode)node);
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isEmpty() {
+        return recentStorage.isEmpty();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean add(final FileReferenceNode item) {
+        if (item == null) {
+            return false;
+        }
+
+        //initial precondition
+        if (recentStorage.size() == MAX_FILES_IN_STACK) {
+            remove(recentStorage.getLast());
+        }
+
+        remove(item);
+
+        recentStorage.addFirst(item);
+        openRecentFilesPresenter.setRecentFiles(getAll());
+
+        //register recent item action
+        RecentFileAction action = recentFileActionFactory.newRecentFileAction(item);
+        fileToAction.add(Pair.of(item, action));
+        actionManager.registerAction(action.getId(), action);
+        recentGroup.add(action, FIRST);
+
+        return true;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean remove(FileReferenceNode item) {
+        recentStorage.remove(item);
+        openRecentFilesPresenter.setRecentFiles(getAll());
+
+        //with one cycle de-register action and remove it from recent group
+        Iterator<Pair<FileReferenceNode, RecentFileAction>> iterator = fileToAction.iterator();
+        while (iterator.hasNext()) {
+            Pair<FileReferenceNode, RecentFileAction> pair = iterator.next();
+            if (pair.getFirst().equals(item)) {
+                recentGroup.remove(pair.getSecond());
+                actionManager.unregisterAction(pair.getSecond().getId());
+                iterator.remove();
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean contains(FileReferenceNode item) {
+        return recentStorage.contains(item);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public List<FileReferenceNode> getAll() {
+        return recentStorage;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void clear() {
+        openRecentFilesPresenter.clearRecentFiles();
+
+        recentStorage.clear();
+
+        //de-register all previously registered actions
+        for (Pair<FileReferenceNode, RecentFileAction> pair : fileToAction) {
+            actionManager.unregisterAction(pair.getSecond().getId());
+            recentGroup.remove(pair.getSecond());
+        }
+
+        fileToAction.clear();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public OpenRecentFilesPresenter getRecentViewDialog() {
+        return openRecentFilesPresenter;
+    }
+
+    /**
+     * Split path if it more then 50 characters. Otherwise, if path is less then 50 characters then it returns as is.
+     *
+     * @param path
+     *         path to check
+     * @return path to display
+     */
+    static String getShortPath(String path) {
+        if (path.length() < MAX_PATH_LENGTH_TO_DISPLAY) {
+            return path;
+        }
+
+        int bIndex = path.length() - MAX_PATH_LENGTH_TO_DISPLAY;
+        String raw = path.substring(bIndex);
+
+        if (raw.indexOf('/') == -1) {
+            return raw;
+        }
+
+        raw = raw.substring(raw.indexOf('/'));
+        raw = "..." + raw;
+
+        return raw;
+    }
+
+    private class ClearRecentListAction extends AbstractPerspectiveAction {
+
+        public ClearRecentListAction() {
+            super(singletonList(PROJECT_PERSPECTIVE_ID), locale.openRecentFileClearTitle(), locale.openRecentFileClearDescription(), null,
+                  null);
+        }
+
+        @Override
+        public void updateInPerspective(@NotNull ActionEvent event) {
+            event.getPresentation().setEnabledAndVisible(!isEmpty());
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            clear();
+        }
+    }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/project/node/ItemReferenceBasedNode.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/project/node/ItemReferenceBasedNode.java
@@ -80,4 +80,21 @@ public abstract class ItemReferenceBasedNode extends ResourceBasedNode<ItemRefer
 
         return ((HasStorablePath)getParent()).getStorablePath() + "/" + getData().getName();
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof HasStorablePath)) return false;
+
+        HasStorablePath that = (HasStorablePath)o;
+
+        if (!getStorablePath().equals(that.getStorablePath())) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return getStorablePath().hashCode();
+    }
 }

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -271,6 +271,13 @@ text.search.file.mask=File mask:
 text.search.directory=Root directory:
 select.path.window.title=Select Path
 
+############# Recent Files #############
+open.recent.file.title=Open Recent File
+open.recent.file.description=Open recent file
+open.recent.files.title=Recent Files
+open.recent.file.clear.title=Clear List
+open.recent.file.clear.description=Clear recent list
+
 ############# Editor tab context menu #############
 editor.tab.context.menu.close=Close
 editor.tab.context.menu.close.description=Close current editor

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/part/editor/recent/recent.css
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/part/editor/recent/recent.css
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+@eval windowFooterBorderColor org.eclipse.che.ide.api.theme.Style.getWindowFooterBorderColor();
+
+.window {
+    padding: 0px;
+}
+
+.label {
+    border-top: 1px solid windowFooterBorderColor;
+    padding: 3px 3px 0px 3px;
+    font-size: 9px;
+}


### PR DESCRIPTION
New dialog will display list of recently opened files (file name and path).
Double clicking on file will open editor.
![- 20 12 2015 - 22 03 07](https://cloud.githubusercontent.com/assets/1968177/11920042/d5ba141a-a76c-11e5-8858-44e2601ace66.png)
User may call this dialog by hotkey Ctrl+E (Linux/Windows) or Command+E (Mac)

Also new menu item: File->Recent.
Will contains the same list. Also user can clear recent list by menu item File->Recent->Clear Recent List
![- 20 12 2015 - 22 01 13](https://cloud.githubusercontent.com/assets/1968177/11920043/e0aeb13c-a76c-11e5-9c25-4923eded36cd.png)

Screencast: https://slack-files.com/T02G3VAG4-F0H2V70HX-a2d294fdf9
@vparfonov @skabashnyuk @evidolob wdyt?