### PR TITLE
Allow creating a DTO from JsonElement directly

### DIFF
--- a/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/DtoFactory.java
+++ b/platform-api/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/DtoFactory.java
@@ -171,6 +171,21 @@ public final class DtoFactory {
     }
 
     /**
+     * Creates new instance of class which implements specified DTO interface, uses the specific JSON data for
+     * initializing fields of DTO object.
+     *
+     * @param json
+     *            JSON data
+     * @param dtoInterface
+     *            DTO interface
+     * @throws IllegalArgumentException
+     *             if can't provide any implementation for specified interface
+     */
+    public <T> T createDtoFromJson(JsonElement json, Class<T> dtoInterface) {
+        return getDtoProvider(dtoInterface).fromJson(json);
+    }
+
+    /**
      * Creates new instance of class which implements specified DTO interface, parses specified JSON data and uses parsed data for
      * initializing fields of DTO object.
      *


### PR DESCRIPTION
avoid an unnecessary double serialization if a JsonElement is available and a DTO needs to be created from it.

Signed-off-by: Tareq Sharafy <tareq.sha@gmail.com>