### PR TITLE
'Navigate to File' action should not be disabled when no project is selected since it works for a whole workspace but not only for the selected project

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -26,6 +26,12 @@ public interface CoreLocalizationConstant extends Messages {
     @Key("extension.category")
     String extensionCategory();
 
+    @Key("action.navigateToFile.text")
+    String actionNavigateToFileText();
+
+    @Key("action.navigateToFile.description")
+    String actionNavigateToFileDescription();
+
     @Key("navigateToFile.view.title")
     String navigateToFileViewTitle();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/NavigateToFileAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/NavigateToFileAction.java
@@ -14,14 +14,15 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import org.eclipse.che.api.analytics.client.logger.AnalyticsEventLogger;
+import org.eclipse.che.ide.CoreLocalizationConstant;
 import org.eclipse.che.ide.Resources;
 import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
-import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.navigation.NavigateToFilePresenter;
+import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
 
 import javax.validation.constraints.NotNull;
-import java.util.Arrays;
+import java.util.Collections;
 
 import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspective.PROJECT_PERSPECTIVE_ID;
 
@@ -34,31 +35,34 @@ import static org.eclipse.che.ide.workspace.perspectives.project.ProjectPerspect
 @Singleton
 public class NavigateToFileAction extends AbstractPerspectiveAction {
 
-    private final NavigateToFilePresenter presenter;
-    private final AppContext              appContext;
-    private final AnalyticsEventLogger    eventLogger;
+    private final NavigateToFilePresenter  presenter;
+    private final AnalyticsEventLogger     eventLogger;
+    private final ProjectExplorerPresenter projectExplorerPresenter;
 
     @Inject
     public NavigateToFileAction(NavigateToFilePresenter presenter,
-                                AppContext appContext,
-                                AnalyticsEventLogger eventLogger, Resources resources) {
-        super(Arrays.asList(PROJECT_PERSPECTIVE_ID), "Navigate to File", "Navigate to file", null, resources.navigateToFile());
+                                AnalyticsEventLogger eventLogger,
+                                Resources resources,
+                                ProjectExplorerPresenter projectExplorerPresenter,
+                                CoreLocalizationConstant localizationConstant) {
+        super(Collections.singletonList(PROJECT_PERSPECTIVE_ID),
+              localizationConstant.actionNavigateToFileText(),
+              localizationConstant.actionNavigateToFileDescription(),
+              null,
+              resources.navigateToFile());
         this.presenter = presenter;
-        this.appContext = appContext;
         this.eventLogger = eventLogger;
+        this.projectExplorerPresenter = projectExplorerPresenter;
     }
 
-
-    /** {@inheritDoc} */
     @Override
     public void actionPerformed(ActionEvent e) {
         eventLogger.log(this);
         presenter.showDialog();
     }
 
-    /** {@inheritDoc} */
     @Override
     public void updateInPerspective(@NotNull ActionEvent event) {
-        event.getPresentation().setEnabled(appContext.getCurrentProject() != null);
+        event.getPresentation().setEnabled(!projectExplorerPresenter.getRootNodes().isEmpty());
     }
 }

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -39,6 +39,8 @@ projectExplorer.button.title=Explorer
 projectExplorer.titleBar.text=Project Explorer
 
 ############### Navigate To File ###############
+action.navigateToFile.text = Navigate to File
+action.navigateToFile.description = Navigate to file
 navigateToFile.view.title = Navigate To File
 navigateToFile.view.file.field.title = Start enter a file name:
 navigateToFile.view.file.field.prompt = Replace one character by '?' - Replace any string by '*'


### PR DESCRIPTION
**Navigate to File** action should not be disabled when no project is selected since it works for a whole workspace but not only for the selected project
@vparfonov 