### PR TITLE
Extended support for module paths

### DIFF
--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/DefaultProjectManager.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/DefaultProjectManager.java
@@ -351,14 +351,14 @@ public final class DefaultProjectManager implements ProjectManager {
         if (parentProject == null)
             throw new NotFoundException("Parent Project not found " + projectPath);
 
-        if (parentProject.getModules().get().contains(modulePath)) {
+        // Normalize the existing module paths and verify that there are no conflicts
+        Path absModulePathObj = Project.getAbsoluteModulePath(modulePath, parentProject);
+        Set<Path> existingAbsModulePaths = parentProject.getModules().getAbsolute();
+        if (existingAbsModulePaths.contains(absModulePathObj)) {
             throw new ConflictException("Module " + modulePath + " already exists");
         }
 
-        if (!projectPath.startsWith("/")) {
-            projectPath = "/" + projectPath;
-        }
-        String absModulePath = modulePath.startsWith("/") ? modulePath : projectPath + "/" + modulePath;
+        String absModulePath = absModulePathObj.toString();
 
         VirtualFileEntry moduleFolder = getProjectsRoot(workspace).getChild(absModulePath);
         if (moduleFolder != null && moduleFolder.isFile())
@@ -370,7 +370,6 @@ public final class DefaultProjectManager implements ProjectManager {
         if (moduleFolder == null) {
             if (moduleConfig == null)
                 throw new ConflictException("Module not found on " + absModulePath + " and module configuration is not defined");
-            Path absModulePathObj = Path.fromString(absModulePath);
             String parentPath = absModulePathObj.getParent().toString();
             String name = absModulePathObj.getName();
             final VirtualFileEntry parentFolder = getProjectsRoot(workspace).getChild(parentPath);

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/DefaultProjectManager.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/DefaultProjectManager.java
@@ -720,24 +720,49 @@ public final class DefaultProjectManager implements ProjectManager {
             // Use the same rules as in method createFile to make client side simpler.
             ((FileEntry) entry).rename(newName, newMediaType);
         } else {
+            Path oldEntryPath = entry.getVirtualFile().getVirtualFilePath();
             entry.rename(newName);
-            String projectName = projectPath(path);
-            /* We should not edit Modules if resource to rename is project */
-            if (!projectName.equals(path) && entry.isFolder() && ((FolderEntry) entry).isProjectFolder()) {
-                Project project = getProject(workspace, projectName);
-
-                /*
-                 * We need module path without projectName, f.e projectName/module1/oldModuleName ->
-                 * module1/oldModuleName
-                 */
-                String oldModulePath = path.replaceFirst(projectName + "/", "");
-                /* Calculates new module path, f.e module1/oldModuleName -> module1/newModuleName */
-                String newModulePath = oldModulePath.substring(0, oldModulePath.lastIndexOf("/") + 1) + newName;
-
-                project.getModules().update(oldModulePath, newModulePath);
+            Path newEntryPath = entry.getVirtualFile().getVirtualFilePath();
+            // Update projects modules
+            List<Project> projects = getProjects(workspace);
+            for (Project project : projects) {
+                renameModulesUnder(oldEntryPath, newEntryPath, workspace, project);
             }
         }
         return entry;
+    }
+
+    private void renameModulesUnder(Path oldFolderPath, Path newFolderPath, String workspace, Project project)
+            throws ForbiddenException, ServerException, NotFoundException, ConflictException {
+        String projectName = project.getName();
+        Set<String> modules = project.getModules().get();
+        // If the new path of the folder is outside the project, make the path absolute
+        boolean makeAbsolute = !newFolderPath.element(0).equals(projectName);
+        for (String odlModulePath : modules) {
+            Path oldAbsModulePath = Project.getAbsoluteModulePath(odlModulePath, project);
+            // Get the new absolute module path, in case it was inside the renamed folder
+            Path newAbsModulePath = null;
+            if (oldAbsModulePath.length() == oldFolderPath.length()) {
+                if (oldAbsModulePath.equals(oldFolderPath)) {
+                    newAbsModulePath = newFolderPath;
+                }
+            } else if (oldAbsModulePath.isChild(oldFolderPath)) {
+                newAbsModulePath = newFolderPath.newPath(oldAbsModulePath.subPath(oldFolderPath.length()));
+            }
+            if (newAbsModulePath == null) {
+                continue;
+            }
+            // Use relative form for the new path only if it is outside the project
+            String newValue;
+            if (makeAbsolute) {
+                newValue = newAbsModulePath.toString();
+            } else {
+                // Remove project name and then the initial '/' to mark it as relative
+                newValue = newAbsModulePath.subPath(1).toString().substring(1);
+            }
+            // Update the module
+            project.getModules().update(odlModulePath, newValue);
+        }
     }
 
     @Override

--- a/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectTest.java
+++ b/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.api.project.server;
 
+import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.notification.EventService;
@@ -597,6 +598,21 @@ public class ProjectTest {
 
     }
 
+    @Test(expectedExceptions = ConflictException.class)
+    public void testAddModuleWithConflictingPath() throws Exception {
+
+        pm.getProjectTypeRegistry().registerProjectType(new ProjectType("testModule", "my type", true, false) {
+        });
+
+        Project myProject = pm.getProject("my_ws", "my_project");
+        myProject.updateConfig(new ProjectConfig("my proj", "testModule"));
+
+        Assert.assertEquals(myProject.getModules().get().size(), 0);
+
+        pm.addModule("my_ws", "my_project", "test", new ProjectConfig("descr", "testModule"), null, null);
+        pm.addModule("my_ws", "my_project", "./test", new ProjectConfig("descr", "testModule"), null, null);
+
+    }
 
     @Test
     public void testModulePathShouldBeAdded() throws Exception {

--- a/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectTest.java
+++ b/platform-api/che-core-api-project/src/test/java/org/eclipse/che/api/project/server/ProjectTest.java
@@ -748,6 +748,39 @@ public class ProjectTest {
 
     }
 
+    // Test that renaming a folder affects all projects that contain modules inside of it, including absolute references
+    @Test
+    public void testRenameModuleIndirectly() throws Exception {
+        final String ws = "my_ws";
+        // Rename folders that contain indirect module
+        final String projType = "myprojtype1";
+        pm.getProjectTypeRegistry().registerProjectType(new ProjectType(projType, "my module type 1", true, false) {
+        });
+        // Modify the main projects
+        final String projName1 = "my_project";
+        Project proj1 = pm.getProject(ws, projName1);
+        proj1.updateConfig(new ProjectConfig("my proj", projType));
+        final String projName2 = "MainProject2";
+        Project proj2 = pm.createProject(ws, projName2, new ProjectConfig("good project", projType), null, null);
+        // Create a nested modules
+        FolderEntry parentFolder = proj1.getBaseFolder().createFolder("myfolder");
+        // first project contains a relative module inside the folder
+        parentFolder.createFolder("mymodule1");
+        pm.addModule(ws, projName1, "myfolder/mymodule1", new ProjectConfig("good project", projType), null, null);
+        // second project contains an absolute module inside the folder
+        parentFolder.createFolder("mymodule2");
+        pm.addModule(ws, projName2, "/my_project/myfolder/mymodule2", new ProjectConfig("good project", projType), null, null);
+        // Verify the modules
+        Assert.assertEquals(proj1.getModules().get(), Collections.singleton("myfolder/mymodule1"));
+        Assert.assertEquals(proj2.getModules().get(), Collections.singleton("/my_project/myfolder/mymodule2"));
+        // Rename and make sure the other project is updated
+        String newParentName = "somestuff";
+        pm.rename(ws, "/my_project/myfolder", newParentName, null);
+        // Verify the modules
+        Assert.assertEquals(proj1.getModules().get(), Collections.singleton("somestuff/mymodule1"));
+        Assert.assertEquals(proj2.getModules().get(), Collections.singleton("/my_project/somestuff/mymodule2"));
+    }
+
     @Test
     public void testDtoConverterWithMixin() throws Exception {
         //final ProjectTypeRegistry registry = injector.getInstance(ProjectTypeRegistry.class);


### PR DESCRIPTION
Current code perform a simple text comparison to check if the module being conflicts with an existing module. Fixed this by comparing actual Path objects.

Current code does not update the modules list if a non-project parent folder of the module is renamed - it explicit requires the renamed folder to be a project folder in order to perform any module updates. Fixed.

Current code does not update projects other than the project that contains the module folder - it only cuts the renamed folder's path and checks that the enclosing project has the renamed folder listed as a module. Fixed.

Signed-off-by: Tareq Sharafy <tareq.sha@gmail.com>