### PR TITLE
Make ProjectManager a non-final class

### DIFF
--- a/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/DefaultProjectManager.java
+++ b/platform-api/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/DefaultProjectManager.java
@@ -69,7 +69,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * @author andrew00x
  */
 @Singleton
-public final class DefaultProjectManager implements ProjectManager {
+public class DefaultProjectManager implements ProjectManager {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultProjectManager.class);
 
     private static final int CACHE_NUM  = 1 << 2;


### PR DESCRIPTION
### What does this PR do?

Down-port of https://github.com/eclipse/che/pull/3267

Make ``ProjectManager`` a non-final class.

### What issues does this PR fix or reference?

Allow mocking and extending ``ProjectManager`` more easily - ``final`` classes are very limited when mocking them and they cannot be extended for injecting modified behavior.
