### PR TITLE
Decode authorization token before setting it to Authorization header

### DIFF
--- a/commons/che-core-commons-env/src/main/java/org/eclipse/che/commons/env/EnvironmentContext.java
+++ b/commons/che-core-commons-env/src/main/java/org/eclipse/che/commons/env/EnvironmentContext.java
@@ -10,6 +10,13 @@
  *******************************************************************************/
 package org.eclipse.che.commons.env;
 
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+
+import javax.ws.rs.core.HttpHeaders;
+
 import org.eclipse.che.commons.lang.concurrent.ThreadLocalPropagateContext;
 import org.eclipse.che.commons.user.User;
 
@@ -109,4 +116,29 @@ public class EnvironmentContext {
     public void setWorkspaceTemporary(boolean workspaceTemporary) {
         this.workspaceTemporary = workspaceTemporary;
     }
+
+    /**
+     * Set the HTTP Authorization header based on the authorization token of the user.
+     * 
+     * @param conn
+     *            The HTTP connection to modify.
+     */
+    public void setAuthorization(HttpURLConnection conn) {
+        User user = getUser();
+        if (user == null) {
+            return;
+        }
+        String token = user.getToken();
+        if (token == null) {
+            return;
+        }
+        String decodedToken;
+        try {
+            decodedToken = URLDecoder.decode(token, Charset.defaultCharset().name());
+        } catch (UnsupportedEncodingException e) {
+            return;
+        }
+        conn.setRequestProperty(HttpHeaders.AUTHORIZATION, decodedToken);
+    }
+
 }

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/RemoteTask.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/RemoteTask.java
@@ -234,10 +234,7 @@ public class RemoteTask {
         conn.setConnectTimeout(60 * 1000);
         conn.setReadTimeout(60 * 1000);
         conn.setRequestMethod(HttpMethod.GET);
-        final EnvironmentContext context = EnvironmentContext.getCurrent();
-        if (context.getUser() != null && context.getUser().getToken() != null) {
-            conn.setRequestProperty(HttpHeaders.AUTHORIZATION, context.getUser().getToken());
-        }
+        EnvironmentContext.getCurrent().setAuthorization(conn);
         try {
             output.setStatus(conn.getResponseCode());
             final String contentType = conn.getContentType();

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/SourcesManagerImpl.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/SourcesManagerImpl.java
@@ -220,10 +220,7 @@ public class SourcesManagerImpl implements SourcesManager {
             conn = (HttpURLConnection)new URL(downloadUrl).openConnection();
             conn.setConnectTimeout(CONNECT_TIMEOUT);
             conn.setReadTimeout(READ_TIMEOUT);
-            final EnvironmentContext context = EnvironmentContext.getCurrent();
-            if (context.getUser() != null && context.getUser().getToken() != null) {
-                conn.setRequestProperty(HttpHeaders.AUTHORIZATION, context.getUser().getToken());
-            }
+            EnvironmentContext.getCurrent().setAuthorization(conn);
             if (!md5sums.isEmpty()) {
                 conn.setRequestMethod(HttpMethod.POST);
                 conn.setRequestProperty("Content-type", MediaType.TEXT_PLAIN);

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequest.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/DefaultHttpJsonRequest.java
@@ -205,9 +205,7 @@ public class DefaultHttpJsonRequest implements HttpJsonRequest {
             conn.setRequestMethod(method);
             //drop a hint for server side that we want to receive application/json
             conn.addRequestProperty(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
-            if (authToken != null) {
-                conn.setRequestProperty(HttpHeaders.AUTHORIZATION, authToken);
-            }
+            EnvironmentContext.getCurrent().setAuthorization(conn);
             if (body != null) {
                 conn.addRequestProperty(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
                 conn.setDoOutput(true);

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpJsonHelper.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpJsonHelper.java
@@ -36,7 +36,9 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -430,9 +432,7 @@ public class HttpJsonHelper {
                 conn.setRequestMethod(method);
                 //drop a hint for server side that we want to receive application/json
                 conn.addRequestProperty(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
-                if (authToken != null) {
-                    conn.setRequestProperty(HttpHeaders.AUTHORIZATION, authToken);
-                }
+                EnvironmentContext.getCurrent().setAuthorization(conn);
                 if (body != null) {
                     conn.addRequestProperty(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
                     conn.setDoOutput(true);

--- a/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RemoteRunnerProcess.java
+++ b/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RemoteRunnerProcess.java
@@ -138,10 +138,7 @@ public class RemoteRunnerProcess {
         conn.setConnectTimeout(60 * 1000);
         conn.setReadTimeout(60 * 1000);
         conn.setRequestMethod(method);
-        final EnvironmentContext context = EnvironmentContext.getCurrent();
-        if (context.getUser() != null && context.getUser().getToken() != null) {
-            conn.setRequestProperty(HttpHeaders.AUTHORIZATION, context.getUser().getToken());
-        }
+        EnvironmentContext.getCurrent().setAuthorization(conn);
         try {
             if (output instanceof HttpOutputMessage) {
                 HttpOutputMessage httpOutput = (HttpOutputMessage)output;

--- a/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RunQueue.java
+++ b/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RunQueue.java
@@ -1237,6 +1237,7 @@ public class RunQueue {
                     conn.setRequestMethod(requestMethod);
                     conn.setConnectTimeout(1000);
                     conn.setReadTimeout(1000);
+                    EnvironmentContext.getCurrent().setAuthorization(conn);
 
                     LOG.debug(String.format("Response code: %d.", conn.getResponseCode()));
                     if (405 == conn.getResponseCode()) {


### PR DESCRIPTION
Setting the user token value as-is to the Authorization header of outgoing requests might cause double encoding because the environment token can have a URL-encoded value. This fix decodes it to the real value so that the ultimate header encoding is left solely to the URL mechanism.

Signed-off-by: Tareq Sharafy <tareq.sha@gmail.com>