### PR TITLE
Add support of BasicAuthentication Authentication to Git

### DIFF
--- a/platform-api/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitBasicAuthenticationCredentialsProvider.java
+++ b/platform-api/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitBasicAuthenticationCredentialsProvider.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.che.api.git;
+
+import org.eclipse.che.api.git.server.dto.DtoServerImpls;
+import org.eclipse.che.api.git.shared.GitUser;
+
+/**
+ * Credentials provider for Git basic authentication
+ *
+ * @author Yossi Balan
+ */
+public class GitBasicAuthenticationCredentialsProvider implements CredentialsProvider  {
+
+    private static ThreadLocal<UserCredential> currRequestCredentials = new ThreadLocal<>();
+    private static final String BASIC_PROVIDER_NAME = "basic";
+
+    @Override
+    public UserCredential getUserCredential() {
+        return currRequestCredentials.get();
+    }
+
+    @Override
+    public GitUser getUser() throws GitException {
+        DtoServerImpls.GitUserImpl gitUser = new DtoServerImpls.GitUserImpl();
+        gitUser.setName(currRequestCredentials.get().getUserName());
+        return gitUser;
+    }
+
+    @Override
+    public String getId() {
+        return BASIC_PROVIDER_NAME;
+    }
+
+    @Override
+    public boolean canProvideCredentials(String url) {
+        return getUserCredential() != null;
+    }
+
+    public static void setCurrentCredentials(String user, String password) {
+        UserCredential creds = new UserCredential(user, password, BASIC_PROVIDER_NAME);
+        currRequestCredentials.set(creds);
+    }
+
+    public static void clearCredentials() {
+        currRequestCredentials.set(null);
+    }
+
+}


### PR DESCRIPTION
### What does this PR do?

Add support of Basic Authentication git.
It will support in operation of import,clone,fetch, rebase ,push,pull.
The user will provide the user and password for the request and it will create credentials provider
What does this PR do?

Add support of Basic Authentication git.
It will support in operation of import,clone,fetch, rebase,push,pull.
The user will provide the user and password for the request and it will create credentials provider

What issues does this PR fix or reference?

Add support to clone and work with repository that support basic authentication

Previous Behavior

Remove this section if not relevant
It was not possible to work with repository that need basic Authentication

New Behavior

This content may also be included in the release notes.

Tests written?

Yes/No
It exist for our scenario

Docs requirements?

Include the content for all the docs changes required. 
1. API changes
1. User docs changes

Please review [Che's Contributing Guide](https://github.com/eclipse/che/CONTRIBUTING.MD) for best practices.

Change-Id: I16aed5c77cf321173c5259c26b014b80366a55c3
Signed-off-by: i053322 yossi.balan@sap.com
