### PR TITLE
Expose optional java.io.File from VirtualFile

### DIFF
--- a/che-core-vfs-impl/src/main/java/org/eclipse/che/vfs/impl/fs/CleanableSearcherProvider.java
+++ b/che-core-vfs-impl/src/main/java/org/eclipse/che/vfs/impl/fs/CleanableSearcherProvider.java
@@ -58,7 +58,10 @@ public class CleanableSearcherProvider extends LuceneSearcherProvider {
 
     @Override
     public Searcher getSearcher(final MountPoint mountPoint, boolean create) throws ServerException {
-        final java.io.File vfsIoRoot = ((VirtualFileImpl)mountPoint.getRoot()).getIoFile();
+        final java.io.File vfsIoRoot = mountPoint.getRoot().getIoFile();
+        if (vfsIoRoot == null) {
+            throw new ServerException("Unable create searcher, mount point is not local");
+        }
         CleanableSearcher searcher = instances.get(vfsIoRoot);
         if (searcher == null && create) {
             final java.io.File myIndexDir;

--- a/che-core-vfs-impl/src/main/java/org/eclipse/che/vfs/impl/fs/GitUrlResolver.java
+++ b/che-core-vfs-impl/src/main/java/org/eclipse/che/vfs/impl/fs/GitUrlResolver.java
@@ -13,6 +13,7 @@ package org.eclipse.che.vfs.impl.fs;
 import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.vfs.server.VirtualFile;
 import org.eclipse.che.api.vfs.server.VirtualFileSystem;
 
 import javax.inject.Inject;
@@ -43,14 +44,14 @@ public class GitUrlResolver {
     public String resolve(UriInfo uriInfo, VirtualFileSystem vfs, String path)
             throws ServerException, NotFoundException, ForbiddenException {
 
-        return resolve(uriInfo.getBaseUri(), ((FSMountPoint)vfs.getMountPoint()).getVirtualFile(path));
+        return resolve(uriInfo.getBaseUri(), vfs.getMountPoint().getVirtualFile(path));
     }
 
-    public String resolve(UriInfo uriInfo, VirtualFileImpl virtualFile) {
+    public String resolve(UriInfo uriInfo, VirtualFile virtualFile) throws ServerException {
         return resolve(uriInfo.getBaseUri(), virtualFile);
     }
 
-    public String resolve(URI baseUri, VirtualFileImpl virtualFile) {
+    public String resolve(URI baseUri, VirtualFile virtualFile) throws ServerException {
         final String localPath = pathResolver.resolve(virtualFile);
 
         URI uriLocalPath = Paths.get(localPath).toUri();

--- a/che-core-vfs-impl/src/main/java/org/eclipse/che/vfs/impl/fs/LocalPathResolver.java
+++ b/che-core-vfs-impl/src/main/java/org/eclipse/che/vfs/impl/fs/LocalPathResolver.java
@@ -10,7 +10,12 @@
  *******************************************************************************/
 package org.eclipse.che.vfs.impl.fs;
 
+import java.io.File;
+
 import javax.inject.Singleton;
+
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.vfs.server.VirtualFile;
 
 /**
  * Resolves location of virtual filesystem item on local filesystem.
@@ -19,7 +24,11 @@ import javax.inject.Singleton;
  */
 @Singleton
 public class LocalPathResolver {
-    public String resolve(VirtualFileImpl virtualFile) {
-        return virtualFile.getIoFile().getAbsolutePath();
+    public String resolve(VirtualFile virtualFile) throws ServerException {
+        File file = virtualFile.getIoFile();
+        if (file == null) {
+            throw new ServerException("Not a local file: " + virtualFile.getPath());
+        }
+        return file.getAbsolutePath();
     }
 }

--- a/che-core-vfs-impl/src/main/java/org/eclipse/che/vfs/impl/fs/VirtualFileImpl.java
+++ b/che-core-vfs-impl/src/main/java/org/eclipse/che/vfs/impl/fs/VirtualFileImpl.java
@@ -327,6 +327,7 @@ public class VirtualFileImpl implements VirtualFile {
 
    /* =================== */
 
+    @Override
     public final java.io.File getIoFile() {
         return ioFile;
     }

--- a/platform-api/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitProjectImporter.java
+++ b/platform-api/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitProjectImporter.java
@@ -20,7 +20,6 @@ import org.eclipse.che.api.project.server.FolderEntry;
 import org.eclipse.che.api.project.server.ProjectImporter;
 import org.eclipse.che.commons.lang.IoUtil;
 
-import org.eclipse.che.vfs.impl.fs.VirtualFileImpl;
 import org.eclipse.che.api.git.shared.Branch;
 import org.eclipse.che.api.git.shared.CheckoutRequest;
 import org.eclipse.che.api.git.shared.BranchListRequest;
@@ -126,7 +125,7 @@ public class GitProjectImporter implements ProjectImporter {
                 branchMerge = parameters.get("branchMerge");
             }
             // Get path to local file. Git works with local filesystem only.
-            final String localPath = localPathResolver.resolve((VirtualFileImpl)baseFolder.getVirtualFile());
+            final String localPath = localPathResolver.resolve(baseFolder.getVirtualFile());
             git = gitConnectionFactory.getConnection(localPath, consumerFactory);
             if (keepDirectory != null) {
                 git.cloneWithSparseCheckout(keepDirectory, location, branch == null ? "master" : branch);

--- a/platform-api/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitService.java
+++ b/platform-api/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitService.java
@@ -60,7 +60,6 @@ import org.eclipse.che.api.vfs.shared.dto.Item;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.vfs.impl.fs.GitUrlResolver;
 import org.eclipse.che.vfs.impl.fs.LocalPathResolver;
-import org.eclipse.che.vfs.impl.fs.VirtualFileImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -461,7 +460,7 @@ public class GitService {
     public String readOnlyGitUrlTextPlain(@Context UriInfo uriInfo) throws ApiException {
         final VirtualFile virtualFile = vfsRegistry.getProvider(vfsId).getMountPoint(true).getVirtualFile(projectPath);
         if (virtualFile.getChild(".git") != null) {
-            return gitUrlResolver.resolve(uriInfo.getBaseUri(), (VirtualFileImpl)virtualFile);
+            return gitUrlResolver.resolve(uriInfo.getBaseUri(), virtualFile);
         } else {
             throw new ServerException("Not git repository");
         }
@@ -478,7 +477,7 @@ public class GitService {
                 return DtoFactory.getInstance().createDto(ImportSourceDescriptor.class)
                                  .withType("git")
                                  .withLocation(
-                                         gitUrlResolver.resolve(uriInfo.getBaseUri(), (VirtualFileImpl)virtualFile))
+                                         gitUrlResolver.resolve(uriInfo.getBaseUri(), virtualFile))
                                  .withParameters(
                                          Collections.singletonMap("commitId", gitConnection.log(null).getCommits().get(0).getId()));
 
@@ -518,7 +517,7 @@ public class GitService {
         Item gitProject = getGitProjectByPath(vfs, folderPath);
         final MountPoint mountPoint = vfs.getMountPoint();
         final VirtualFile virtualFile = mountPoint.getVirtualFile(gitProject.getPath());
-        return localPathResolver.resolve((VirtualFileImpl)virtualFile);
+        return localPathResolver.resolve(virtualFile);
     }
 
     protected GitConnection getGitConnection() throws ApiException {

--- a/platform-api/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitValueProviderFactory.java
+++ b/platform-api/che-core-api-git/src/main/java/org/eclipse/che/api/git/GitValueProviderFactory.java
@@ -77,6 +77,6 @@ public class GitValueProviderFactory implements ValueProviderFactory {
         Item gitProject = vfs.getItemByPath(folderPath, null, false, PropertyFilter.ALL_FILTER);
         final MountPoint mountPoint = vfs.getMountPoint();
         final VirtualFile virtualFile = mountPoint.getVirtualFile(gitProject.getPath());
-        return localPathResolver.resolve((VirtualFileImpl)virtualFile);
+        return localPathResolver.resolve(virtualFile);
     }
 }

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/VirtualFile.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/VirtualFile.java
@@ -22,6 +22,7 @@ import org.eclipse.che.api.vfs.shared.dto.Principal;
 import org.eclipse.che.api.vfs.shared.dto.Property;
 import org.eclipse.che.commons.lang.Pair;
 
+import java.io.File;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
@@ -592,4 +593,12 @@ public interface VirtualFile extends Comparable<VirtualFile> {
      *         if any error occurs
      */
     LazyIterator<Pair<String, String>> countMd5Sums() throws ServerException;
+
+    /**
+     * Get the {@link File} that this virtual file corresponds to.
+     * 
+     * @return The File that this virtual file corresponds to, or null if no such file exists.
+     */
+    File getIoFile();
+
 }

--- a/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/impl/memory/MemoryVirtualFile.java
+++ b/platform-api/che-core-api-vfs/src/main/java/org/eclipse/che/api/vfs/server/impl/memory/MemoryVirtualFile.java
@@ -55,6 +55,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -1283,6 +1284,11 @@ public class MemoryVirtualFile implements VirtualFile {
             return 1;
         }
         return getName().compareTo(o.getName());
+    }
+
+    @Override
+    public File getIoFile() {
+        return null;
     }
 
     boolean hasPermission(String permission, boolean checkParent) {


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?

Alternative VFS providers could not integrate correctly into existing Che services, especially the Git API.

### Previous Behavior
Several areas in the code failred during runtime due to direct cast to ``VirtualFileImpl``, although the given ``VirtualFile`` instance has a different implementation provided from an alternative VFS implementation.

### New Behavior
``VirtualFile`` exposes a new method ``java.io.File getIoFile()`` that returns a concrete ``File`` if such file is available, otherwise null. Che services use this method instead of casting to ``VirtualFileImpl`` unsafely, failing with proper exceptions if a ``File`` is unexpectedly not available.

avoid direct casts to VirtualFileImpl and expose the required function
instead, allowing alternative VFS provider to integrate flawlessly in the
Che platform with any desired java.io.File delegations

Change-Id: I6a6e7ef65279c6aa2714dcedb75dcb4dce5e50ff