### PR TITLE
Authentication token fixes

### DIFF
--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuildQueue.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuildQueue.java
@@ -430,8 +430,7 @@ public class BuildQueue {
         final Link zipballLink = descriptor.getLink(org.eclipse.che.api.project.server.Constants.LINK_REL_EXPORT_ZIP);
         if (zipballLink != null) {
             final String zipballLinkHref = zipballLink.getHref();
-            final String token = getAuthenticationToken();
-            request.setSourcesUrl(token != null ? String.format("%s?token=%s", zipballLinkHref, token) : zipballLinkHref);
+            request.setSourcesUrl(zipballLinkHref);
         }
     }
 

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/Builder.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/Builder.java
@@ -28,6 +28,7 @@ import org.eclipse.che.api.core.util.ProcessUtil;
 import org.eclipse.che.api.core.util.StreamPump;
 import org.eclipse.che.api.core.util.Watchdog;
 import org.eclipse.che.commons.lang.IoUtil;
+import org.eclipse.che.commons.lang.concurrent.ThreadLocalPropagateContext;
 import org.eclipse.che.dto.server.DtoFactory;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -408,7 +409,8 @@ public abstract class Builder {
                 }
             }
         };
-        final FutureBuildTask task = new FutureBuildTask(callable, internalId, commandLine, getName(), configuration, myLogger, callback);
+        Callable<Boolean> contextCallable = ThreadLocalPropagateContext.wrap(callable);
+        final FutureBuildTask task = new FutureBuildTask(contextCallable, internalId, commandLine, getName(), configuration, myLogger, callback);
         tasks.put(internalId, task);
         executor.execute(task);
         return task;

--- a/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/internal/Runner.java
+++ b/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/internal/Runner.java
@@ -368,13 +368,7 @@ public abstract class Runner {
         }
         String url = null;
         if (link != null) {
-            final String href = link.getHref();
-            final String token = request.getUserToken();
-            if (href.indexOf('?') > 0) {
-                url = href + "&token=" + token;
-            } else {
-                url = href + "?token=" + token;
-            }
+            url = link.getHref();
         }
         if (url == null) {
             return NO_SOURCES;


### PR DESCRIPTION
Some fixes to make pass authentication token correctly across multi-threading in Che.
- Do not not add an explicit token query parameter is the download-sources URL that is passed from the build request from BuildQueue to the slave builder, leave it to the authentication header.
- Do not not add an explicit token query parameter is the URL of the deployment sources that is passed from the run request from RunQueue to the slave runner, leave it to the authentication header.
- Add authorization header to the HTTP requests issued from HTTP download plugin so that core components do not fail due to authorization issues when using it.
- Propagate thread-local context to default builder task in Che, so that the sources manager issues the download-sources HTTP call with the required authentication information available.

Signed-off-by: Tareq Sharafy tareq.sha@gmail.com
