### PR TITLE
Enhance BuilderSelectionStrategy with environment and request

### DIFF
--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuildQueue.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuildQueue.java
@@ -909,10 +909,7 @@ public class BuildQueue {
                         return null; // expected to get here if task is canceled
                     }
                 } else {
-                    if (available.size() > 1) {
-                        return builderSelector.select(available);
-                    }
-                    return available.get(0);
+                    return builderSelector.select(available, request);
                 }
             }
         }

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuilderSelectionStrategy.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuilderSelectionStrategy.java
@@ -11,15 +11,34 @@
 package org.eclipse.che.api.builder;
 
 import java.util.List;
+import org.eclipse.che.api.builder.dto.BaseBuilderRequest;
 
 /**
- * Selects the 'best' SlaveBuilder from the List according to implementation. BuildQueue uses implementation of this interface fo
- * find the 'best' slave-builder for processing incoming build request. If more then one slave-builder available then BuildQueue collects
+ * Selects the 'best' SlaveBuilder from the List according to implementation. BuildQueue uses implementation of this interface to
+ * find the 'best' slave-builder for processing incoming build request. If slave-builder available then BuildQueue collects
  * them (their front-ends which are represented by SlaveBuilder) and passes to implementation of this interface. This implementation
  * should select the 'best' one.
  *
  * @author andrew00x
  */
 public interface BuilderSelectionStrategy {
+
+    /**
+     * Selects best matching {@code RemoteBuilder} that satisfies the implemented strategy
+     * @param slaveBuilders
+     * @return {@code RemoteBuilder} or {@code null} if there is no adequate selection
+     */
     RemoteBuilder select(List<RemoteBuilder> slaveBuilders);
+
+    /**
+     * Selects best matching {@code RemoteBuilder} that satisfies implemented strategy.
+     * Implemented strategy may consider both {@code BaseBuilderRequest} and {@code RemoteBuilder} properties
+     * This method is implementation optional, as selection by builder properties might be enough, and backward compatible.
+     * @param slaveBuilders
+     * @param request
+     * @return {@code RemoteBuilder} or {@code null} if there is no adequate selection
+     */
+    default RemoteBuilder select(List<RemoteBuilder> slaveBuilders, BaseBuilderRequest request){
+        return select(slaveBuilders);
+    }
 }

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/RemoteBuilder.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/RemoteBuilder.java
@@ -27,10 +27,13 @@ import org.eclipse.che.api.core.rest.shared.Links;
 import org.eclipse.che.api.core.rest.shared.dto.Link;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.dto.server.DtoFactory;
+import org.eclipse.che.api.builder.dto.BuilderEnvironment;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents remote {@code Builder}.
@@ -57,6 +60,7 @@ public class RemoteBuilder {
     private final String     name;
     private final String     description;
     private final int        hashCode;
+    private final Map<String, BuilderEnvironment> environmentMap;
 
     private volatile long lastUsage = -1;
 
@@ -65,6 +69,7 @@ public class RemoteBuilder {
         this.baseUrl = baseUrl;
         name = builderDescriptor.getName();
         description = builderDescriptor.getDescription();
+        this.environmentMap = builderDescriptor.getEnvironments();
         this.links = new ArrayList<>(links);
         int hashCode = 7;
         hashCode = hashCode * 31 + baseUrl.hashCode();
@@ -103,6 +108,14 @@ public class RemoteBuilder {
      */
     public long getLastUsageTime() {
         return lastUsage;
+    }
+
+    /**
+     * Get Builder Environment map
+     * @return map of BuilderEnvironment
+     */
+    public Map<String, BuilderEnvironment> getBuilderEnvironment(){
+        return Collections.unmodifiableMap(this.environmentMap);
     }
 
     /**


### PR DESCRIPTION
This will extend the functionality of the Builder with a more generic way to select a builder out of available builders.

basically the change is to allow the builder selection strategy to consider the build request as well as the remote builder properties.

This is needed for running Che in Cloud Foundry environment, where there can be several available builders across different spaces.

Currently Che allows registering builders by the access criteria
"builderServerAccessCriteria": {
    "project": "",
    "workspace": ""
 }

and by matching this criteria together with default builder on project type the match is done. 
Than builder selection strategy implementation is called (if there are more then a single available builder) and the selection can filter by properties in the [RemoteBuilder](ttps://github.com/codenvy/che-core/blob/5c0c82c9defd2c08f52ee72126481f833c8718be/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/RemoteBuilder.java).

Also the getEnvironment() method on the Builder class is not accessible in RemoteBuilder , so it can't select using this data

This is not enough and hence the motivation for contribution.

The suggested  enhance do the following:
- class RemoteBuilder it saves the environment provided by the builder and expose it via get method.
- interface BuilderSelectionStrategy adds a default method that receives additional parameter of the build request, there the extra information can be used to better filter the builders with data coming from the Build request. the default implementation is used so not to affect already existing strategies 
- class BuildQueue - calls the builder strategy with the build request. 
  And also calls selector when there is a single builder available as it might not pass the selection criteria.

@tareqhs - please review

happy for any input 
Regards
Roy
