### PR TITLE
IDEX-2389: Add getProjectExplorerSelection method in SelectionAgent

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/PartPresenter.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/PartPresenter.java
@@ -32,7 +32,7 @@ import java.util.List;
 public interface PartPresenter extends Presenter {
     /** The property id for <code>getTitle</code>, <code>getTitleImage</code> and <code>getTitleToolTip</code>. */
     int TITLE_PROPERTY     = 0x001;
-    /** The property id for <code>getSelection</code>. */
+    /** The property id for <code>getActivePartSelection</code>. */
     int SELECTION_PROPERTY = 0x002;
 
     /** @return Title of the Part */

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/selection/SelectionAgent.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/selection/SelectionAgent.java
@@ -12,6 +12,7 @@ package org.eclipse.che.ide.api.selection;
 
 import org.eclipse.che.ide.api.event.SelectionChangedEvent;
 import org.eclipse.che.ide.api.extension.SDK;
+
 import com.google.web.bindery.event.shared.EventBus;
 
 /**
@@ -28,7 +29,14 @@ public interface SelectionAgent {
     /**
      * Provides a way of getting current app-wide Selection.
      *
-     * @return
+     * @return Active part selection
      */
-    Selection<?> getSelection();
+    Selection<?> getActivePartSelection();
+
+    /**
+     * Provides a way of getting project explorer Selection.
+     *
+     * @return Project explorer selection
+     */
+    Selection<?> getProjectExplorerSelection();
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/CopyAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/CopyAction.java
@@ -96,7 +96,7 @@ public class CopyAction extends Action {
             return false;
         }
 
-        Selection<?> selection = agent.getSelection();
+        Selection<?> selection = agent.getActivePartSelection();
         if (selection == null || selection.isEmpty()) {
             return false;
         }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/CutAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/CutAction.java
@@ -96,7 +96,7 @@ public class CutAction extends Action {
             return false;
         }
 
-        Selection<?> selection = agent.getSelection();
+        Selection<?> selection = agent.getActivePartSelection();
         if (selection == null || selection.isEmpty()) {
             return false;
         }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/DeleteItemAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/DeleteItemAction.java
@@ -123,7 +123,7 @@ public class DeleteItemAction extends AbstractPerspectiveAction implements Promi
     public void actionPerformed(ActionEvent e) {
         eventLogger.log(this);
 
-        final Selection<?> selection = selectionAgent.getSelection();
+        final Selection<?> selection = selectionAgent.getActivePartSelection();
 
         if (selection == null || selection.isEmpty()) {
             throw new IllegalStateException("Nodes weren't found in the selection agent");
@@ -279,7 +279,7 @@ public class DeleteItemAction extends AbstractPerspectiveAction implements Promi
     public void updateInPerspective(@NotNull ActionEvent event) {
         event.getPresentation().setVisible(true);
 
-        final Selection<?> selection = selectionAgent.getSelection();
+        final Selection<?> selection = selectionAgent.getActivePartSelection();
 
         if (selection == null || selection.isEmpty()) {
             event.getPresentation().setEnabled(false);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RenameItemAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RenameItemAction.java
@@ -76,7 +76,7 @@ public class RenameItemAction extends AbstractPerspectiveAction {
     public void actionPerformed(ActionEvent e) {
         eventLogger.log(this);
 
-        final Selection<?> selection = selectionAgent.getSelection();
+        final Selection<?> selection = selectionAgent.getActivePartSelection();
         if (selection == null || selection.isEmpty()) {
             return;
         }
@@ -99,7 +99,7 @@ public class RenameItemAction extends AbstractPerspectiveAction {
             return;
         }
 
-        final Selection<?> selection = selectionAgent.getSelection();
+        final Selection<?> selection = selectionAgent.getActivePartSelection();
 
         if (selection == null || selection.isEmpty()) {
             e.getPresentation().setEnabled(false);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/UploadFileAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/UploadFileAction.java
@@ -64,7 +64,7 @@ public class UploadFileAction extends AbstractPerspectiveAction {
     public void updateInPerspective(@NotNull ActionEvent event) {
         event.getPresentation().setVisible(true);
         boolean enabled = false;
-        Selection<?> selection = selectionAgent.getSelection();
+        Selection<?> selection = selectionAgent.getActivePartSelection();
         if (selection != null) {
             enabled = selection.getHeadElement() != null;
         }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/UploadFolderAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/UploadFolderAction.java
@@ -68,7 +68,7 @@ public class UploadFolderAction extends AbstractPerspectiveAction {
     public void updateInPerspective(@NotNull ActionEvent event) {
         event.getPresentation().setVisible(true);
         boolean enabled = false;
-        Selection<?> selection = selectionAgent.getSelection();
+        Selection<?> selection = selectionAgent.getActivePartSelection();
         if (selection != null) {
             enabled = selection.getHeadElement() != null;
         }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/ProjectWizard.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/ProjectWizard.java
@@ -159,7 +159,7 @@ public class ProjectWizard extends AbstractWizard<ProjectConfigDto> {
     }
 
     private String getPathToSelectedNodeParent() {
-        Selection<?> selection = selectionAgent.getSelection();
+        Selection<?> selection = selectionAgent.getActivePartSelection();
 
         if (selection.isMultiSelection() || selection.isEmpty()) {
             return "";

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/selection/SelectionAgentImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/selection/SelectionAgentImpl.java
@@ -17,6 +17,8 @@ import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.api.parts.PropertyListener;
 import org.eclipse.che.ide.api.selection.Selection;
 import org.eclipse.che.ide.api.selection.SelectionAgent;
+import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
+
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
 
@@ -29,22 +31,29 @@ public class SelectionAgentImpl implements ActivePartChangedHandler, PropertyLis
 
     private       PartPresenter activePart;
     private final EventBus      eventBus;
+    private final ProjectExplorerPresenter projectExplorer;
 
     @Inject
-    public SelectionAgentImpl(EventBus eventBus) {
+    public SelectionAgentImpl(EventBus eventBus, ProjectExplorerPresenter projectExplorer) {
         this.eventBus = eventBus;
+        this.projectExplorer = projectExplorer;
         // bind event listener
         eventBus.addHandler(ActivePartChangedEvent.TYPE, this);
     }
 
     /** {@inheritDoc} */
     @Override
-    public Selection<?> getSelection() {
+    public Selection<?> getActivePartSelection() {
         return activePart != null ? activePart.getSelection() : null;
     }
 
+    @Override
+    public Selection<?> getProjectExplorerSelection() {
+        return projectExplorer.getSelection();
+    }
+
     protected void notifySelectionChanged() {
-        eventBus.fireEvent(new SelectionChangedEvent(getSelection()));
+        eventBus.fireEvent(new SelectionChangedEvent(getActivePartSelection()));
     }
 
     /** {@inheritDoc} */

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/projecttype/wizard/ProjectWizardTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/projecttype/wizard/ProjectWizardTest.java
@@ -193,7 +193,7 @@ public class ProjectWizardTest {
     public void moduleShouldBeCreated() {
         Selection selection = mock(Selection.class);
         //noinspection unchecked
-        when(selectionAgent.getSelection()).thenReturn(selection);
+        when(selectionAgent.getActivePartSelection()).thenReturn(selection);
         when(dtoUnmarshallerFactory.newUnmarshaller(ProjectConfigDto.class)).thenReturn(projectConfigUnmarshallable);
         prepareWizard(CREATE_MODULE);
 
@@ -210,7 +210,7 @@ public class ProjectWizardTest {
     public void someErrorHappenedDuringModuleCreating() {
         Selection selection = mock(Selection.class);
         //noinspection unchecked
-        when(selectionAgent.getSelection()).thenReturn(selection);
+        when(selectionAgent.getActivePartSelection()).thenReturn(selection);
         Throwable throwable = mock(Throwable.class);
         when(dtoUnmarshallerFactory.newUnmarshaller(ProjectConfigDto.class)).thenReturn(projectConfigUnmarshallable);
         prepareWizard(CREATE_MODULE);

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/selection/TestSelectionAgent.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/selection/TestSelectionAgent.java
@@ -23,6 +23,7 @@ import org.eclipse.che.ide.api.event.SelectionChangedHandler;
 import org.eclipse.che.ide.api.parts.AbstractPartPresenter;
 import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.api.selection.Selection;
+import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,6 +33,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -46,25 +48,36 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class TestSelectionAgent {
 
-    private EventBus eventBus = new SimpleEventBus();
-
-    private SelectionAgentImpl agent = new SelectionAgentImpl(eventBus);
+    @Mock
+    private PartPresenter            part;
 
     @Mock
-    private PartPresenter part;
+    private ProjectExplorerPresenter projectExplorer;
 
     @Mock
-    private Selection selection;
+    private Selection                selection;
+
+    private SelectionAgentImpl       agent;
+    private EventBus                 eventBus = new SimpleEventBus();
 
     @Before
     public void disarm() {
         // don't throw an exception if GWT.create() invoked
         GWTMockUtilities.disarm();
+        agent = new SelectionAgentImpl(eventBus, projectExplorer);
     }
 
     @After
     public void restore() {
         GWTMockUtilities.restore();
+    }
+    
+    /** Check proper Selection returned when getProjectExplorerSelection method called */
+    @Test
+    public void shouldReturnProjectExplorerSelection() {
+        when(projectExplorer.getSelection()).thenReturn(selection);
+
+        assertEquals(selection, agent.getProjectExplorerSelection());
     }
 
     /** Check proper Selection returned when part changed */
@@ -75,7 +88,7 @@ public class TestSelectionAgent {
         // fire event, for agent to get information about active part
         eventBus.fireEvent(new ActivePartChangedEvent(part));
 
-        assertEquals("Agent should return proper Selection", selection, agent.getSelection());
+        assertEquals("Agent should return proper Selection", selection, agent.getActivePartSelection());
     }
 
     /** Event should be fired, when active part changed */


### PR DESCRIPTION
When performing git commit with "add selected files" check-box selected and console part is active, NPE appears because the getSelection method in Selection agent returned a selection of console part, but we need a selection of project explorer
@vparfonov @skabashnyuk  please review