### PR TITLE
genearte_exception_message_for_git

### DIFF
--- a/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
+++ b/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
@@ -131,6 +131,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.net.ssl.SSLHandshakeException;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FilenameFilter;
@@ -210,6 +211,8 @@ class JGitConnection implements GitConnection {
 
     private static final String MESSAGE_COMMIT_NOT_POSSIBLE = "Commit is not possible because repository state is '%s'";
     private static final String MESSAGE_AMEND_NOT_POSSIBLE  = "Amend is not possible because repository state is '%s'";
+
+    private static final String FILE_NAME_TOO_LONG_ERROR_PREFIX = "File name too long";
 
     private static final Logger LOG = LoggerFactory.getLogger(JGitConnection.class);
 
@@ -459,7 +462,8 @@ class JGitConnection implements GitConnection {
             if (removeIfFailed) {
                 deleteRepositoryFolder();
             }
-            throw new GitException(exception.getMessage(), exception);
+            String message = generateExceptionMessage(exception);
+            throw new GitException(message, exception);
         }
     }
 
@@ -568,7 +572,7 @@ class JGitConnection implements GitConnection {
             } else if ("Nothing to fetch.".equals(exception.getMessage())) {
                 return;
             } else {
-                errorMessage = exception.getMessage();
+                errorMessage = generateExceptionMessage(exception);
             }
             throw new GitException(errorMessage, exception);
         }
@@ -908,7 +912,7 @@ class JGitConnection implements GitConnection {
             if (exception.getMessage().equals("Invalid remote: " + remoteName)) {
                 errorMessage = ERROR_NO_REMOTE_REPOSITORY;
             } else {
-                errorMessage = exception.getMessage();
+                errorMessage = generateExceptionMessage(exception);
             }
             throw new GitException(errorMessage, exception);
         }
@@ -949,7 +953,8 @@ class JGitConnection implements GitConnection {
             if ("origin: not found.".equals(exception.getMessage())) {
                 throw new GitException(ERROR_NO_REMOTE_REPOSITORY, exception);
             } else {
-                throw new GitException(exception.getMessage(), exception);
+                String message = generateExceptionMessage(exception);
+                throw new GitException(message, exception);
             }
         }
     }
@@ -1445,7 +1450,8 @@ class JGitConnection implements GitConnection {
                 }
             }
         } catch (IOException exception) {
-            throw new GitException(exception.getMessage(), exception);
+            String message = generateExceptionMessage(exception);
+            throw new GitException(message, exception);
         }
     }
 
@@ -1596,5 +1602,43 @@ class JGitConnection implements GitConnection {
             }
         }
         return returnName;
+    }
+
+    /**
+     * Method for generate exception message. The default logic return message from the error.
+     * It also check if the type of the message is for SSL or in case that the error
+     * start with "file name to long" then it raise the relevant message
+     *
+     * @param error
+     *        throwable error
+     * @return exception message
+     */
+    private String generateExceptionMessage(Throwable error) {
+        String message = error.getMessage();
+        while (error.getCause() != null) {
+            //if e caused by an SSLHandshakeException - replace thrown message with a hardcoded message
+            if (error.getCause() instanceof SSLHandshakeException) {
+                message = "The system is not configured to trust the security certificate provided by the Git server";
+                break;
+            } else if (error.getCause() instanceof IOException) {
+                // Security fix - error message should not include complete local file path on the target system
+                // Error message for example - File name too long (path /xx/xx/xx/xx/xx/xx/xx/xx /, working dir /xx/xx/xx)
+                if (message != null && message.startsWith(FILE_NAME_TOO_LONG_ERROR_PREFIX)) {
+                    try {
+                        String repoPath = repository.getWorkTree().getCanonicalPath();
+                        int startIndex = message.indexOf(repoPath);
+                        int endIndex = message.indexOf(",");
+                        if (startIndex > -1 && endIndex > -1) {
+                            message = FILE_NAME_TOO_LONG_ERROR_PREFIX + " " + message.substring(startIndex + repoPath.length(), endIndex);
+                        }
+                        break;
+                    } catch (IOException e) {
+                        //Hide exception as it is only needed for this message generation
+                    }
+                }
+            }
+            error = error.getCause();
+        }
+        return message;
     }
 }


### PR DESCRIPTION
### What does this PR do?

In action like clone , fetch , pull , push I added messages for case of SSL or if the message start with file name to long security issue,
### What issues does this PR fix or reference?

The message handle in two new cases:
1. SSL in case of SSLHandshakeException we raise message SAP Web IDE is not configured to trust the security certificate provided by the Git server.
2. in case that the message start with "file name too long" - there is security issue, error message should not include complete local file path on the target system
### Previous Behavior

Remove this section if not relevant
The message that raisewas from Throwable message
### New Behavior

This content may also be included in the release notes.
### Tests written?

Yes/No
There are tests for all the git actions
### Docs requirements?

Include the content for all the docs changes required. 
1.  API changes  
2.  User docs changes  

Please review [Che's Contributing Guide](https://github.com/eclipse/che/CONTRIBUTING.MD) for best practices.

Change-Id: I399e92bd075f1282be90fc3cdd1aadd470261ae8
Signed-off-by: i053322 yossi.balan@sap.com
