### PR TITLE
IDEX-3842: Fix GitHub Authorize application

### DIFF
--- a/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/security/oauth/JsOAuthWindow.java
+++ b/commons/che-core-commons-gwt/src/main/java/org/eclipse/che/security/oauth/JsOAuthWindow.java
@@ -76,7 +76,7 @@ public class JsOAuthWindow {
 
                     if (href) {
                         var path = popupWindow.location.pathname;
-                        if (path == ("/ws/" + $wnd.IDE.config.workspaceName) || path == "/dashboard/") {
+                        if (path == (authUrl.substring(authUrl.lastIndexOf("/ws"))) || path == "/dashboard/") {
                             instance.@org.eclipse.che.security.oauth.JsOAuthWindow::setAuthenticationStatus(I)(3);
                             popupWindow.close();
                             popupWindow = null;


### PR DESCRIPTION
$wnd.IDE.config is a deprecated variable and it returns empty workspace name, so I check that loaded page url is equels to given url.
@vparfonov @skabashnyuk 