### PR TITLE
A single flow for all outgoing HTTP requests

### DIFF
--- a/platform-api/che-core-api-builder/pom.xml
+++ b/platform-api/che-core-api-builder/pom.xml
@@ -223,49 +223,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/*Test.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>unix</id>
-            <activation>
-                <os>
-                    <family>unix</family>
-                </os>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <workDir>${project.build.directory}</workDir>
-                            </systemPropertyVariables>
-                            <includes>
-                                <include>**/*Test.java</include>
-                            </includes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuilderUtils.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/BuilderUtils.java
@@ -37,10 +37,10 @@ public class BuilderUtils {
 		try {
 			return req.request();
 		} catch (IOException e) {
-			throw new BuilderException(e);
+			throw new BuilderException(e.getMessage(), e);
 		} catch (ServerException | UnauthorizedException | ForbiddenException | NotFoundException | ConflictException
 				| BadRequestException e) {
-			throw new BuilderException(e.getServiceError());
+			throw new BuilderException(e.getMessage(), e);
 		}
 	}
 

--- a/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/SourcesManagerImpl.java
+++ b/platform-api/che-core-api-builder/src/main/java/org/eclipse/che/api/builder/internal/SourcesManagerImpl.java
@@ -11,8 +11,12 @@
 package org.eclipse.che.api.builder.internal;
 
 import org.eclipse.che.api.builder.dto.BaseBuilderRequest;
+import org.eclipse.che.api.core.rest.HttpJsonRequest;
+import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
+import org.eclipse.che.api.core.rest.HttpRequest;
+import org.eclipse.che.api.core.rest.HttpRequest.BodyWriter;
+import org.eclipse.che.api.core.rest.HttpResponse;
 import org.eclipse.che.api.core.util.ValueHolder;
-import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.json.JsonHelper;
 import org.eclipse.che.commons.json.JsonParseException;
 import org.eclipse.che.commons.lang.IoUtil;
