### PR TITLE
IDEX-4101 Ignore not existing resources in class path during scanning classes

### DIFF
--- a/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/DtoFactoryVisitorRegistryGenerator.java
+++ b/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/DtoFactoryVisitorRegistryGenerator.java
@@ -13,8 +13,6 @@ package org.eclipse.che.util;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.che.ide.dto.ClientDtoFactoryVisitor;
 import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.scanners.TypeAnnotationsScanner;
 
 import java.io.File;
 import java.io.IOException;
@@ -23,6 +21,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+
+import static org.eclipse.che.util.IgnoreUnExistedResourcesReflectionConfigurationBuilder.*;
 
 /**
  * Generates {DtoFactoryVisitorRegistry} class source.
@@ -81,7 +81,7 @@ public class DtoFactoryVisitorRegistryGenerator {
      */
     @SuppressWarnings("unchecked")
     private static void findDtoFactoryVisitors() throws IOException {
-        Reflections reflection = new Reflections(new SubTypesScanner(), new TypeAnnotationsScanner());
+        Reflections reflection = new Reflections(getConfigurationBuilder());
         Set<Class<?>> classes = reflection.getTypesAnnotatedWith(ClientDtoFactoryVisitor.class);
         int i = 0;
         for (Class clazz : classes) {

--- a/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/ExtensionManagerGenerator.java
+++ b/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/ExtensionManagerGenerator.java
@@ -10,12 +10,9 @@
  *******************************************************************************/
 package org.eclipse.che.util;
 
-import org.eclipse.che.ide.api.extension.Extension;
-
 import org.apache.commons.io.FileUtils;
+import org.eclipse.che.ide.api.extension.Extension;
 import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.scanners.TypeAnnotationsScanner;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,6 +22,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Pattern;
+
+import static org.eclipse.che.util.IgnoreUnExistedResourcesReflectionConfigurationBuilder.*;
 
 /**
  * Generates {ExtensionManager} class source
@@ -187,7 +186,7 @@ public class ExtensionManagerGenerator {
      */
     @SuppressWarnings("unchecked")
     public static void findExtensions() throws IOException {
-        Reflections reflection = new Reflections(new SubTypesScanner(), new TypeAnnotationsScanner());
+        Reflections reflection = new Reflections(getConfigurationBuilder());
         Set<Class<?>> classes = reflection.getTypesAnnotatedWith(Extension.class);
         for (Class clazz : classes) {
             EXTENSIONS_FQN.put(clazz.getCanonicalName(), clazz.getSimpleName());

--- a/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/IDEInjectorGenerator.java
+++ b/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/IDEInjectorGenerator.java
@@ -10,18 +10,17 @@
  *******************************************************************************/
 package org.eclipse.che.util;
 
-import org.eclipse.che.ide.api.extension.ExtensionGinModule;
-
 import org.apache.commons.io.FileUtils;
+import org.eclipse.che.ide.api.extension.ExtensionGinModule;
 import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.scanners.TypeAnnotationsScanner;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+
+import static org.eclipse.che.util.IgnoreUnExistedResourcesReflectionConfigurationBuilder.*;
 
 /**
  * This class looks for all the Gin Modules annotated with ExtensionGinModule annotation
@@ -150,7 +149,8 @@ public class IDEInjectorGenerator {
      */
     @SuppressWarnings("unchecked")
     public static void findGinModules(File rootFolder) throws IOException {
-        Reflections reflection = new Reflections(new SubTypesScanner(), new TypeAnnotationsScanner());
+        Reflections reflection = new Reflections(getConfigurationBuilder());
+
         Set<Class<?>> classes = reflection.getTypesAnnotatedWith(ExtensionGinModule.class);
         for (Class clazz : classes) {
             EXTENSIONS_FQN.add(clazz.getCanonicalName());

--- a/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/IgnoreUnExistedResourcesReflectionConfigurationBuilder.java
+++ b/ide/che-core-ide-generators/src/main/java/org/eclipse/che/util/IgnoreUnExistedResourcesReflectionConfigurationBuilder.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.util;
+
+import org.reflections.util.ConfigurationBuilder;
+
+import java.io.File;
+import java.util.stream.Collectors;
+
+/**
+ * Reflections configuration builder that ignore resources that is not exists.
+ * It happens when ide generators runs on generate-sources stage and ../target/classes folder is listed in class path but not exists.
+ * Reflections print NPE for such folders. See more https://github.com/ronmamo/reflections/issues/111
+ *
+ * @author Sergii Kabashniuk
+ */
+public final class IgnoreUnExistedResourcesReflectionConfigurationBuilder {
+
+    private static ConfigurationBuilder configurationBuilder;
+    static {
+        configurationBuilder=  ConfigurationBuilder.build();
+        configurationBuilder.setUrls(configurationBuilder.getUrls()
+                                                         .stream()
+                                                         .filter(input -> !input.getProtocol().equals("file") ||
+                                                                                             new File(input.getFile()).exists())
+                                                         .collect(Collectors.toList()));
+
+    }
+
+    private IgnoreUnExistedResourcesReflectionConfigurationBuilder() {
+    }
+
+    /**
+     * @return Reflections ConfigurationBuilder that ignore not existing resources in class path.
+     */
+    public static ConfigurationBuilder getConfigurationBuilder(){
+        return configurationBuilder ;
+    }
+}


### PR DESCRIPTION
Created reflections configuration builder that ignore resources that is not exists.
It happens when ide generators runs on generate-sources stage and ../target/classes folder is listed in class path but not exists.
Reflections print NPE for such folders. See more https://github.com/ronmamo/reflections/issues/111