### PR TITLE
Add support for Git Log API

### DIFF
--- a/platform-api/che-core-api-git/src/main/java/org/eclipse/che/api/git/shared/DiffCommitFile.java
+++ b/platform-api/che-core-api-git/src/main/java/org/eclipse/che/api/git/shared/DiffCommitFile.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2015 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.che.api.git.shared;
+
+import org.eclipse.che.dto.shared.DTO;
+
+/**
+ * Created by I048384 on 24/05/2016.
+ */
+
+@DTO
+public interface DiffCommitFile {
+    /** @return get the file change type*/
+    String getChangeType();
+    /** set the file change type*/
+    void setChangeType(String type);
+    DiffCommitFile withChangeType(String type);
+
+    /** @return get the file previous location*/
+    String getOldPath();
+    /** set the file previous location*/
+    void setOldPath(String oldPath);
+    DiffCommitFile withOldPath(String oldPath);
+
+    /** @return get the file new location*/
+    String getNewPath();
+    /** set the file new location*/
+    void setNewPath(String newPath);
+    DiffCommitFile withNewPath(String newPath);
+
+}

--- a/platform-api/che-core-api-git/src/main/java/org/eclipse/che/api/git/shared/LogRequest.java
+++ b/platform-api/che-core-api-git/src/main/java/org/eclipse/che/api/git/shared/LogRequest.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.api.git.shared;
 
 import org.eclipse.che.dto.shared.DTO;
+import java.util.List;
 
 /**
  * Request to get commit logs.
@@ -21,12 +22,35 @@ import org.eclipse.che.dto.shared.DTO;
 public interface LogRequest extends GitRequest {
     /** @return revision range since */
     String getRevisionRangeSince();
-    /** @return revision range since */
-    String getRevisionRangeUntil();
-    
+	/** @set revision range since */
     void setRevisionRangeSince(String revisionRangeSince);
-    void setRevisionRangeUntil(String revisionRangeUntil);	
-    // private List<String> fileFilter;
-    // private boolean noRenames = true;
-    // private int renameLimit;
+    LogRequest withRevisionRangeSince(String v);
+
+
+    /** @return revision range until */
+    String getRevisionRangeUntil();
+	/** @set revision range until */
+    void setRevisionRangeUntil(String revisionRangeUntil);
+    LogRequest withRevisionRangeUntil(String v);
+
+
+    /** @return the integer value of the number of commits that will be skipped when calling log API */
+    int getSkip();
+    /**  set the integer value of the number of commits that will be skipped when calling log API */
+    void setSkip(int skip);
+    LogRequest withSkip(int v);
+
+
+    /** @return the integer value of the number of commits that will be returned when calling log API */
+    int getMaxCount();
+    /**  set the integer value of the number of commits that will be returned when calling log API */
+    void setMaxCount(int maxCount);
+    LogRequest withMaxCount(int v);
+
+
+    /** @return get the file/folder path used when calling the log API */
+    String getFilePath();
+    /** set the file/folder path used when calling the log API */
+    void setFilePath(String filePath);
+    LogRequest withFilePath(String filePath);
 }

--- a/platform-api/che-core-api-git/src/main/java/org/eclipse/che/api/git/shared/Revision.java
+++ b/platform-api/che-core-api-git/src/main/java/org/eclipse/che/api/git/shared/Revision.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.api.git.shared;
 
 import org.eclipse.che.dto.shared.DTO;
+import java.util.List;
 
 /**
  * Describe single commit.
@@ -25,37 +26,51 @@ public interface Revision {
      * @return
      */
     boolean isFake();
-
     void setFake(boolean fake);
 
     /** @return branch name */
     String getBranch();
-    
     void setBranch(String branch);
-    
     Revision withBranch(String branch);
 
     /** @return commit id */
     String getId();
-    
     void setId(String id);
-    
     Revision withId(String id);
 
     /** @return commit message */
     String getMessage();
-    
     void setMessage(String message);
-    
     Revision withMessage(String message);
 
     /** @return time of commit */
     long getCommitTime();
-    
     Revision withCommitTime(long time);
+    void setCommitTime(long v);
 
-    /** @return committer */
+    /** @return commit committer */
     GitUser getCommitter();
-    
     Revision withCommitter(GitUser user);
+    void setCommitter(GitUser v);
+
+    /** @return commit author */
+    GitUser getAuthor();
+    Revision withAuthor(GitUser user);
+    void setAuthor(GitUser v);
+
+
+    /** @return commit branches */
+    List<Branch> getBranches();
+    Revision withBranches(List<Branch> branches);
+    void setBranches(List<Branch> v);
+
+    /** @return diff commit files */
+    List<DiffCommitFile> getDiffCommitFile();
+    Revision withDiffCommitFile(List<DiffCommitFile> diffCommitFiles);
+    void setDiffCommitFile(List<DiffCommitFile> v);
+
+    /** @return commit parents */
+    List<String> getCommitParent();
+    Revision withCommitParent(List<String> commitParents);
+    void setCommitParent(List<String> v);
 }


### PR DESCRIPTION
Add support for skip and maxCount when calling the LOG API.
Add support to get the log for a specific folder or file in the repository.
For every commit that is returned when calling the LOG API, the following data was added:
    The author of the commit
    A list of branch names that the commit is related to.
    A list of file names that were changed/deleted/added in the commit.
    A list of commit parents (to enable for example clients to paint a graph)

Change-Id: Ie2fbd5a502ba1c8f29bb044bfb3a750883260b46
Signed-off-by: Shimon Ben.Yair shimon.ben.yair@sap.com