@@ -29,6 +33,7 @@ import org.everrest.core.impl.header.HeaderParameterParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -40,7 +45,9 @@ import java.io.OutputStreamWriter;
 import java.io.StringReader;
 import java.io.Writer;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.text.ParseException;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -82,19 +89,21 @@ public class SourcesManagerImpl implements SourcesManager {
     private final AtomicReference<String>             projectKeyHolder;
     private final Set<SourceManagerListener>          listeners;
     private final ScheduledExecutorService            executor;
+    private final HttpJsonRequestFactory              provider;
 
     private static final long KEEP_PROJECT_TIME = TimeUnit.MINUTES.toMillis(30);
     private static final int  CONNECT_TIMEOUT   = (int)TimeUnit.MINUTES.toMillis(4);//This time is chosen empirically and
     private static final int  READ_TIMEOUT      = (int)TimeUnit.MINUTES.toMillis(4);//necessary for some large projects. See IDEX-1957.
 
     @Inject
-    public SourcesManagerImpl(@Named(Constants.BASE_DIRECTORY) File rootDirectory) {
+    public SourcesManagerImpl(@Named(Constants.BASE_DIRECTORY) File rootDirectory, HttpJsonRequestFactory provider) {
         this.rootDirectory = rootDirectory;
         tasks = new ConcurrentHashMap<>();
         projectKeyHolder = new AtomicReference<>();
         executor = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder().setNameFormat(getClass().getSimpleName() + "-FileCleaner-%d").setDaemon(true).build());
         listeners = new CopyOnWriteArraySet<>();
+        this.provider = provider;
     }
 
     @PostConstruct
@@ -202,53 +211,51 @@ public class SourcesManagerImpl implements SourcesManager {
     };
 
     private void download(String downloadUrl, java.io.File downloadTo, File directory) throws IOException {
-        HttpURLConnection conn = null;
-        try {
-            final LinkedList<java.io.File> q = new LinkedList<>();
-            q.add(downloadTo);
-            final long start = System.currentTimeMillis();
-            final List<Pair<String, String>> md5sums = new LinkedList<>();
-            while (!q.isEmpty()) {
-                java.io.File current = q.pop();
-                java.io.File[] list = current.listFiles();
-                if (list != null) {
-                    for (java.io.File f : list) {
-                        if (f.isDirectory()) {
-                            q.push(f);
-                        } else {
-                            md5sums.add(Pair.of(com.google.common.io.Files.hash(f, Hashing.md5()).toString(),
-                                                downloadTo.toPath().relativize(f.toPath()).toString()
-                                                          .replace("\\", "/"))); //Replacing of "\" is need for windows support
+        final LinkedList<java.io.File> q = new LinkedList<>();
+        q.add(downloadTo);
+        final long start = System.currentTimeMillis();
+        final List<Pair<String, String>> md5sums = new LinkedList<>();
+        while (!q.isEmpty()) {
+            java.io.File current = q.pop();
+            java.io.File[] list = current.listFiles();
+            if (list != null) {
+                for (java.io.File f : list) {
+                    if (f.isDirectory()) {
+                        q.push(f);
+                    } else {
+                        md5sums.add(Pair.of(com.google.common.io.Files.hash(f, Hashing.md5()).toString(),
+                                            downloadTo.toPath().relativize(f.toPath()).toString()
+                                                      .replace("\\", "/"))); //Replacing of "\" is need for windows support
+                    }
+                }
+            }
+        }
+        final long end = System.currentTimeMillis();
+        if (md5sums.size() > 0) {
+            LOG.debug("count md5sums of {} files, time: {}ms", md5sums.size(), (end - start));
+        }
+        // Create the main request
+        HttpRequest request = provider.target(downloadUrl).setTimeout(READ_TIMEOUT);
+        // handle case where checksums are sent
+        if (!md5sums.isEmpty()) {
+            request.usePostMethod();
+            request.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN);
+            request.addHeader(HttpHeaders.ACCEPT, MediaType.MULTIPART_FORM_DATA);
+            request.setBodyWriter(new BodyWriter() {
+                @Override
+                public void writeTo(OutputStream output) throws IOException {
+                    try (Writer writer = new OutputStreamWriter(output)) {
+                        for (Pair<String, String> pair : md5sums) {
+                            writer.write(pair.first);
+                            writer.write(' ');
+                            writer.write(pair.second);
+                            writer.write('\n');
                         }
                     }
                 }
-            }
-            final long end = System.currentTimeMillis();
-            if (md5sums.size() > 0) {
-                LOG.debug("count md5sums of {} files, time: {}ms", md5sums.size(), (end - start));
-            }
-            conn = (HttpURLConnection)new URL(downloadUrl).openConnection();
-            conn.setConnectTimeout(CONNECT_TIMEOUT);
-            conn.setReadTimeout(READ_TIMEOUT);
-            final EnvironmentContext context = EnvironmentContext.getCurrent();
-            if (context.getUser() != null && context.getUser().getToken() != null) {
-                conn.setRequestProperty(HttpHeaders.AUTHORIZATION, context.getUser().getToken());
-            }
-            if (!md5sums.isEmpty()) {
-                conn.setRequestMethod(HttpMethod.POST);
-                conn.setRequestProperty("Content-type", MediaType.TEXT_PLAIN);
-                conn.setRequestProperty(HttpHeaders.ACCEPT, MediaType.MULTIPART_FORM_DATA);
-                conn.setDoOutput(true);
-                try (OutputStream output = conn.getOutputStream();
-                     Writer writer = new OutputStreamWriter(output)) {
-                    for (Pair<String, String> pair : md5sums) {
-                        writer.write(pair.first);
-                        writer.write(' ');
-                        writer.write(pair.second);
-                        writer.write('\n');
-                    }
-                }
-            }
+            });
+        }
+        try (HttpResponse conn = request.request()) {
             final int responseCode = conn.getResponseCode();
             if (responseCode == HttpURLConnection.HTTP_OK) {
                 final String contentType = conn.getHeaderField("content-type");
@@ -314,10 +321,6 @@ public class SourcesManagerImpl implements SourcesManager {
             }
         } catch (ParseException | JsonParseException e) {
             throw new IOException(e.getMessage(), e);
-        } finally {
-            if (conn != null) {
-                conn.disconnect();
-            }
         }
     }
 

--- a/platform-api/che-core-api-builder/src/test/java/org/eclipse/che/api/builder/BuilderTest.java
+++ b/platform-api/che-core-api-builder/src/test/java/org/eclipse/che/api/builder/BuilderTest.java
@@ -211,14 +211,12 @@ public class BuilderTest {
         Assert.assertEquals(remoteBuilder.getBuilderEnvironment(), builder.getEnvironments());
     }
 
-    private void waitForTask(BuildTask task) throws Exception {
+    private static void waitForTask(BuildTask task) throws Exception {
         final long end = System.currentTimeMillis() + 5000;
-        synchronized (this) {
-            while (!task.isDone()) {
-                wait(100);
-                if (System.currentTimeMillis() > end) {
-                    Assert.fail("timeout");
-                }
+        while (!task.isDone()) {
+            Thread.sleep(100);
+            if (System.currentTimeMillis() > end) {
+                Assert.fail("timeout");
             }
         }
     }

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/DefaultHttpRequest.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/DefaultHttpRequest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.rest;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Simple implementation of {@link HttpJsonRequest} based on {@link HttpURLConnection}.
+ *
+ * <p>
+ * The implementation is not thread-safe, instance of this class must be created each time when it's needed.
+ *
+ * <p>
+ * The instance of this request is reusable, which means that it is possible to call {@link #request()} method more than
+ * one time per instance
+ *
+ * @author Yevhenii Voevodin
+ * @see DefaultHttpJsonRequestFactory
+ */
+public class DefaultHttpRequest extends DefaultHttpRequestBase<HttpRequest> implements HttpRequest {
+
+    private BodyWriter bodyWriter;
+    private Map<String, String> headers;
+
+    public DefaultHttpRequest(String url) {
+        super(url, null);
+    }
+
+    @Override
+    public HttpRequest setBodyWriter(BodyWriter bodyWriter) {
+        this.bodyWriter = Objects.requireNonNull(bodyWriter, "Required non-null body writer");
+        return this;
+    }
+
+    @Override
+    public HttpRequest addHeader(String name, String value) {
+        requireNonNull(name, "Required non-null header name");
+        if (headers == null) {
+            headers = new HashMap<>();
+        }
+        headers.put(name, value);
+        return this;
+    }
+
+    @Override
+    public HttpResponse request() throws IOException {
+        beforeRequest();
+        return doGeneralRequest(timeout, url, method, bodyWriter, headers, queryParams);
+    }
+
+}

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/DefaultHttpRequestBase.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/DefaultHttpRequestBase.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.rest;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.UriBuilder;
+
+import org.eclipse.che.api.core.rest.HttpRequest.BodyWriter;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.lang.Pair;
+import org.eclipse.che.commons.user.User;
+
+/**
+ * A base class for all implementations of {@link HttpRequestBase}.
+ * 
+ * @author Tareq Sharafy
+ *
+ * @param <RequestT>
+ */
+public class DefaultHttpRequestBase<RequestT extends HttpRequestBase<RequestT>> implements HttpRequestBase<RequestT> {
+
+    private static final int DEFAULT_QUERY_PARAMS_LIST_SIZE = 5;
+
+    protected final String url;
+    protected int timeout;
+    protected String method;
+    protected List<Pair<String, ?>> queryParams;
+
+    protected DefaultHttpRequestBase(String url, String method) {
+        this.url = requireNonNull(url, "Required non-null url");
+        this.method = method;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public RequestT setMethod(@NotNull String method) {
+        this.method = requireNonNull(method, "Required non-null http method");
+        return (RequestT) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public RequestT addQueryParam(@NotNull String name, @NotNull Object value) {
+        requireNonNull(name, "Required non-null query parameter name");
+        requireNonNull(value, "Required non-null query parameter value");
+        if (queryParams == null) {
+            queryParams = new ArrayList<>(DEFAULT_QUERY_PARAMS_LIST_SIZE);
+        }
+        queryParams.add(Pair.of(name, value));
+        return (RequestT) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public RequestT setTimeout(int timeout) {
+        this.timeout = timeout;
+        return (RequestT) this;
+    }
+
+    /**
+     * Do any required validations before th erequest is executed.
+     */
+    protected void beforeRequest() {
+        if (method == null) {
+            throw new IllegalStateException("Could not perform request, request method wasn't set");
+        }
+    }
+
+    protected HttpResponse doGeneralRequest(int timeout, String url, String method, BodyWriter bodyWriter,
+            Map<String, String> headers, List<Pair<String, ?>> queryParams) throws IOException {
+        // Set the query parameters
+        if (queryParams != null && !queryParams.isEmpty()) {
+            final UriBuilder ub = UriBuilder.fromUri(url);
+            for (Pair<String, ?> parameter : queryParams) {
+                String name = URLEncoder.encode(parameter.first, "UTF-8");
+                String value = parameter.second == null ? null
+                        : URLEncoder.encode(String.valueOf(parameter.second), "UTF-8");
+                ub.queryParam(name, value);
+            }
+            url = ub.build().toString();
+        }
+        // Initialize the connection
+        URL urlObj = new URL(url);
+        HttpURLConnection conn = (HttpURLConnection) urlObj.openConnection();
+        conn.setConnectTimeout(timeout > 0 ? timeout : DEFAULT_TIMEOUT);
+        conn.setReadTimeout(timeout > 0 ? timeout : DEFAULT_TIMEOUT);
+        if (method != null) {
+            conn.setRequestMethod(method);
+        }
+        // Set the authorization header if present
+        String authToken = getAuthenticationToken(urlObj);
+        if (authToken != null) {
+            conn.setRequestProperty(HttpHeaders.AUTHORIZATION, authToken);
+        }
+        // Set all the custom headers
+        if (headers != null) {
+            headers.forEach(conn::setRequestProperty);
+        }
+        // Write the body
+        if (bodyWriter != null) {
+            conn.setDoOutput(true);
+            bodyWriter.writeTo(conn.getOutputStream());
+        }
+        // The result
+        return new URLConnectionHttpResponse(conn);
+    }
+
+    protected String getAuthenticationToken(URL urlObj) {
+        final User user = EnvironmentContext.getCurrent().getUser();
+        if (user != null) {
+            return user.getToken();
+        }
+        return null;
+    }
+
+}

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpJsonRequest.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpJsonRequest.java
@@ -22,11 +22,9 @@ import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.dto.server.JsonSerializable;
 
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.HttpMethod;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Defines simple set of methods for requesting json objects.
@@ -60,18 +58,7 @@ import java.util.Objects;
  * @see HttpJsonRequestFactory
  */
 @Beta
-public interface HttpJsonRequest {
-
-    /**
-     * Sets http method to use in this request(e.g. {@link javax.ws.rs.HttpMethod#GET GET}).
-     *
-     * @param method
-     *         http method
-     * @return this request instance
-     * @throws NullPointerException
-     *         when {@code method} is null
-     */
-    HttpJsonRequest setMethod(@NotNull String method);
+public interface HttpJsonRequest extends HttpRequestBase<HttpJsonRequest> {
 
     /**
      * Sets request body.
@@ -108,27 +95,6 @@ public interface HttpJsonRequest {
      */
     HttpJsonRequest setBody(@NotNull List<?> list);
 
-    /**
-     * Adds query parameter to the request.
-     *
-     * @param name
-     *         query parameter name
-     * @param value
-     *         query parameter value
-     * @return this request instance
-     * @throws NullPointerException
-     *         when either name or value is null
-     */
-    HttpJsonRequest addQueryParam(@NotNull String name, @NotNull Object value);
-
-    /**
-     * Sets request timeout.
-     *
-     * @param timeout
-     *         request timeout
-     * @return this request instance
-     */
-    HttpJsonRequest setTimeout(int timeout);
 
     /**
      * Makes http request with content type "application/json" and authorization headers
@@ -160,61 +126,4 @@ public interface HttpJsonRequest {
                                       ConflictException,
                                       BadRequestException;
 
-    /**
-     * Uses {@link HttpMethod#GET} as a request method.
-     *
-     * @return this request instance
-     */
-    default HttpJsonRequest useGetMethod() {
-        return setMethod(HttpMethod.GET);
-    }
-
-    /**
-     * Uses {@link HttpMethod#OPTIONS} as a request method.
-     *
-     * @return this request instance
-     */
-    default HttpJsonRequest useOptionsMethod() {
-        return setMethod(HttpMethod.OPTIONS);
-    }
-
-    /**
-     * Uses {@link HttpMethod#POST} as a request method.
-     *
-     * @return this request instance
-     */
-    default HttpJsonRequest usePostMethod() {
-        return setMethod(HttpMethod.POST);
-    }
-
-    /**
-     * Uses {@link HttpMethod#DELETE} as a request method.
-     *
-     * @return this request instance
-     */
-    default HttpJsonRequest useDeleteMethod() {
-        return setMethod(HttpMethod.DELETE);
-    }
-
-    /**
-     * Uses {@link HttpMethod#PUT} as a request method.
-     *
-     * @return this request instance
-     */
-    default HttpJsonRequest usePutMethod() {
-        return setMethod(HttpMethod.PUT);
-    }
-
-    /**
-     * Adds set of query parameters to this request.
-     *
-     * @param params
-     *         query parameters map
-     * @return this request instance
-     */
-    default HttpJsonRequest addQueryParams(@NotNull Map<String, ?> params) {
-        Objects.requireNonNull(params, "Required non-null query parameters");
-        params.forEach(this::addQueryParam);
-        return this;
-    }
 }

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpJsonRequestFactory.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpJsonRequestFactory.java
@@ -24,7 +24,7 @@ import javax.validation.constraints.NotNull;
  */
 @Beta
 @ImplementedBy(DefaultHttpJsonRequestFactory.class)
-public interface HttpJsonRequestFactory {
+public interface HttpJsonRequestFactory extends HttpRequestFactory {
 
     /**
      * Creates {@link HttpJsonRequest} based on {@code url}, with an initial HTTP method {@code GET}. 

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpRequest.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpRequest.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.rest;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import javax.validation.constraints.NotNull;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * Defines simple set of methods for requesting json objects.
+ *
+ * <p>
+ * Unlike {@link HttpJsonHelper} - provides <i>builder-like</i> style for building requests and getting responses.
+ *
+ * <p>
+ * Simple use-cases:
+ * 
+ * <pre>
+ * {@code
+ *     // starting new workspace
+ *     requestFactory.fromUri(apiEndpoint + "/workspace/" + id + "/runtime")
+ *                   .setMethod("POST")
+ *                   .addQueryParam("envName", envName)
+ *                   .addQueryParam("accountId", accountId)
+ *                   .request();
+ *
+ *     // getting user preferences
+ *     Map<String, String> prefs = requestFactory.fromUri(apiEndpoint + "/profile/prefs")
+ *                                               .setMethod("GET")
+ *                                               .request()
+ *                                               .asProperties();
+ *
+ *    // getting workspace
+ *    UsersWorkspaceDto workspace = requestFactory.fromLink(getWorkspaceLink)
+ *                                                .request()
+ *                                                .asDto(UsersWorkspaceDto.class);
+ * }
+ * </pre>
+ *
+ * <p>
+ * Do not use this class for requesting content different from "application/json".
+ *
+ * @author Yevhenii Voevodin
+ * @see HttpJsonRequestFactory
+ */
+@Beta
+public interface HttpRequest extends HttpRequestBase<HttpRequest> {
+
+    public interface BodyWriter {
+        public void writeTo(OutputStream out) throws IOException;
+    }
+
+    /**
+     * Copy the given input stream to the request body.
+     *
+     * @param bodyWriter
+     *            write data to the request output stream.
+     * @return this request instance
+     * @throws NullPointerException
+     *             when {@code body} is null
+     */
+    HttpRequest setBodyWriter(@NotNull BodyWriter bodyWriter);
+
+    /**
+     * Adds a header to the request.
+     * 
+     * @param name
+     *            The name of the header.
+     * @param value
+     *            The value of the header.
+     * @return this request instance
+     */
+    HttpRequest addHeader(@NotNull String name, String value);
+
+    /**
+     * Makes http request.
+     * 
+     * @return {@link HttpResponse} instance which represents response of this request
+     * @throws IOException
+     *             when any io error occurs
+     */
+    HttpResponse request() throws IOException;
+
+}

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpRequestBase.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpRequestBase.java
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.rest;
+
+import java.util.Map;
+import java.util.Objects;
+
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.HttpMethod;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * Defines simple set of methods for requesting json objects.
+ *
+ * <p>Unlike {@link HttpJsonHelper} - provides <i>builder-like</i> style for building requests and getting responses.
+ *
+ * <p>Simple use-cases:
+ * <pre>{@code
+ *     // starting new workspace
+ *     requestFactory.fromUri(apiEndpoint + "/workspace/" + id + "/runtime")
+ *                   .setMethod("POST")
+ *                   .addQueryParam("envName", envName)
+ *                   .addQueryParam("accountId", accountId)
+ *                   .request();
+ *
+ *     // getting user preferences
+ *     Map<String, String> prefs = requestFactory.fromUri(apiEndpoint + "/profile/prefs")
+ *                                               .setMethod("GET")
+ *                                               .request()
+ *                                               .asProperties();
+ *
+ *    // getting workspace
+ *    UsersWorkspaceDto workspace = requestFactory.fromLink(getWorkspaceLink)
+ *                                                .request()
+ *                                                .asDto(UsersWorkspaceDto.class);
+ * }</pre>
+ *
+ * <p>Do not use this class for requesting content different from "application/json".
+ *
+ * @author Yevhenii Voevodin
+ * @see HttpJsonRequestFactory
+ */
+@Beta
+public interface HttpRequestBase<RequestT extends HttpRequestBase<RequestT>> {
+
+    static final int DEFAULT_TIMEOUT = 60 * 1000;
+
+    /**
+     * Sets http method to use in this request(e.g. {@link javax.ws.rs.HttpMethod#GET GET}).
+     *
+     * @param method
+     *         http method
+     * @return this request instance
+     * @throws NullPointerException
+     *         when {@code method} is null
+     */
+    RequestT setMethod(@NotNull String method);
+
+    /**
+     * Adds query parameter to the request.
+     *
+     * @param name
+     *         query parameter name
+     * @param value
+     *         query parameter value
+     * @return this request instance
+     * @throws NullPointerException
+     *         when either name or value is null
+     */
+    RequestT addQueryParam(@NotNull String name, @NotNull Object value);
+
+    /**
+     * Sets request timeout.
+     *
+     * @param timeout
+     *         request timeout
+     * @return this request instance
+     */
+    RequestT setTimeout(int timeout);
+
+    /**
+     * Uses {@link HttpMethod#GET} as a request method.
+     *
+     * @return this request instance
+     */
+    default RequestT useGetMethod() {
+        return setMethod(HttpMethod.GET);
+    }
+
+    /**
+     * Uses {@link HttpMethod#OPTIONS} as a request method.
+     *
+     * @return this request instance
+     */
+    default RequestT useOptionsMethod() {
+        return setMethod(HttpMethod.OPTIONS);
+    }
+
+    /**
+     * Uses {@link HttpMethod#POST} as a request method.
+     *
+     * @return this request instance
+     */
+    default RequestT usePostMethod() {
+        return setMethod(HttpMethod.POST);
+    }
+
+    /**
+     * Uses {@link HttpMethod#DELETE} as a request method.
+     *
+     * @return this request instance
+     */
+    default RequestT useDeleteMethod() {
+        return setMethod(HttpMethod.DELETE);
+    }
+
+    /**
+     * Uses {@link HttpMethod#PUT} as a request method.
+     *
+     * @return this request instance
+     */
+    default RequestT usePutMethod() {
+        return setMethod(HttpMethod.PUT);
+    }
+
+    /**
+     * Adds set of query parameters to this request.
+     *
+     * @param params
+     *         query parameters map
+     * @return this request instance
+     */
+    default RequestT addQueryParams(@NotNull Map<String, ?> params) {
+        Objects.requireNonNull(params, "Required non-null query parameters");
+        params.forEach(this::addQueryParam);
+        @SuppressWarnings("unchecked")
+        RequestT r = (RequestT) this; // to avoid suppressing on the whole method
+        return r;
+    }
+}

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpRequestFactory.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpRequestFactory.java
@@ -10,32 +10,29 @@
  *******************************************************************************/
 package org.eclipse.che.api.core.rest;
 
-import org.eclipse.che.api.core.rest.shared.dto.Link;
-
-import javax.inject.Singleton;
 import javax.validation.constraints.NotNull;
 
+import com.google.common.annotations.Beta;
+import com.google.inject.ImplementedBy;
+
 /**
- * Creates {@link DefaultHttpJsonRequest} instances.
+ * Factory for {@link HttpRequest} instances.
  *
  * @author Yevhenii Voevodin
  */
-@Singleton
-public class DefaultHttpJsonRequestFactory implements HttpJsonRequestFactory {
+@Beta
+@ImplementedBy(DefaultHttpJsonRequestFactory.class)
+public interface HttpRequestFactory {
 
-    @Override
-    public HttpJsonRequest fromUrl(@NotNull String url) {
-        return new DefaultHttpJsonRequest(url);
-    }
-
-    @Override
-    public HttpJsonRequest fromLink(@NotNull Link link) {
-        return new DefaultHttpJsonRequest(link);
-    }
-
-    @Override
-    public HttpRequest target(String url) {
-        return new DefaultHttpRequest(url);
-    }
+    /**
+     * Creates {@link HttpJsonRequest} based on {@code url}, with an initial HTTP method {@code GET}.
+     *
+     * @param url
+     *            request target url
+     * @return new instance of {@link HttpRequest}
+     * @throws NullPointerException
+     *             when url is null
+     */
+    HttpRequest target(@NotNull String url);
 
 }

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpResponse.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/HttpResponse.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.rest;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * Defines response of {@link HttpRequestFactory}.
+ * 
+ * @author Tareq Sharafy
+ */
+@Beta
+public interface HttpResponse extends AutoCloseable {
+
+    /**
+     * Returns a response code.
+     */
+    int getResponseCode() throws IOException;
+
+    /**
+     * The content type of the response data.
+     */
+    String getHeaderField(String name);
+
+    /**
+     * The value of the Content-Type header.
+     */
+    String getContentType();
+
+    /**
+     * Gets a stream of the response body.
+     */
+    InputStream getInputStream() throws IOException;
+
+    @Override
+    void close() throws IOException;
+
+}

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/URLConnectionHttpResponse.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/URLConnectionHttpResponse.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.rest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+
+import javax.net.ssl.HttpsURLConnection;
+
+/**
+ * An {@link HttpResponse} implementation that is based on {@link HttpURLConnection} and {@link HttpsURLConnection}
+ * connections.
+ * 
+ * @author Tareq Sharafy
+ *
+ */
+public class URLConnectionHttpResponse implements HttpResponse {
+
+    private final HttpURLConnection conn;
+
+    public URLConnectionHttpResponse(HttpURLConnection conn) {
+        this.conn = conn;
+    }
+
+    @Override
+    public void close() {
+        conn.disconnect();
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        InputStream errStm = conn.getErrorStream();
+        return errStm != null ? errStm : conn.getInputStream();
+    }
+
+    @Override
+    public int getResponseCode() throws IOException {
+        return conn.getResponseCode();
+    }
+
+    @Override
+    public String getHeaderField(String name) {
+        return conn.getHeaderField(name);
+    }
+
+    @Override
+    public String getContentType() {
+        return conn.getContentType();
+    }
+
+}

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/DownloadPlugin.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/DownloadPlugin.java
@@ -12,11 +12,14 @@ package org.eclipse.che.api.core.util;
 
 import java.io.IOException;
 
+import com.google.inject.ImplementedBy;
+
 /**
  * Downloads remote file.
  *
  * @author andrew00x
  */
+@ImplementedBy(DownloadPluginImpl.class)
 public interface DownloadPlugin {
 
     interface Callback {

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/DownloadPluginImpl.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/DownloadPluginImpl.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.core.util;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.eclipse.che.api.core.rest.HttpRequestFactory;
+import org.eclipse.che.api.core.rest.HttpResponse;
+
+/**
+ * DownloadPlugin that downloads single file.
+ *
+ * @author Tareq Sharafy
+ */
+@Singleton
+public class DownloadPluginImpl extends HttpDownloadPlugin {
+
+    private static final int READ_TIMEOUT = (int) TimeUnit.MINUTES.toMillis(3);
+
+    private final HttpRequestFactory provider;
+
+    @Inject
+    public DownloadPluginImpl(HttpRequestFactory provider) {
+        this.provider = provider;
+    }
+
+    @Override
+    protected HttpResponse openUrlConnection(String downloadUrl) throws IOException {
+        // Check it
+        HttpResponse conn = provider.target(downloadUrl).setTimeout(READ_TIMEOUT).request();
+        // Connect
+        final int responseCode = conn.getResponseCode();
+        if (responseCode != 200) {
+            conn.close();
+            throw new IOException(String.format("Invalid response status %d from remote server. ", responseCode));
+        }
+        return conn;
+    }
+
+}

--- a/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/HttpDownloadPlugin.java
+++ b/platform-api/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/HttpDownloadPlugin.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.che.api.core.util;
 
+import org.eclipse.che.api.core.rest.HttpResponse;
+import org.eclipse.che.api.core.rest.URLConnectionHttpResponse;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.slf4j.Logger;
@@ -30,17 +32,15 @@ import javax.ws.rs.core.HttpHeaders;
  *
  * @author andrew00x
  */
-public final class HttpDownloadPlugin implements DownloadPlugin {
+public class HttpDownloadPlugin implements DownloadPlugin {
     private static final Logger LOG = LoggerFactory.getLogger(HttpDownloadPlugin.class);
 
     private static final int CONNECT_TIMEOUT = (int)TimeUnit.MINUTES.toMillis(3);
-    private static final int READ_TIMEOUT    = (int)TimeUnit.MINUTES.toMillis(3);
+    protected static final int READ_TIMEOUT    = (int)TimeUnit.MINUTES.toMillis(3);
 
     @Override
     public void download(String downloadUrl, java.io.File downloadTo, Callback callback) {
-        HttpURLConnection conn = null;
-        try {
-            conn = openUrlConnection(downloadUrl);
+        try (HttpResponse conn = openUrlConnection(downloadUrl)) {
             final String contentDisposition = conn.getHeaderField(HttpHeaders.CONTENT_DISPOSITION);
             String fileName = null;
             if (contentDisposition != null) {
@@ -65,18 +65,12 @@ public final class HttpDownloadPlugin implements DownloadPlugin {
         } catch (IOException e) {
             LOG.debug(String.format("Failed access: %s, error: %s", downloadUrl, e.getMessage()), e);
             callback.error(e);
-        } finally {
-            if (conn != null) {
-                conn.disconnect();
-            }
         }
     }
 
     @Override
     public void download(String downloadUrl, java.io.File downloadTo, String fileName, boolean replaceExisting) throws IOException {
-        HttpURLConnection conn = null;
-        try {
-            conn = openUrlConnection(downloadUrl);
+        try (HttpResponse conn = openUrlConnection(downloadUrl)) {
             final java.io.File downloadFile = new java.io.File(downloadTo, fileName);
             try (InputStream in = conn.getInputStream()) {
                 if (replaceExisting) {
@@ -85,14 +79,10 @@ public final class HttpDownloadPlugin implements DownloadPlugin {
                     Files.copy(in, downloadFile.toPath());
                 }
             }
-        } finally {
-            if (conn != null) {
-                conn.disconnect();
-            }
         }
     }
 
-    private static HttpURLConnection openUrlConnection(String downloadUrl) throws IOException {
+    protected HttpResponse openUrlConnection(String downloadUrl) throws IOException {
         HttpURLConnection conn = (HttpURLConnection)new URL(downloadUrl).openConnection();
         // Set timeouts
         conn.setConnectTimeout(CONNECT_TIMEOUT);
@@ -107,6 +97,6 @@ public final class HttpDownloadPlugin implements DownloadPlugin {
         if (responseCode != 200) {
             throw new IOException(String.format("Invalid response status %d from remote server. ", responseCode));
         }
-        return conn;
+        return new URLConnectionHttpResponse(conn);
     }
 }

--- a/platform-api/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/FactoryServiceTest.java
+++ b/platform-api/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/FactoryServiceTest.java
@@ -123,6 +123,7 @@ public class FactoryServiceTest {
                                             editValidator,
                                             new LinksHelper(),
                                             factoryBuilder,
+                                            null,
                                             projectManager);
 
         when(accountDao.getByMember(anyString())).thenReturn(Arrays.asList(new Member().withRoles(Arrays.asList("account/owner"))));

--- a/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RunQueue.java
+++ b/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RunQueue.java
@@ -18,15 +18,12 @@ import org.eclipse.che.api.builder.BuildStatus;
 import org.eclipse.che.api.builder.BuilderService;
 import org.eclipse.che.api.builder.dto.BuildOptions;
 import org.eclipse.che.api.builder.dto.BuildTaskDescriptor;
-import org.eclipse.che.api.core.ConflictException;
-import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
-import org.eclipse.che.api.core.UnauthorizedException;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
-import org.eclipse.che.api.core.rest.HttpJsonHelper;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
+import org.eclipse.che.api.core.rest.HttpResponse;
 import org.eclipse.che.api.core.rest.RemoteServiceDescriptor;
 import org.eclipse.che.api.core.rest.ServiceContext;
 import org.eclipse.che.api.core.rest.shared.dto.Link;
@@ -76,7 +73,6 @@ import javax.ws.rs.core.UriBuilder;
 import static org.eclipse.che.api.runner.RunnerUtils.runnerRequest;
 
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -1189,7 +1185,7 @@ public class RunQueue {
 
     // >>>>>>>>>>>>>>>>>>>>>>>>>>>>> application start checker
 
-    private static class ApplicationUrlChecker implements Runnable {
+    private class ApplicationUrlChecker implements Runnable {
         final long taskId;
         final URL  url;
         final int  healthCheckerTimeout;
@@ -1215,13 +1211,7 @@ public class RunQueue {
                 } catch (InterruptedException e) {
                     return;
                 }
-                HttpURLConnection conn = null;
-                try {
-                    conn = (HttpURLConnection)url.openConnection();
-                    conn.setRequestMethod(requestMethod);
-                    conn.setConnectTimeout(1000);
-                    conn.setReadTimeout(1000);
-
+                try (HttpResponse conn = requestFactory.target(url.toString()).setTimeout(1000).setMethod(requestMethod).request()) {
                     LOG.debug(String.format("Response code: %d.", conn.getResponseCode()));
                     if (405 == conn.getResponseCode()) {
                         // In case of Method not allowed, we use get instead of HEAD. X-HTTP-Method-Override would be nice but support is
@@ -1249,10 +1239,6 @@ public class RunQueue {
                         }
                     }
                 } catch (IOException ignored) {
-                } finally {
-                    if (conn != null) {
-                        conn.disconnect();
-                    }
                 }
             }
         }

--- a/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RunnerUtils.java
+++ b/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/RunnerUtils.java
@@ -37,10 +37,10 @@ public class RunnerUtils {
 		try {
 			return req.request();
 		} catch (IOException e) {
-			throw new RunnerException(e);
+			throw new RunnerException(e.getMessage(), e);
 		} catch (ServerException | UnauthorizedException | ForbiddenException | NotFoundException | ConflictException
 				| BadRequestException e) {
-			throw new RunnerException(e.getServiceError());
+			throw new RunnerException(e.getMessage(), e);
 		}
 	}
 

--- a/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/internal/Runner.java
+++ b/platform-api/che-core-api-runner/src/main/java/org/eclipse/che/api/runner/internal/Runner.java
@@ -35,6 +35,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collections;
@@ -90,6 +92,10 @@ public abstract class Runner {
     private ScheduledExecutorService cleanScheduler;
     private java.io.File             deployDirectory;
 
+    @Inject
+    private DownloadPlugin theDownloadPlugin;
+    /** @deprecated use {@link #downloadFile(String, java.io.File, String, boolean)} */
+    @Deprecated
     protected final DownloadPlugin downloadPlugin;
 
     public Runner(java.io.File deployDirectoryRoot, int cleanupDelay, ResourceAllocators allocators, EventService eventService) {
@@ -374,7 +380,7 @@ public abstract class Runner {
             return NO_SOURCES;
         }
         final DownloadCallback callback = new DownloadCallback();
-        downloadPlugin.download(url, dir, callback);
+        theDownloadPlugin.download(url, dir, callback);
         if (callback.getError() != null) {
             throw callback.getError();
         }
@@ -413,7 +419,7 @@ public abstract class Runner {
     }
 
     protected java.io.File downloadFile(String url, java.io.File downloadDir, String fileName, boolean replaceExisting) throws IOException {
-        downloadPlugin.download(url, downloadDir, fileName, replaceExisting);
+        theDownloadPlugin.download(url, downloadDir, fileName, replaceExisting);
         return new java.io.File(downloadDir, fileName);
     }
 

--- a/platform-api/che-core-api-runner/src/test/java/org/eclipse/che/api/runner/RunQueueTest.java
+++ b/platform-api/che-core-api-runner/src/test/java/org/eclipse/che/api/runner/RunQueueTest.java
@@ -25,6 +25,8 @@ import org.eclipse.che.api.core.rest.DefaultHttpJsonRequest;
 import org.eclipse.che.api.core.rest.DefaultHttpJsonResponse;
 import org.eclipse.che.api.core.rest.HttpJsonRequest;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
+import org.eclipse.che.api.core.rest.HttpRequest;
+import org.eclipse.che.api.core.rest.HttpResponse;
 import org.eclipse.che.api.core.rest.RemoteServiceDescriptor;
 import org.eclipse.che.api.core.rest.ServiceContext;
 import org.eclipse.che.api.core.rest.shared.dto.Link;
@@ -147,6 +149,11 @@ public class RunQueueTest {
         @Override
         public HttpJsonRequest fromLink(Link link) {
             return new TestJsonRequest(link);
+        }
+
+        @Override
+        public HttpRequest target(String url) {
+            return null;
         }
     }
     


### PR DESCRIPTION
phase 1 - builder, runner, all json requests

An injected interface, HttpRequestFactory, allows managing all outgoing
HTTP requests. HttpJsonRequest factory should use it internally. The
defult DefaultHttpJsonRequest as reusable as it accepts the general HTTP
factory in its constructor. Extensions can replace HttpJsonRequestFactory
and provide DefaultHttpJsonRequest as-is, given a different impl.

Signed-off-by: Tareq Sharafy tareq.sha@gmail.com
Change-Id: I2f334b7bb133b3f136d2b8e5b18301602f427355
