### PR TITLE
CLDIDE-2692: Clean up workspace config validator

### DIFF
--- a/platform-api/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/WsAgentLauncherImplTest.java
+++ b/platform-api/che-core-api-machine/src/test/java/org/eclipse/che/api/machine/server/WsAgentLauncherImplTest.java
@@ -78,7 +78,7 @@ public class WsAgentLauncherImplTest {
 
     @BeforeMethod
     public void setUp() throws Exception {
-        wsAgentLauncher = new WsAgentLauncherImpl(machineManager,
+        wsAgentLauncher = new WsAgentLauncherImpl(() -> machineManager,
                                                   requestFactory,
                                                   WS_AGENT_START_CMD_LINE,
                                                   new URI("http://localhost:8080" + API_ENDPOINT_PATH),

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceConfigValidator.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceConfigValidator.java
@@ -8,16 +8,14 @@
  * Contributors:
  *   Codenvy, S.A. - initial API and implementation
  *******************************************************************************/
-package org.eclipse.che.api.workspace.server.model.impl;
+package org.eclipse.che.api.workspace.server;
 
 import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.core.model.machine.Command;
 import org.eclipse.che.api.core.model.machine.MachineConfig;
 import org.eclipse.che.api.core.model.workspace.Environment;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
-import org.eclipse.che.api.workspace.server.WorkspaceConfigValidator;
 
-import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.regex.Pattern;
 
@@ -25,43 +23,41 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 
 /**
- * @author Alexander Reshetnyak
+ * Default implementation of {@link WorkspaceConfigValidator}.
+ *
+ * @author Yevhenii Voevodin
  */
 @Singleton
-public class WorkspaceConfigValidatorImpl implements WorkspaceConfigValidator {
+public class DefaultWorkspaceConfigValidator implements WorkspaceConfigValidator {
     /* should contain [3, 20] characters, first and last character is letter or digit, available characters {A-Za-z0-9.-_}*/
     private static final Pattern WS_NAME = Pattern.compile("[\\w][\\w\\.\\-]{1,18}[\\w]");
 
-    @Inject
-    public WorkspaceConfigValidatorImpl() {
-    }
-
+    /**
+     * Checks that workspace configuration is valid.
+     *
+     * <ul>Validation rules:
+     * <li>Workspace name must not be null & must match {@link #WS_NAME} pattern</li>
+     * <li>Workspace attributes keys must not start with 'codenvy' keyword and must not be empty</li>
+     * <li>Workspace default environment name must not be empty or null</li>
+     * <li>Workspace environment must contain default environment </li>
+     * <li>Environment name must not be null</li>
+     * <li>Each environment must contain at least 1 machine(which is dev), also it must contain exactly one dev machine</li>
+     * <li>Each machine must contain its name and source</li>
+     * <li>Each command name and command line must not be null</li>
+     * </ul>
+     */
     @Override
-    public void validate(WorkspaceConfig cfg) throws BadRequestException {
-        validateWorkspaceName(cfg.getName());
-        validateConfig(cfg);
-    }
-
-    @Override
-    public void validateWithoutWorkspaceName(WorkspaceConfig cfg) throws BadRequestException {
-        validateConfig(cfg);
-    }
-
-    @Override
-    public void validateWorkspaceName(String workspace) throws BadRequestException {
-        if (isNullOrEmpty(workspace)) {
-            throw new BadRequestException("Workspace name should not be null or empty");
-        }
-        if (!WS_NAME.matcher(workspace).matches()) {
-            throw new BadRequestException("Incorrect workspace name, it should be between 3 to 20 characters and may contain digits, " +
+    public void validate(WorkspaceConfig config) throws BadRequestException {
+        // configuration object itself
+        requiredNotNull(config.getName(), "Workspace name required");
+        if (!WS_NAME.matcher(config.getName()).matches()) {
+            throw new BadRequestException("Incorrect workspace name, it must be between 3 and 20 characters and may contain digits, " +
                                           "latin letters, underscores, dots, dashes and should start and end only with digits, " +
                                           "latin letters or underscores");
         }
-    }
 
-    private void validateConfig(WorkspaceConfig cfg) throws BadRequestException {
         //attributes
-        for (String attributeName : cfg.getAttributes().keySet()) {
+        for (String attributeName : config.getAttributes().keySet()) {
             //attribute name should not be empty and should not start with codenvy
             if (attributeName.trim().isEmpty() || attributeName.toLowerCase().startsWith("codenvy")) {
                 throw new BadRequestException(format("Attribute name '%s' is not valid", attributeName));
@@ -69,11 +65,11 @@ public class WorkspaceConfigValidatorImpl implements WorkspaceConfigValidator {
         }
 
         //environments
-        requiredNotNull(cfg.getDefaultEnv(), "Workspace default environment name required");
-        if (!cfg.getEnvironments().stream().anyMatch(env -> env.getName().equals(cfg.getDefaultEnv()))) {
+        requiredNotNull(config.getDefaultEnv(), "Workspace default environment name required");
+        if (!config.getEnvironments().stream().anyMatch(env -> env.getName().equals(config.getDefaultEnv()))) {
             throw new BadRequestException("Workspace default environment configuration required");
         }
-        for (Environment environment : cfg.getEnvironments()) {
+        for (Environment environment : config.getEnvironments()) {
             final String envName = environment.getName();
             requiredNotNull(envName, "Environment name should not be null");
 
@@ -100,11 +96,11 @@ public class WorkspaceConfigValidatorImpl implements WorkspaceConfigValidator {
         }
 
         //commands
-        for (Command command : cfg.getCommands()) {
-            requiredNotNull(command.getName(), "Workspace " + cfg.getName() + " contains command without of name");
+        for (Command command : config.getCommands()) {
+            requiredNotNull(command.getName(), "Workspace " + config.getName() + " contains command without of name");
             requiredNotNull(command.getCommandLine(), format("Command line required for command '%s' in workspace '%s'",
                                                              command.getName(),
-                                                             cfg.getName()));
+                                                             config.getName()));
         }
 
         //projects
@@ -112,14 +108,8 @@ public class WorkspaceConfigValidatorImpl implements WorkspaceConfigValidator {
     }
 
     /**
-     * Checks object reference is not {@code null}
-     *
-     * @param object
-     *         object reference to check
-     * @param message
-     *         used as subject of exception message "{subject} required"
-     * @throws org.eclipse.che.api.core.BadRequestException
-     *         when object reference is {@code null}
+     * Checks that object reference is not null, throws {@link BadRequestException}
+     * in the case of null {@code object} with given {@code message}.
      */
     private void requiredNotNull(Object object, String message) throws BadRequestException {
         if (object == null) {

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceConfigValidator.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceConfigValidator.java
@@ -11,60 +11,25 @@
 package org.eclipse.che.api.workspace.server;
 
 import org.eclipse.che.api.core.BadRequestException;
-import org.eclipse.che.api.core.model.workspace.Environment;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 
 /**
- * Interface for validations of workspace config.
+ * Interface for workspace config validations.
  *
- * @author Alexander Reshetnyak
+ * <p>This interface doesn't declare any validation constrains
+ * because the validation itself is implementation specific.
+ *
+ * @author Yevhenii Voevodin
  */
 public interface WorkspaceConfigValidator {
 
     /**
-     * Checks that {@link WorkspaceConfig cfg} contains valid values, if it is not throws {@link BadRequestException}.
+     * Checks that workspace is valid.
      *
-     * Validation rules:
-     * <ul>
-     * <li>{@link WorkspaceConfig#getName()} must not be empty or null</li>
-     * <li>{@link WorkspaceConfig#getDefaultEnv()} must not be empty or null</li>
-     * <li>{@link WorkspaceConfig#getEnvironments()} must contain {@link WorkspaceConfig#getDefaultEnv() default environment}
-     * which is declared in the same configuration</li>
-     * <li>{@link Environment#getName()} must not be null</li>
-     * <li>{@link Environment#getMachineConfigs()} must contain at least 1 machine(which is dev),
-     * also it must contain exactly one dev machine</li>
-     * </ul>
-     *
+     * @param config
+     *         workspace configuration for validation
      * @throws BadRequestException
-     *         when any constrain violation
+     *         in the case of constrain violation
      */
-    void validate(WorkspaceConfig cfg) throws BadRequestException;
-
-    /**
-     * Checks that {@link WorkspaceConfig cfg} contains valid values, if it is not throws {@link BadRequestException}.
-     *
-     * Validation rules:
-     * <ul>
-     * <li>{@link WorkspaceConfig#getName()} does not check</li>
-     * <li>{@link WorkspaceConfig#getDefaultEnv()} must not be empty or null</li>
-     * <li>{@link WorkspaceConfig#getEnvironments()} must contain {@link WorkspaceConfig#getDefaultEnv() default environment}
-     * which is declared in the same configuration</li>
-     * <li>{@link Environment#getName()} must not be null</li>
-     * <li>{@link Environment#getMachineConfigs()} must contain at least 1 machine(which is dev),
-     * also it must contain exactly one dev machine</li>
-     * </ul>
-     *
-     * @throws BadRequestException
-     *         when any constrain violation
-     */
-    void validateWithoutWorkspaceName(WorkspaceConfig cfg) throws BadRequestException;
-
-    /**
-     * Checks workspace name. It must contain valid value, if it is not throws {@link BadRequestException}.
-     * @param workspace
-     *
-     * @throws BadRequestException
-     *         when constrain violation
-     */
-    void validateWorkspaceName(String workspace) throws BadRequestException;
+    void validate(WorkspaceConfig config) throws BadRequestException;
 }

--- a/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/UsersWorkspaceImpl.java
+++ b/platform-api/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/UsersWorkspaceImpl.java
@@ -18,6 +18,7 @@ import org.eclipse.che.api.core.model.workspace.UsersWorkspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.machine.server.model.impl.CommandImpl;
+import org.eclipse.che.commons.lang.NameGenerator;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -297,6 +298,11 @@ public class UsersWorkspaceImpl implements UsersWorkspace {
             workspace.setStatus(status);
             workspace.setTemporary(isTemporary);
             return workspace;
+        }
+
+        public UsersWorkspaceImplBuilder generateId() {
+            id = NameGenerator.generate("workspace", 16);
+            return this;
         }
 
         public UsersWorkspaceImplBuilder fromConfig(WorkspaceConfig workspaceConfig) {

--- a/platform-api/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceConfigValidatorTest.java
+++ b/platform-api/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/DefaultWorkspaceConfigValidatorTest.java
@@ -14,7 +14,6 @@ import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.machine.shared.dto.MachineConfigDto;
 import org.eclipse.che.api.machine.shared.dto.MachineSourceDto;
-import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigValidatorImpl;
 import org.eclipse.che.api.workspace.shared.dto.EnvironmentDto;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceConfigDto;
 import org.testng.annotations.BeforeClass;
@@ -28,18 +27,17 @@ import static org.testng.Assert.assertNull;
 import static org.testng.AssertJUnit.assertNotNull;
 
 /**
- * Tests for {@link org.eclipse.che.api.workspace.server.WorkspaceConfigValidator} and {@link WorkspaceConfigValidatorImpl}
+ * Tests for {@link WorkspaceConfigValidator} and {@link DefaultWorkspaceConfigValidator}
  *
  * @author Alexander Reshetnyak
  */
-
-public class WorkspaceConfigValidatorTest {
+public class DefaultWorkspaceConfigValidatorTest {
 
     private WorkspaceConfigValidator wsValidator;
 
     @BeforeClass
     public void prepare() throws Exception {
-        wsValidator = new WorkspaceConfigValidatorImpl();
+        wsValidator = new DefaultWorkspaceConfigValidator();
     }
 
     @Test
@@ -84,72 +82,6 @@ public class WorkspaceConfigValidatorTest {
             exResult = e;
         }
         assertNotNull(exResult);
-    }
-
-    @Test
-    public void shouldNotBeValidationHaveNotDevMachineInConfigButWsNameNullWsNameNotCheck() throws Exception {
-        Exception exResult = null;
-        try {
-            wsValidator.validateWithoutWorkspaceName(createConfig(null, false));
-        } catch (BadRequestException e) {
-            exResult = e;
-        }
-        assertNotNull(exResult);
-    }
-
-    @Test
-    public void shouldBeValidationHaveDevMachineInConfigButWsNameNullWsNameNotCheck() throws Exception {
-        Exception exResult = null;
-        try {
-            wsValidator.validateWithoutWorkspaceName(createConfig(null, true));
-        } catch (BadRequestException e) {
-            exResult = e;
-        }
-        assertNull(exResult);
-    }
-
-    @Test
-    public void shouldNotBeValidationWsNameNull() throws Exception {
-        Exception exResult = null;
-        try {
-            wsValidator.validateWorkspaceName(null);
-        } catch (BadRequestException e) {
-            exResult = e;
-        }
-        assertNotNull(exResult);
-    }
-
-    @Test
-    public void shouldNotBeValidationWsNameShort() throws Exception {
-        Exception exResult = null;
-        try {
-            wsValidator.validateWorkspaceName("ws");
-        } catch (BadRequestException e) {
-            exResult = e;
-        }
-        assertNotNull(exResult);
-    }
-
-    @Test
-    public void shouldNotBeValidationWsNameLong() throws Exception {
-        Exception exResult = null;
-        try {
-            wsValidator.validateWorkspaceName("ws01234567890123456789");
-        } catch (BadRequestException e) {
-            exResult = e;
-        }
-        assertNotNull(exResult);
-    }
-
-    @Test
-    public void shouldBeValidationWsNameValid() throws Exception {
-        Exception exResult = null;
-        try {
-            wsValidator.validateWorkspaceName("dev-workspace1");
-        } catch (BadRequestException e) {
-            exResult = e;
-        }
-        assertNull(exResult);
     }
 
 

--- a/platform-api/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/platform-api/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -121,16 +121,6 @@ public class WorkspaceManagerTest {
     }
 
     @Test
-    public void shouldGenerateWorkspaceNameIfItIsNotPresentInConfiguration() throws Exception {
-        final WorkspaceConfigDto config = createConfig().withName(null);
-        when(workspaceDao.get(any())).thenThrow(new NotFoundException("Not found"));
-
-        final UsersWorkspaceImpl workspace = workspaceManager.createWorkspace(config, "user123", "account");
-
-        assertNotNull(workspace.getName());
-    }
-
-    @Test
     public void shouldBeAbleToGetWorkspaceById() throws Exception {
         final UsersWorkspaceImpl workspace = workspaceManager.createWorkspace(createConfig(), "user123", "account");
         when(workspaceDao.get(workspace.getId())).thenReturn(workspace);


### PR DESCRIPTION
Leave the only one `validate(WorkspaceConfig)` method in the `WorkspaceConfigValidator`, move default implementation from the `model.impl` package.

@skabashnyuk, @akorneta, @garagatyi  please review