### PR TITLE
A central class for all builder clean-up operations

### DIFF
--- a/commons/che-core-commons-schedule/src/main/java/org/eclipse/che/commons/schedule/executor/ThreadPullLauncher.java
+++ b/commons/che-core-commons-schedule/src/main/java/org/eclipse/che/commons/schedule/executor/ThreadPullLauncher.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.che.commons.schedule.executor;
 
+import org.eclipse.che.commons.lang.concurrent.ThreadLocalPropagateContext;
 import org.eclipse.che.commons.schedule.Launcher;
 import org.eclipse.che.inject.ConfigurationException;
 
@@ -77,7 +78,7 @@ public class ThreadPullLauncher implements Launcher {
         }
         try {
             CronExpression expression = new CronExpression(cron);
-            service.schedule(runnable, expression);
+            service.schedule(wrap(runnable), expression);
             LOG.debug("Schedule method {} with cron  {} schedule", runnable, cron);
         } catch (ParseException e) {
             LOG.error(e.getLocalizedMessage(), e);
@@ -87,7 +88,7 @@ public class ThreadPullLauncher implements Launcher {
 
     @Override
     public void scheduleWithFixedDelay(Runnable runnable, long initialDelay, long delay, TimeUnit unit) {
-        service.scheduleWithFixedDelay(runnable, initialDelay, delay, unit);
+        service.scheduleWithFixedDelay(wrap(runnable), initialDelay, delay, unit);
         LOG.debug("Schedule method {} with fixed initial delay {} delay {} unit {}",
                   runnable,
                   initialDelay,
@@ -96,11 +97,16 @@ public class ThreadPullLauncher implements Launcher {
 
     @Override
     public void scheduleAtFixedRate(Runnable runnable, long initialDelay, long period, TimeUnit unit) {
-        service.scheduleAtFixedRate(runnable, initialDelay, period, unit);
+        service.scheduleAtFixedRate(wrap(runnable), initialDelay, period, unit);
         LOG.debug("Schedule method {} with fixed rate. Initial delay {} period {} unit {}",
                   runnable,
                   initialDelay,
                   period,
                   unit);
     }
+
+    private static Runnable wrap(Runnable runnable) {
+        return ThreadLocalPropagateContext.wrap(runnable);
+    }
+
 }

--- a/platform-api/che-core-api-builder/pom.xml
+++ b/platform-api/che-core-api-builder/pom.xml
@@ -94,6 +94,10 @@
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-schedule</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.everrest</groupId>
             <artifactId>everrest-core</artifactId>
         </dependency>

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/BuilderCleaner.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/BuilderCleaner.java
@@ -1,0 +1,73 @@
+package org.eclipse.che.api.builder.internal;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.eclipse.che.commons.lang.IoUtil;
+import org.eclipse.che.commons.schedule.ScheduleRate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages clean-up operations for build tasks of local slave builders.
+ * 
+ * @author Tareq Sharafy
+ */
+@Singleton
+public class BuilderCleaner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BuilderCleaner.class);
+
+    private final BuilderRegistry builders;
+    private final long keepResultTimeMillis;
+
+    @Inject
+    public BuilderCleaner(BuilderRegistry builders, @Named(Constants.KEEP_RESULT_TIME) int keepResultTime) {
+        this.builders = builders;
+        this.keepResultTimeMillis = TimeUnit.SECONDS.toMillis(keepResultTime);
+    }
+
+    @ScheduleRate(initialDelay = 1, period = 1, unit = TimeUnit.MINUTES)
+    public void cleanExpiredTasks() {
+        int num = 0;
+        for (Builder builder : builders.getAll()) {
+            for (BuildTask task : builder.getAllBduildTasks()) {
+                long endTime = task.getEndTime();
+                if (endTime > 0 && (endTime + keepResultTimeMillis) < System.currentTimeMillis()) {
+                    try {
+                        builder.cleanBuildTask(task.getId());
+                    } catch (Exception e) {
+                        LOG.error(e.getMessage(), e);
+                    }
+                    num++;
+                }
+            }
+        }
+        if (num > 0) {
+            LOG.debug("Remove {} expired tasks", num);
+        }
+    }
+
+    @PreDestroy
+    public void stop() {
+        // Delete all builder folders
+        for (Builder builder : builders.getAll()) {
+            File repository = builder.getRepository();
+            final File[] files = repository.listFiles();
+            if (files != null) {
+                for (File f : files) {
+                    boolean deleted = IoUtil.deleteRecursive(f);
+                    if (!deleted) {
+                        LOG.warn("Failed delete {}", f);
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/BuilderModule.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/BuilderModule.java
@@ -20,5 +20,6 @@ public class BuilderModule extends AbstractModule {
         // Initialize empty set of Builders.
         Multibinder.newSetBinder(binder(), Builder.class);
         bind(BuilderRegistryPlugin.class).asEagerSingleton();
+        bind(BuilderCleaner.class).asEagerSingleton();
     }
 }


### PR DESCRIPTION
Currently each builder runs own thread for cleaning expired tasks, although a single universal thread that cleans all expired tasks in all builder is more efficient. This change moves the logic from individual builders to a central that uses a single thread to clean all expired tasks.

Signed-off-by: Tareq Sharafy tareq.sha@gmail.com
Change-Id: I80df89ff897e34783dd9300b6caec46264dc0c4a
