### PR TITLE
Do not add token to sourcesUrl of BuildRequest explicitly

### DIFF
--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuildQueue.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuildQueue.java
@@ -430,8 +430,7 @@ public class BuildQueue {
         final Link zipballLink = descriptor.getLink(org.eclipse.che.api.project.server.Constants.LINK_REL_EXPORT_ZIP);
         if (zipballLink != null) {
             final String zipballLinkHref = zipballLink.getHref();
-            final String token = getAuthenticationToken();
-            request.setSourcesUrl(token != null ? String.format("%s?token=%s", zipballLinkHref, token) : zipballLinkHref);
+            request.setSourcesUrl(zipballLinkHref);
         }
     }
 


### PR DESCRIPTION
Passing the token in the URL that is provided to the slave builder might conflict with the authorization header on the other side

Signed-off-by: Tareq Sharafy <tareq.sha@gmail.com>