### PR TITLE
IDEX-4127. Do not display error when new name equals current name at renaming item

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -119,13 +119,13 @@ public interface CoreLocalizationConstant extends Messages {
     String renameNodeDialogTitle();
 
     @Key("renameFileDialogTitle")
-    String renameFileDialogTitle();
+    String renameFileDialogTitle(String name);
 
     @Key("renameFolderDialogTitle")
-    String renameFolderDialogTitle();
+    String renameFolderDialogTitle(String name);
 
     @Key("renameProjectDialogTitle")
-    String renameProjectDialogTitle();
+    String renameProjectDialogTitle(String name);
 
     @Key("renameDialogNewNameLabel")
     String renameDialogNewNameLabel();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RenameItemAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/RenameItemAction.java
@@ -168,11 +168,11 @@ public class RenameItemAction extends AbstractPerspectiveAction {
 
     private String getDialogTitle(ResourceBasedNode<?> node) {
         if (node instanceof FileReferenceNode) {
-            return localization.renameFileDialogTitle();
+            return localization.renameFileDialogTitle(node.getName());
         } else if (node instanceof FolderReferenceNode) {
-            return localization.renameFolderDialogTitle();
+            return localization.renameFolderDialogTitle(node.getName());
         } else if (node instanceof ProjectNode) {
-            return localization.renameProjectDialogTitle();
+            return localization.renameProjectDialogTitle(node.getName());
         }
         return localization.renameNodeDialogTitle();
     }
@@ -190,7 +190,7 @@ public class RenameItemAction extends AbstractPerspectiveAction {
                 return new Violation() {
                     @Override
                     public String getMessage() {
-                        return localization.invalidName();
+                        return "";
                     }
 
                     @Override

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -28,9 +28,9 @@ action.rename.text = Rename...
 action.rename.description = Rename selected item
 
 renameNodeDialogTitle = Rename
-renameFileDialogTitle = Rename file
-renameFolderDialogTitle = Rename folder
-renameProjectDialogTitle = Rename project
+renameFileDialogTitle = Rename file \"{0}\"
+renameFolderDialogTitle = Rename folder \"{0}\"
+renameProjectDialogTitle = Rename project \"{0}\"
 
 renameDialogNewNameLabel = New name:
 

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogPresenter.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogPresenter.java
@@ -138,13 +138,12 @@ public class InputDialogPresenter implements InputDialog, InputDialogView.Action
         }
 
         String errorMessage = violation.getMessage();
-        if (errorMessage != null) {
-            errorMessage = errorMessage.isEmpty() ? localizationConstant.validationErrorMessage() : errorMessage;
-            view.showErrorHint(errorMessage);
-            return false;
+        if (errorMessage == null) {
+            view.hideErrorHint();
+            return true;
         }
 
-        view.hideErrorHint();
-        return true;
+        view.showErrorHint(errorMessage);
+        return false;
     }
 }


### PR DESCRIPTION
1. Do not display error when new name equals current name at renaming item
2. Disable button "OK" in this case
3. Display current name in the title of the rename dialog.
![rename_dialog](https://cloud.githubusercontent.com/assets/5676062/12513423/5b2dddac-c126-11e5-8898-c5c330db8750.png)
 