### PR TITLE
IDEX-3854 Update error code returned if there is an error in ServletProxy

### DIFF
--- a/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/proxy/MachineExtensionProxyServlet.java
+++ b/platform-api/che-core-api-machine/src/main/java/org/eclipse/che/api/machine/server/proxy/MachineExtensionProxyServlet.java
@@ -37,8 +37,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
-import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static javax.servlet.http.HttpServletResponse.SC_BAD_GATEWAY;
+import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
 
 /**
  * Routes requests to extension API hosted in machine
@@ -77,15 +77,15 @@ public class MachineExtensionProxyServlet extends HttpServlet {
 
                 setResponse(resp, conn);
             } catch (IOException e) {
-                resp.sendError(SC_INTERNAL_SERVER_ERROR, "Request can't be forwarded to machine. " + e.getLocalizedMessage());
+                resp.sendError(SC_BAD_GATEWAY, "Request can't be forwarded to machine. " + e.getLocalizedMessage());
             } finally {
                 conn.disconnect();
             }
 
         } catch (NotFoundException e) {
-            resp.sendError(SC_NOT_FOUND, "Request can't be forwarded to machine. " + e.getLocalizedMessage());
+            resp.sendError(SC_SERVICE_UNAVAILABLE, "Request can't be forwarded to machine. " + e.getLocalizedMessage());
         } catch (ServerException e) {
-            resp.sendError(SC_INTERNAL_SERVER_ERROR, "Request can't be forwarded to machine. " + e.getLocalizedMessage());
+            resp.sendError(SC_BAD_GATEWAY, "Request can't be forwarded to machine. " + e.getLocalizedMessage());
         }
     }
 

--- a/platform-api/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/proxy/MachineExtensionProxyServletTest.java
+++ b/platform-api/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/proxy/MachineExtensionProxyServletTest.java
@@ -46,6 +46,8 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static javax.servlet.http.HttpServletResponse.SC_BAD_GATEWAY;
+import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -269,7 +271,7 @@ public class MachineExtensionProxyServletTest {
 
         proxyServlet.service(mockRequest, mockResponse);
 
-        assertEquals(mockResponse.getStatus(), 500);
+        assertEquals(mockResponse.getStatus(), SC_BAD_GATEWAY);
         // TODO look like bug in everrest test library, if {@code HttpServletResponse#sendError(int code, String message)}
         // is used no response message in output stream can be found
 //        assertEquals(mockResponse.getOutputContent(), "Request can't be forwarded to machine. No extension server found in machine");
@@ -450,7 +452,7 @@ public class MachineExtensionProxyServletTest {
 
         proxyServlet.service(mockRequest, mockResponse);
 
-        assertEquals(mockResponse.getStatus(), 500, mockResponse.getOutputContent());
+        assertEquals(mockResponse.getStatus(), SC_BAD_GATEWAY, mockResponse.getOutputContent());
     }
 
     @Test
@@ -469,7 +471,7 @@ public class MachineExtensionProxyServletTest {
 
         proxyServlet.service(mockRequest, mockResponse);
 
-        assertEquals(mockResponse.getStatus(), 404, mockResponse.getOutputContent());
+        assertEquals(mockResponse.getStatus(), SC_SERVICE_UNAVAILABLE, mockResponse.getOutputContent());
     }
 
     /**


### PR DESCRIPTION
error 404 changed into 503 if machine not here (service unavailable)
error 500 changed into 502 if there is error when communicating (bad gateway)

Change-Id: I0853af71062d7c102a8015c16c8f61097a9f8d2e
Signed-off-by: Florent BENOIT <fbenoit@codenvy.com>