### PR TITLE
Allow modifying the environment variables of a Builder command process

### DIFF
--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/StreamPump.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/StreamPump.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 
 /** @author andrew00x */
-public final class StreamPump implements Runnable {
+public final class StreamPump implements Runnable, AutoCloseable {
 
     private BufferedReader bufferedReader;
     private LineConsumer   lineConsumer;
@@ -33,9 +33,11 @@ public final class StreamPump implements Runnable {
 
     public synchronized void stop() {
         // Not clear do we need close original stream, but since it was wrapped by BufferedReader close it anyway.
-        try {
-            bufferedReader.close();
-        } catch (IOException ignored) {
+        if (bufferedReader != null) {
+            try {
+                bufferedReader.close();
+            } catch (IOException ignored) {
+            }
         }
     }
 
@@ -73,4 +75,10 @@ public final class StreamPump implements Runnable {
             }
         }
     }
+
+    @Override
+    public void close() {
+        stop();
+    }
+
 }


### PR DESCRIPTION
An extension might require setting/modifying the environment variables of the forked process that execute the command. Currently, the Che builder does not modify the environment of the built process at all and all the environment variables of the parent java process are passed as-is. Not only does this cause some issue due to possibly missing environment variables, but it also might pose a security issue due to exposing "too much" from the environment of the parent java process.

This change adds a an optional method that can be overridden to manipulate the environment variables that are set for the command process that is executed by Che builders. It also upgrades the codes slightly to use Java 8's new native Process timing APIs.

Signed-off-by: Tareq Sharafy tareq.sha@gmail.com
