### PR TITLE
Remove unused property maven.model.version in pom.xml since we don't use org.apache.maven.maven-model anymore

### DIFF
--- a/platform-api/pom.xml
+++ b/platform-api/pom.xml
@@ -41,7 +41,6 @@
         <module>che-core-api-infrastructure-local</module>
     </modules>
     <properties>
-        <maven.model.version>3.0.5</maven.model.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
         <url>https://github.com/codenvy/che-core</url>
     </scm>
     <properties>
-        <maven.model.version>3.0.5</maven.model.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>
     <repositories>


### PR DESCRIPTION
Removed unused property **maven.model.version** in pom.xml since we don't use **org.apache.maven.maven-model** anymore
@vparfonov 