### PR TITLE
Propagate thread-local context in missing areas in che-core

### DIFF
--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuildQueue.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuildQueue.java
@@ -596,7 +596,7 @@ public class BuildQueue {
             };
             scheduler = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder().setNameFormat("BuildQueueScheduler-%d")
                                                                                              .setDaemon(true).build());
-            scheduler.scheduleAtFixedRate(new Runnable() {
+            scheduler.scheduleAtFixedRate(ThreadLocalPropagateContext.wrap(new Runnable() {
                 @Override
                 public void run() {
                     int num = 0;
@@ -650,7 +650,7 @@ public class BuildQueue {
                         LOG.debug("Remove {} expired tasks, {} of them were waiting for processing", num, waitingNum);
                     }
                 }
-            }, 1, 1, TimeUnit.MINUTES);
+            }), 1, 1, TimeUnit.MINUTES);
 
             eventService.subscribe(new EventSubscriber<BuilderEvent>() {
                 @Override

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/Builder.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/Builder.java
@@ -167,7 +167,7 @@ public abstract class Builder {
                                                 queueSize);
             scheduler = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder().setNameFormat(
                     getName() + "-BuilderSchedulerPool-%d").setDaemon(true).build());
-            scheduler.scheduleAtFixedRate(new Runnable() {
+            scheduler.scheduleAtFixedRate(ThreadLocalPropagateContext.wrap(new Runnable() {
                 public void run() {
                     int num = 0;
                     for (Iterator<FutureBuildTask> i = tasks.values().iterator(); i.hasNext(); ) {
@@ -189,7 +189,7 @@ public abstract class Builder {
                         LOG.debug("Remove {} expired tasks", num);
                     }
                 }
-            }, 1, 1, TimeUnit.MINUTES);
+            }), 1, 1, TimeUnit.MINUTES);
         } else {
             throw new IllegalStateException("Already started");
         }
@@ -727,7 +727,7 @@ public abstract class Builder {
         final synchronized void started() {
             if (callback != null) {
                 // NOTE: important to do it in separate thread!
-                getExecutor().execute(new Runnable() {
+                getExecutor().execute(ThreadLocalPropagateContext.wrap(new Runnable() {
                     @Override
                     public void run() {
                         try {
@@ -740,7 +740,7 @@ public abstract class Builder {
                         }
                         callback.begin(FutureBuildTask.this);
                     }
-                });
+                }));
             }
         }
 
@@ -761,12 +761,12 @@ public abstract class Builder {
             endTime = System.currentTimeMillis();
             if (callback != null) {
                 // NOTE: important to do it in separate thread!
-                getExecutor().execute(new Runnable() {
+                getExecutor().execute(ThreadLocalPropagateContext.wrap(new Runnable() {
                     @Override
                     public void run() {
                         callback.done(FutureBuildTask.this);
                     }
-                });
+                }));
             }
         }
 

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/SourcesManagerImpl.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/SourcesManagerImpl.java
@@ -18,6 +18,7 @@ import org.eclipse.che.commons.json.JsonParseException;
 import org.eclipse.che.commons.lang.IoUtil;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.commons.lang.ZipUtils;
+import org.eclipse.che.commons.lang.concurrent.ThreadLocalPropagateContext;
 
 import com.google.common.hash.Hashing;
 import com.google.common.io.CharStreams;
@@ -125,7 +126,7 @@ public class SourcesManagerImpl implements SourcesManager {
         Future<Void> future = tasks.get(key);
         final ValueHolder<IOException> errorHolder = new ValueHolder<>();
         if (future == null) {
-            final FutureTask<Void> newFuture = new FutureTask<>(new Runnable() {
+            final FutureTask<Void> newFuture = new FutureTask<>(ThreadLocalPropagateContext.wrap(new Runnable() {
                 @Override
                 public void run() {
                     try {
@@ -135,7 +136,7 @@ public class SourcesManagerImpl implements SourcesManager {
                         errorHolder.set(e);
                     }
                 }
-            }, null);
+            }), null);
             future = tasks.putIfAbsent(key, newFuture);
             if (future == null) {
                 future = newFuture;
@@ -358,7 +359,7 @@ public class SourcesManagerImpl implements SourcesManager {
      * @return runnable task for scheduler
      */
     private Runnable createSchedulerTask() {
-        return new Runnable() {
+        return ThreadLocalPropagateContext.wrap(new Runnable() {
             @Override
             public void run() {
                 //get list of workspaces
@@ -387,6 +388,6 @@ public class SourcesManagerImpl implements SourcesManager {
                     }
                 }
             }
-        };
+        });
     }
 }

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectImportOutputWSLineConsumer.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectImportOutputWSLineConsumer.java
@@ -11,6 +11,8 @@
 package org.eclipse.che.api.project.server;
 
 import org.eclipse.che.api.core.util.LineConsumer;
+import org.eclipse.che.commons.lang.concurrent.ThreadLocalPropagateContext;
+
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import org.everrest.core.impl.provider.json.JsonUtils;
@@ -45,7 +47,7 @@ public class ProjectImportOutputWSLineConsumer implements LineConsumer {
         lineToSendQueue = new ArrayBlockingQueue<>(1024);
         executor = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder().setNameFormat(ProjectImportOutputWSLineConsumer.class.getSimpleName()+"-%d").setDaemon(true).build());
-        executor.scheduleAtFixedRate(new Runnable() {
+        executor.scheduleAtFixedRate(ThreadLocalPropagateContext.wrap(new Runnable() {
             @Override
             public void run() {
                 String lineToSend = null;
@@ -57,7 +59,7 @@ public class ProjectImportOutputWSLineConsumer implements LineConsumer {
                 }
                 sendMessage(lineToSend);
             }
-        }, 0, delayBetweenMessages, TimeUnit.MILLISECONDS);
+        }), 0, delayBetweenMessages, TimeUnit.MILLISECONDS);
         lineCounter = new AtomicInteger(1);
     }
 

--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java
@@ -66,6 +66,7 @@ import org.eclipse.che.api.vfs.server.search.SearcherProvider;
 import org.eclipse.che.api.vfs.shared.dto.AccessControlEntry;
 import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.lang.concurrent.ThreadLocalPropagateContext;
 import org.eclipse.che.commons.lang.ws.rs.ExtMediaType;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.slf4j.Logger;
@@ -1080,7 +1081,7 @@ public class ProjectService extends Service {
      */
     private void reindexProject(long creationDate, FolderEntry baseProjectFolder, final Project project) throws ServerException {
         final VirtualFile file = baseProjectFolder.getVirtualFile();
-        executor.execute(new Runnable() {
+        executor.execute(ThreadLocalPropagateContext.wrap(new Runnable() {
             @Override
             public void run() {
                 try {
@@ -1089,7 +1090,7 @@ public class ProjectService extends Service {
                     LOG.warn(String.format("Workspace: %s, project: %s", project.getWorkspace(), project.getPath()), e.getMessage());
                 }
             }
-        });
+        }));
         if (creationDate > 0) {
             final ProjectMisc misc = project.getMisc();
             misc.setCreationDate(creationDate);

--- a/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RunQueue.java
+++ b/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RunQueue.java
@@ -269,7 +269,7 @@ public class RunQueue {
             };
             cleanScheduler = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder().setNameFormat("RunQueueScheduler-%d")
                                                                                                   .setDaemon(true).build());
-            cleanScheduler.scheduleAtFixedRate(new Runnable() {
+            cleanScheduler.scheduleAtFixedRate(ThreadLocalPropagateContext.wrap(new Runnable() {
                 @Override
                 public void run() {
                     int num = 0;
@@ -327,7 +327,7 @@ public class RunQueue {
                         LOG.debug("Remove {} expired tasks, {} of them were waiting for processing", num, waitingNum);
                     }
                 }
-            }, cleanerPeriod, cleanerPeriod, TimeUnit.MILLISECONDS);
+            }), cleanerPeriod, cleanerPeriod, TimeUnit.MILLISECONDS);
 
             // sending message by websocket connection for notice about used memory size changing
             eventService.subscribe(new ResourcesChangesMessenger());


### PR DESCRIPTION
These areas fail if some thread locals are missing, mostly the user token information in EnvironmentContext

**AN IMPORTANT FIX**

Signed-off-by: Tareq Sharafy tareq.sha@gmail.com
