### PR TITLE
Make SourcesManager an injected singleton

### DIFF
--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/Constants.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/Constants.java
@@ -70,6 +70,9 @@ public class Constants {
     /** Build results archive type: .tar */
     public static final String RESULT_ARCHIVE_TAR         = "tar";
 
+    /** Name of directory that contains project sources inside each builder directory */
+    public static final String SOURCES_DIR_NAME           = "sources";
+
     /* ================================================= */
 
     /** @deprecated use {@link #BASE_DIRECTORY} */

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/SourcesManager.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/SourcesManager.java
@@ -10,7 +10,10 @@
  *******************************************************************************/
 package org.eclipse.che.api.builder.internal;
 
+import java.io.File;
 import java.io.IOException;
+
+import com.google.inject.ImplementedBy;
 
 /**
  * Manages build sources.
@@ -18,6 +21,7 @@ import java.io.IOException;
  * @author andrew00x
  * @author Eugene Voevodin
  */
+@ImplementedBy(SourcesManagerImpl.class)
 public interface SourcesManager {
     /**
      * Get build sources. Sources are copied to the directory <code>workDir</code>.
@@ -28,12 +32,12 @@ public interface SourcesManager {
      *         project
      * @param sourcesUrl
      *         sources url
+     * @param sourcesDir
+     *         The sources directory of the builder
      * @param workDir
      *         directory where sources will be copied
      */
-    void getSources(BuildLogger logger, String workspace, String project, String sourcesUrl, java.io.File workDir) throws IOException;
-
-    java.io.File getDirectory();
+    void getSources(BuildLogger logger, String workspace, String project, String sourcesUrl, File sourcesDir, File workDir) throws IOException;
 
     boolean addListener(SourceManagerListener listener);
 

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/SourcesManagerImpl.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/SourcesManagerImpl.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -56,6 +57,11 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
@@ -66,11 +72,11 @@ import javax.ws.rs.core.MediaType;
  * @author andrew00x
  * @author Eugene Voevodin
  */
-// TODO: make singleton
+@Singleton
 public class SourcesManagerImpl implements SourcesManager {
     private static final Logger LOG = LoggerFactory.getLogger(SourcesManagerImpl.class);
 
-    private final java.io.File                        directory;
+    private final File                                rootDirectory;
     private final ConcurrentMap<String, Future<Void>> tasks;
     private final AtomicReference<String>             projectKeyHolder;
     private final Set<SourceManagerListener>          listeners;
@@ -80,8 +86,9 @@ public class SourcesManagerImpl implements SourcesManager {
     private static final int  CONNECT_TIMEOUT   = (int)TimeUnit.MINUTES.toMillis(4);//This time is chosen empirically and
     private static final int  READ_TIMEOUT      = (int)TimeUnit.MINUTES.toMillis(4);//necessary for some large projects. See IDEX-1957.
 
-    public SourcesManagerImpl(java.io.File directory) {
-        this.directory = directory;
+    @Inject
+    public SourcesManagerImpl(@Named(Constants.BASE_DIRECTORY) File rootDirectory) {
+        this.rootDirectory = rootDirectory;
         tasks = new ConcurrentHashMap<>();
         projectKeyHolder = new AtomicReference<>();
         executor = Executors.newSingleThreadScheduledExecutor(
@@ -89,22 +96,24 @@ public class SourcesManagerImpl implements SourcesManager {
         listeners = new CopyOnWriteArraySet<>();
     }
 
-    public void start() { // TODO: guice must do this
+    @PostConstruct
+    public void start() {
         executor.scheduleAtFixedRate(createSchedulerTask(), 5, 5, TimeUnit.MINUTES);
     }
 
-    public void stop() { // TODO: guice must do this
+    @PreDestroy
+    public void stop() {
         listeners.clear();
         executor.shutdown();
     }
 
-    public void getSources(BuildLogger logger, BuilderConfiguration configuration) throws IOException {
+    public void getSources(BuildLogger logger, File sourcesDir, BuilderConfiguration configuration) throws IOException {
         final BaseBuilderRequest request = configuration.getRequest();
-        getSources(logger, request.getWorkspace(), request.getProject(), request.getSourcesUrl(), configuration.getWorkDir());
+        getSources(logger, request.getWorkspace(), request.getProject(), request.getSourcesUrl(), sourcesDir, configuration.getWorkDir());
     }
 
     @Override
-    public void getSources(BuildLogger logger, String workspace, String project, final String sourcesUrl, java.io.File workDir)
+    public void getSources(BuildLogger logger, String workspace, String project, final String sourcesUrl, File directory, File workDir)
             throws IOException {
         // Directory for sources. Keep sources to avoid download whole project before build.
         // This directory is not permanent and may be removed at any time.
@@ -129,7 +138,7 @@ public class SourcesManagerImpl implements SourcesManager {
                 @Override
                 public void run() {
                     try {
-                        download(sourcesUrl, srcDir);
+                        download(sourcesUrl, srcDir, directory);
                     } catch (IOException e) {
                         LOG.error(e.getMessage(), e);
                         errorHolder.set(e);
@@ -191,7 +200,7 @@ public class SourcesManagerImpl implements SourcesManager {
         }
     };
 
-    private void download(String downloadUrl, java.io.File downloadTo) throws IOException {
+    private void download(String downloadUrl, java.io.File downloadTo, File directory) throws IOException {
         HttpURLConnection conn = null;
         try {
             final LinkedList<java.io.File> q = new LinkedList<>();
@@ -338,11 +347,6 @@ public class SourcesManagerImpl implements SourcesManager {
     }
 
     @Override
-    public java.io.File getDirectory() {
-        return directory;
-    }
-
-    @Override
     public boolean addListener(SourceManagerListener listener) {
         return listeners.add(listener);
     }
@@ -361,6 +365,10 @@ public class SourcesManagerImpl implements SourcesManager {
         return new Runnable() {
             @Override
             public void run() {
+                // get a list of the builder source dirs
+                File[] builders = rootDirectory.listFiles();
+                for (File builderDir : builders) {
+                File directory = new File(builderDir, Constants.SOURCES_DIR_NAME);
                 //get list of workspaces
                 java.io.File[] workspaces = directory.listFiles();
                 for (java.io.File workspace : workspaces) {
@@ -385,6 +393,7 @@ public class SourcesManagerImpl implements SourcesManager {
                             }
                         }
                     }
+                }
                 }
             }
         };

--- a/platform-api/che-core-api-builder/src/test/java/org/eclipse/che/api/builder/BuilderTest.java
+++ b/platform-api/che-core-api-builder/src/test/java/org/eclipse/che/api/builder/BuilderTest.java
@@ -84,13 +84,8 @@ public class BuilderTest {
         public SourcesManager getSourcesManager() {
             return new SourcesManager() {
                 @Override
-                public void getSources(BuildLogger logger, String workspace, String project, String sourcesUrl, File workDir) throws IOException {
+                public void getSources(BuildLogger logger, String workspace, String project, String sourcesUrl, File sourcesDir, File workDir) throws IOException {
                     // Don't need for current set of tests.
-                }
-
-                @Override
-                public java.io.File getDirectory() {
-                    return getSourcesDirectory();
                 }
 
                 @Override


### PR DESCRIPTION
Currently each builder instantiates its own SourcesManagerImpl, taking the responsibility for its lifecycle as well. This takes the SourcesManager implementation out of the dependency injection, and causes creating clean-up task scheduler although a single task is enough.

The change makes SourcesManagerImpl an injected singleton that all builders share.

Signed-off-by: Tareq Sharafy tareq.sha@gmail.com
